### PR TITLE
IdentitiesOnly directive support

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -66,7 +66,7 @@ module Net
       :logger, :paranoid, :password, :port, :proxy, :rekey_blocks_limit,
       :rekey_limit, :rekey_packet_limit, :timeout, :verbose,
       :global_known_hosts_file, :user_known_hosts_file, :host_key_alias,
-      :host_name, :user, :properties, :passphrase
+      :host_name, :user, :properties, :passphrase, :keys_only
     ]
 
     # The standard means of starting a new SSH connection. When used with a
@@ -125,6 +125,10 @@ module Net
     #   and hostbased authentication
     # * :key_data => an array of strings, with each element of the array being
     #   a raw private key in PEM format.
+    # * :keys_only => set to +true+ to use only private keys from +keys+ and
+    #   +key_data+ parameters, even if ssh-agent offers more identities. This
+    #   option is intended for situations where ssh-agent offers many different
+    #   identites.
     # * :logger => the logger instance to use when logging
     # * :paranoid => either true, false, or :very, specifying how strict
     #   host-key verification should be

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -19,6 +19,7 @@ module Net; module SSH
   # * HostKeyAlias => :host_key_alias
   # * HostName => :host_name
   # * IdentityFile => maps to the :keys option
+  # * IdentitiesOnly => :keys_only
   # * Macs => maps to the :hmac option
   # * PasswordAuthentication => maps to the :auth_methods option
   # * Port => :port
@@ -128,6 +129,8 @@ module Net; module SSH
             hash[:timeout] = value
           when 'forwardagent' then
             hash[:forward_agent] = value
+          when 'identitiesonly' then
+            hash[:keys_only] = value
           when 'globalknownhostsfile'
             hash[:global_known_hosts_file] = value
           when 'hostbasedauthentication' then

--- a/test/authentication/test_key_manager.rb
+++ b/test/authentication/test_key_manager.rb
@@ -59,6 +59,20 @@ module Authentication
       assert_equal({:from => :agent}, manager.known_identities[dsa])
     end
 
+    def test_only_identities_with_key_files_should_load_from_agent_of_keys_only_set
+      manager(:keys_only => true).stubs(:agent).returns(agent)
+
+      stub_file_key "/first", rsa
+
+      identities = []
+      manager.each_identity { |identity| identities << identity }
+
+      assert_equal 1, identities.length
+      assert_equal rsa.to_blob, identities.first.to_blob
+
+      assert_equal({:from => :agent}, manager.known_identities[rsa])
+    end
+
     def test_sign_with_agent_originated_key_should_request_signature_from_agent
       manager.stubs(:agent).returns(agent)
       manager.each_identity { |identity| } # preload the known_identities
@@ -96,8 +110,8 @@ module Authentication
         @agent ||= stub("agent", :identities => [rsa, dsa])
       end
 
-      def manager
-        @manager ||= Net::SSH::Authentication::KeyManager.new(nil)
+      def manager(options = {})
+        @manager ||= Net::SSH::Authentication::KeyManager.new(nil, options)
       end
 
   end


### PR DESCRIPTION
Hi!

This patch adds support for ssh_config IdentitiesOnly directive and twin "keys_only" Net::SSH.start option. Test included too.

[Lighthouse ticket](http://net-ssh.lighthouseapp.com/projects/36253/tickets/24-netssh-start-should-allow-for-identitiesonly)
