### PR TITLE
check an availability of UNIXSocket and UNIXServer

### DIFF
--- a/lib/net/ssh/service/forward.rb
+++ b/lib/net/ssh/service/forward.rb
@@ -57,7 +57,7 @@ module Net; module SSH; module Service
       local_port_type = :long
 
       socket = begin
-        if args.first.class == UNIXServer
+        if defined?(UNIXServer) and args.first.class == UNIXServer
           local_port_type = :string
           args.shift
         else

--- a/test/manual/test_forward.rb
+++ b/test/manual/test_forward.rb
@@ -128,7 +128,7 @@ class TestForward < Test::Unit::TestCase
     tempfile.delete
     yield UNIXServer.open(path)
     File.delete(path)
-  end
+  end if defined?(UNIXServer)
   
   def test_forward_local_unix_socket_to_remote_port
     session = Net::SSH.start(*ssh_start_params) 
@@ -157,7 +157,7 @@ class TestForward < Test::Unit::TestCase
 
     assert_not_nil(client_data, "client should have received data")
     assert(client_data.match(/item\d/), 'client should have received the string item')
-  end
+  end if defined?(UNIXSocket)
 
   def test_loop_should_not_abort_when_server_side_of_forward_is_closed
     session = Net::SSH.start(*ssh_start_params)    


### PR DESCRIPTION
Hello,

I tried to use net-ssh on Windows environment and it works almost fine, thanks.
However, local forwarding could not work due to lack of UNIXServer.
I'm not good at Windows, but I can understand that the UNIXServer is not available on it.
Fortunately, it appears only one situation to determine the argument type on 
Net::SSH::Service::Forward#local, and it is avoidable.
In addition, test_forward_local_unix_socket_to_remote_port on test/manual/test_forward.rb 
is using UNIXSocket, and its helper method create_local_socket is using UNIXServer.

Thanks again!
