### PR TITLE
Applied Patch described in https://github.com/net-ssh/net-ssh/issues/21

### DIFF
--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -73,7 +73,8 @@ module Net; module SSH; module Transport
 
       @host_key_verifier = select_host_key_verifier(options[:paranoid])
 
-      @server_version = ServerVersion.new(socket, logger)
+
+      @server_version = timeout(options[:timeout] || 0) { ServerVersion.new(socket, logger) }
 
       @algorithms = Algorithms.new(self, options)
       wait { algorithms.initialized? }


### PR DESCRIPTION
As I described in https://github.com/net-ssh/net-ssh/issues/21 this would make the call to ServerVersion more robust to buggy SSH-Servers.
I propose to also pull this into other branches (eg. 2.1 and 2.0)

Kind regards,

Sven
