### PR TITLE
Add Net::SSH::ConnectionTimeout exception class

### DIFF
--- a/lib/net/ssh/errors.rb
+++ b/lib/net/ssh/errors.rb
@@ -7,6 +7,9 @@ module Net; module SSH
   # public key authentication, password authentication, or whatever).
   class AuthenticationFailed < Exception; end
 
+  # This exception is raised when a connection attempt times out.
+  class ConnectionTimeout < Exception; end
+
   # This exception is raised when the remote host has disconnected
   # unexpectedly.
   class Disconnect < Exception; end


### PR DESCRIPTION
This is required for https://github.com/net-ssh/net-ssh-multi/pull/1. I was unsure where this may need to be raised in net-ssh itself (or if it needed to be at all, really).
