### PR TITLE
Fix an un-necessary crash

### DIFF
--- a/lib/net/ssh/authentication/session.rb
+++ b/lib/net/ssh/authentication/session.rb
@@ -68,7 +68,12 @@ module Net; module SSH; module Authentication
           attempted << name
 
           debug { "trying #{name}" }
-          method = Methods.const_get(name.split(/\W+/).map { |p| p.capitalize }.join).new(self, :key_manager => key_manager)
+          begin 
+            method = Methods.const_get(name.split(/\W+/).map { |p| p.capitalize }.join).new(self, :key_manager => key_manager)
+          rescue NameError => ne
+            debug{"Mechanism #{name} was requested, but isn't a known type.  Ignoring it."}
+            next
+          end
 
           return true if method.authenticate(next_service, username, password)
         rescue Net::SSH::Authentication::DisallowedMethod


### PR DESCRIPTION
When running on a client with an ssh_config that specifies authentication methods that are not supported by net-ssh (specifically gssapi-keyex and gssapi-with-mic in my case) net-ssh will bomb out in session.rb even if there are later methods that are supported.

I see that there is net-ssh-kerberos, but it doesn't support gssapi-keyex, just gssapi-with-mic, so this issue would still happen with it.

I don't know if there are any other considerations with ignoring unknown mechanisms, but this appears to be necessary to work with a mixture of supported and unsupported mechanisms.
