### PR TITLE
Fix code example indentation to render well in RDoc

### DIFF
--- a/lib/net/ssh/connection/channel.rb
+++ b/lib/net/ssh/connection/channel.rb
@@ -435,9 +435,9 @@ module Net; module SSH; module Connection
     #   data, via data.read_string. (Not all SSH servers support this channel
     #   request type.)
     #
-    #   channel.on_request "exit-status" do |ch, data|
-    #     puts "process terminated with exit status: #{data.read_long}"
-    #   end
+    #     channel.on_request "exit-status" do |ch, data|
+    #       puts "process terminated with exit status: #{data.read_long}"
+    #     end
     def on_request(type, &block)
       old, @on_request[type] = @on_request[type], block
       old


### PR DESCRIPTION
A few missing space characters made the RDoc look bad: http://net-ssh.github.com/ssh/v2/api/classes/Net/SSH/Connection/Channel.html#M000070
