### PR TITLE
Fix multibyte strings for UTF-8 encoding in Net::SSH messages.

### DIFF
--- a/lib/net/ssh/buffer.rb
+++ b/lib/net/ssh/buffer.rb
@@ -318,7 +318,7 @@ module Net; module SSH
     def write_string(*text)
       text.each do |string|
         s = string.to_s
-        write_long(s.length)
+        write_long(s.bytesize)
         write(s)
       end
       self

--- a/lib/net/ssh/transport/packet_stream.rb
+++ b/lib/net/ssh/transport/packet_stream.rb
@@ -120,18 +120,18 @@ module Net; module SSH; module Transport
       payload = client.compress(payload)
 
       # the length of the packet, minus the padding
-      actual_length = 4 + payload.length + 1
+      actual_length = 4 + payload.bytesize + 1
 
       # compute the padding length
       padding_length = client.block_size - (actual_length % client.block_size)
       padding_length += client.block_size if padding_length < 4
 
       # compute the packet length (sans the length field itself)
-      packet_length = payload.length + padding_length + 1
+      packet_length = payload.bytesize + padding_length + 1
 
       if packet_length < 16
         padding_length += client.block_size
-        packet_length = payload.length + padding_length + 1
+        packet_length = payload.bytesize + padding_length + 1
       end
 
       padding = Array.new(padding_length) { rand(256) }.pack("C*")

--- a/test/test_buffer.rb
+++ b/test/test_buffer.rb
@@ -29,6 +29,11 @@ class TestBuffer < Test::Unit::TestCase
     assert_equal "\1\2\3\4\5", buffer.to_s
   end
 
+  def test_from_should_measure_bytesize_of_utf_8_string_correctly
+    buffer = Net::SSH::Buffer.from(:string, "\u2603") # Snowman is 3 bytes
+    assert_equal "\0\0\0\3\u2603", buffer.to_s
+  end
+
   def test_read_without_argument_should_read_to_end
     buffer = new("hello world")
     assert_equal "hello world", buffer.read

--- a/test/transport/test_packet_stream.rb
+++ b/test/transport/test_packet_stream.rb
@@ -165,6 +165,14 @@ module Transport
       assert_equal 24, stream.write_buffer.length
     end
 
+    def test_enqueue_utf_8_packet_should_ensure_packet_length_is_in_bytes_and_multiple_of_block_length
+      packet = Net::SSH::Buffer.from(:string, "\u2603") # Snowman is 3 bytes
+      stream.enqueue_packet(packet)
+      # When bytesize is measured wrong using length, the result is off by 2.
+      # With length instead of bytesize, you get 26 length buffer.
+      assert_equal 0, stream.write_buffer.length % 8
+    end
+
     PACKETS = {
       "3des-cbc" => {
         "hmac-md5" => {


### PR DESCRIPTION
> Previously, UTF-8 encoded strings would result in the error:
> 
> `final': data not multiple of block length (OpenSSL::Cipher::CipherError)
> 
> This is because cipher padding length was based on character length
> instead of bytesize. When a UTF-8 character with a bytesize of e.g. 3
> was encountered, Net::SSH would incorrectly add 2 more padding than was
> needed, breaking the block size multiple.
> 
> Buffer also incorrectly identified the length of the string in
> write_string using character length instead of bytesize.

I also reported this bug here about 6 months ago:

http://net-ssh.lighthouseapp.com/projects/36253/tickets/48-netssh-fails-with-different-encodings

All tests pass as far as I can tell. In particular you can see how the block size is wrong without the fix (26) and then is correct with the fix (24)
