### PR TITLE
Remove the keys default, as this causes http://net-ssh.lighthouseapp.com/

### DIFF
--- a/lib/net/ssh/authentication/session.rb
+++ b/lib/net/ssh/authentication/session.rb
@@ -127,8 +127,7 @@ module Net; module SSH; module Authentication
       # attempting any key-based authentication mechanism.
       def keys
         Array(
-          options[:keys] ||
-          %w(~/.ssh/id_dsa ~/.ssh/id_rsa ~/.ssh2/id_dsa ~/.ssh2/id_rsa)
+          options[:keys]
         )
       end
 

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -146,7 +146,7 @@ module Transport
     def test_allow_when_not_pending_should_be_true_for_all_packets
       (0..255).each do |type|
         packet = stub("packet", :type => type)
-        assert algorithms.allow?(packet), type
+        assert algorithms.allow?(packet), type.to_s
       end
     end
 


### PR DESCRIPTION
Remove the keys default, as this causes http://net-ssh.lighthouseapp.com/projects/36253/tickets/30-net-ssh-prompts-for-passphrase-even-with-keys-loaded-in-ssh-agent

Also fix the assertion, for tests to pass on Ruby 1.9.2-p290
