### PR TITLE
Transport won't be closed, if authentication fails.

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -193,6 +193,7 @@ module Net
           return connection
         end
       else
+        transport.closed
         raise AuthenticationFailed, user
       end
     end


### PR DESCRIPTION
I use Net::SSH in a system administration context, where I test if a sysadmin can login to a server as root or as himself and perform privileged actions with sudo. If authentication fails, the transport layer won't be closed. After several attempts to the same server I could observe increasing sshd children not being closed, after returning from a Net::SSH.start do end block. Closing the transport layer solved my problem, preventing the server to reach the limits defined by MaxStartups in sshd_config.
## 

Patrick Marchi
Department of Geography, University of Zurich
http://www.geo.uzh.ch/en/services/computingit/
