### PR TITLE
Changed encoding of file to prevent warnings when generating docs

### DIFF
--- a/lib/net/ssh/authentication/pageant.rb
+++ b/lib/net/ssh/authentication/pageant.rb
@@ -18,7 +18,7 @@ module Net; module SSH; module Authentication
   # identities.
   #
   # This code is a slightly modified version of the original implementation
-  # by Guillaume Marçais (guillaume.marcais@free.fr). It is used and
+  # by Guillaume MarÃ§ais (guillaume.marcais@free.fr). It is used and
   # relicensed by permission.
   module Pageant
 


### PR DESCRIPTION
This prevents warnings like

```
Installing ri documentation for net-ssh-2.6.0...
unable to convert lib/net/ssh/authentication/pageant.rb to UTF-8, skipping
Installing RDoc documentation for net-ssh-2.6.0...
unable to convert lib/net/ssh/authentication/pageant.rb to UTF-8, skipping
```

when installing the gem. It looks a bit strange in the diff view but that's just fine.
