### PR TITLE
Don't depend on jruby-pageant unless we're installing under jruby

### DIFF
--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -14,10 +14,12 @@
   s.require_paths = %w[lib]
   s.rubygems_version = '1.3.2'
 
-  # This has two flavours with java one actually doing something and other
-  # one just raising error. This is a workaround for no ability to specify
-  # platform specific dependencies in gemspecs.
-  s.add_dependency 'jruby-pageant', ">=1.0.2"
+  if RUBY_PLATFORM == "java"
+    # This has two flavours with java one actually doing something and other
+    # one just raising error. This is a workaround for no ability to specify
+    # platform specific dependencies in gemspecs.
+    s.add_dependency 'jruby-pageant', ">=1.0.2"
+  end
 
   s.executables = %w[]
 


### PR DESCRIPTION
The idea that windows and java follow me into my app even though I'm not using them, even in the limited version of jruby-pageant, makes me feel as though they might one day creep in through my window and stare at me from the corner as I sleep.

There are a few alternatives:
- Declare the dependency only under java (as done here)
- Declare the dependency only under java + windows
- Drop the dependency altogether and print a message on failure to load jruby-pageant

I'm fine with any of these. What do you think?
