### PR TITLE
PacketStream: Properly detect disconnects in nonblocking reads.

### DIFF
--- a/lib/net/ssh/transport/packet_stream.rb
+++ b/lib/net/ssh/transport/packet_stream.rb
@@ -82,7 +82,11 @@ module Net; module SSH; module Transport
     def next_packet(mode=:nonblock)
       case mode
       when :nonblock then
-        fill if available_for_read?
+        if available_for_read?
+          if fill <= 0
+            raise Net::SSH::Disconnect, "connection closed by remote host"
+          end
+        end
         poll_next_packet
 
       when :block then


### PR DESCRIPTION
We see a bug where it's possible to get net-ssh into an infite loop
spinning CPU after a connection has been closed. I am unable to
reliably reproduce it, so I can't be positive this is the fix, but I
have not seen a recurrence in our environment since adding this patch.
