### PR TITLE
Get agent forwarding working on Windows (with Pageant)

### DIFF
--- a/lib/net/ssh/authentication/pageant.rb
+++ b/lib/net/ssh/authentication/pageant.rb
@@ -110,6 +110,7 @@ module Net; module SSH; module Authentication
             "pageant process not running"
         end
 
+        @pending_query = nil
         @res = nil
         @pos = 0
       end
@@ -168,7 +169,11 @@ module Net; module SSH; module Authentication
       # Conceptually close the socket. This doesn't really do anthing
       # significant, but merely complies with the Socket interface.
       def close
-        @res = nil
+        # hack. probably need to move closed state to a flag,
+        # since ready and closed will look equivalent
+        # also basically we never need to actually be closed
+
+        # @res = nil
         @pos = 0
       end
 
@@ -183,6 +188,7 @@ module Net; module SSH; module Authentication
       # is +nil+, returns all remaining data from the last query.
       def read(n = nil)
         return nil unless @res
+
         if n.nil?
           start, @pos = @pos, @res.size
           return @res[start..-1]
@@ -192,6 +198,35 @@ module Net; module SSH; module Authentication
         end
       end
 
+      # methods we need since they dont come from buffer/buffered_io any more
+      def available
+        return @res.nil? ? 0 : @res.length - @pos
+      end
+
+      def read_available(n=nil)
+        read(n)
+      end
+
+      def fill(n=nil)
+        @res = read(n)
+        return @res.length
+      end
+
+      def enqueue(data)
+        @pending_query = (@pending_query || '') + data
+      end
+
+      def send_pending
+        return if @pending_query.nil?
+
+        @res = send_query(@pending_query)
+        @pos = 0
+        @pending_query = nil
+      end
+
+      def shutdown(reason)
+        #no op
+      end
     end
 
     # Socket changes for Ruby 1.9
@@ -202,6 +237,8 @@ module Net; module SSH; module Authentication
       # process via the Windows messaging subsystem. The result is
       # cached, to be returned piece-wise when #read is called.
       def send_query(query)
+        query = @always_query || query
+
         res = nil
         filemap = 0
         ptr = nil

--- a/lib/net/ssh/connection/session.rb
+++ b/lib/net/ssh/connection/session.rb
@@ -224,20 +224,26 @@ module Net; module SSH; module Connection
     # then calls Net::SSH::Transport::Session#rekey_as_needed to allow the
     # transport layer to rekey. Then returns true.
     def postprocess(readers, writers)
+      # sometimes, got an execution hang on reader.fill.zero?
+      # the reader and writer socket was the same in those cases
+      # swapping the order so that pending writes execute before readers are closed seems to work
+      
+      Array(writers).each do |writer|
+        writer.send_pending
+      end
+
       Array(readers).each do |reader|
         if listeners[reader]
           listeners[reader].call(reader)
         else
-          if reader.fill.zero?
+          z = reader.fill.zero?
+          if z
             reader.close
             stop_listening_to(reader)
           end
         end
       end
 
-      Array(writers).each do |writer|
-        writer.send_pending
-      end
 
       transport.rekey_as_needed
 

--- a/lib/net/ssh/ruby_compat.rb
+++ b/lib/net/ssh/ruby_compat.rb
@@ -26,8 +26,34 @@ module Net; module SSH
     # See: http://net-ssh.lighthouseapp.com/projects/36253/tickets/1-ioselect-threading-bug-in-ruby-18
     # The root issue is documented here: http://redmine.ruby-lang.org/issues/show/1993
     if RUBY_VERSION >= '1.9' || RUBY_PLATFORM == 'java'
+      
+      # problem: Pageant sockets aren't real sockets/don't inherit from IO, so we can't call IO.select on them
+      # solution: when a Pageant socket is found in the readers/writers array, slice it out then merge it back in before returning (just assume it's always ready)
+      # unfortunately this fix will also need to be ported to any other library that reaches in to Net::SSH and select's its sockets (like Capistrano)
+      # this is slightly more verbose than necessary, but it's useful for debugging
       def self.io_select(*params)
-        IO.select(*params)
+        read_array = params[0]
+        write_array = params[1]
+        error_array = params[2]
+        timeout = params[3]
+
+        read_sockets = read_array.nil? ? [] : read_array.reject {|s| s.class.name =~ /Pageant/ }
+        read_pageant = read_array.nil? ? [] : read_array.select {|s| s.class.name =~ /Pageant/ }
+
+        write_sockets = write_array.nil? ? [] : write_array.reject {|s| s.class.name =~ /Pageant/ }
+        write_pageant = write_array.nil? ? [] : write_array.select {|s| s.class.name =~ /Pageant/ }
+
+        result = IO.select(read_sockets, write_sockets, error_array, timeout)
+
+        if result.nil?
+          return nil
+        else
+          ready_read_sockets = result[0]
+          ready_write_sockets = result[1]
+          ready_error_array_only_sockets = result[2]
+
+          return [ready_read_sockets | read_pageant, ready_write_sockets | write_pageant, ready_error_array_only_sockets]
+        end
       end
     else
       SELECT_MUTEX = Mutex.new


### PR DESCRIPTION
I see two potential paths to get agent forwarding working here;
- Make Pageant::Socket / Pageant::Socket19 more like actual sockets (inherit from IO & operate correctly with IO.select)
- Accept that they aren't real sockets and patch the code that uses Pageant classes accordingly

Because it seemed easier, I went with option two, which does work. The main downside of this approach is that it's somewhat hacky and require any other libraries that reach into Net::SSH to be aware of this consideration (namely Capistrano, for which I have also submitted a pull request).

On the other hand, it's a relatively patch... turns out after all these years it didn't take that much to get agent forwarding to work on Windows after all.

Here's a simple connection testing script for those interested https://gist.github.com/4091377
