### PR TITLE
Add BindAddress support to Net::SSH.

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -61,10 +61,10 @@ module Net
     # This is the set of options that Net::SSH.start recognizes. See
     # Net::SSH.start for a description of each option.
     VALID_OPTIONS = [
-      :auth_methods, :compression, :compression_level, :config, :encryption,
-      :forward_agent, :hmac, :host_key, :kex, :keys, :key_data, :languages,
-      :logger, :paranoid, :password, :port, :proxy, :rekey_blocks_limit,
-      :rekey_limit, :rekey_packet_limit, :timeout, :verbose,
+      :auth_methods, :bind_address, :compression, :compression_level, :config, 
+      :encryption, :forward_agent, :hmac, :host_key, :kex, :keys, :key_data, 
+      :languages, :logger, :paranoid, :password, :port, :proxy, 
+      :rekey_blocks_limit,:rekey_limit, :rekey_packet_limit, :timeout, :verbose,
       :global_known_hosts_file, :user_known_hosts_file, :host_key_alias,
       :host_name, :user, :properties, :passphrase, :keys_only
     ]
@@ -98,6 +98,9 @@ module Net
     # This method accepts the following options (all are optional):
     #
     # * :auth_methods => an array of authentication methods to try
+    # * :bind_address => the IP address on the connecting machine to use in
+    #   establishing connection. (:bind_address is discarded if :proxy
+    #   is set.)
     # * :compression => the compression algorithm to use, or +true+ to use
     #   whatever is supported.
     # * :compression_level => the compression level to use when sending data

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -119,6 +119,8 @@ module Net; module SSH
       def translate(settings)
         settings.inject({}) do |hash, (key, value)|
           case key
+          when 'bindaddress' then
+            hash[:bind_address] = value
           when 'ciphers' then
             hash[:encryption] = value.split(/,/)
           when 'compression' then

--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -58,11 +58,12 @@ module Net; module SSH; module Transport
 
       @host = host
       @port = options[:port] || DEFAULT_PORT
+      @bind_address = options[:bind_address] || nil
       @options = options
 
       debug { "establishing connection to #{@host}:#{@port}" }
       factory = options[:proxy] || TCPSocket
-      @socket = timeout(options[:timeout] || 0) { factory.open(@host, @port) }
+      @socket = timeout(options[:timeout] || 0) { @bind_address.nil? || options[:proxy] ? factory.open(@host, @port) : factory.open(@host,@port,@bind_address) }
       @socket.extend(PacketStream)
       @socket.logger = @logger
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -67,6 +67,7 @@ class TestConfig < Test::Unit::TestCase
 
   def test_translate_should_correctly_translate_from_openssh_to_net_ssh_names
     open_ssh = {
+      'bindaddress'             => "127.0.0.1",
       'ciphers'                 => "a,b,c",
       'compression'             => true,
       'compressionlevel'        => 6,
@@ -95,6 +96,7 @@ class TestConfig < Test::Unit::TestCase
     assert_equal %w(j k l), net_ssh[:hmac]
     assert_equal 1234,      net_ssh[:port]
     assert_equal 1024,      net_ssh[:rekey_limit]
+    assert_equal "127.0.0.1", net_ssh[:bind_address]
   end
   
   def test_load_with_plus_sign_hosts


### PR DESCRIPTION
Allow specification of :bind_address as an option on Net::SSH.start
or honor BindAddress option on system OpenSSH config files if specified.
:bind_address parameter is used in initializing TCPSocket to initiate connection
to remote machine from a specific local IP address. :bind_address is discarded 
if :proxy is specified as the Proxy mechanism doesn't support passing of
:bind_address as an option.

:bind_address is primarily useful on systems with multiple public interfaces or
IP addresses where remote firewall configuration requires connections
initiating from a specific IP address.
