### PR TITLE
Add stderr handling to Net::SSH::Test

### DIFF
--- a/lib/net/ssh/test/channel.rb
+++ b/lib/net/ssh/test/channel.rb
@@ -10,6 +10,7 @@ module Net; module SSH; module Test
   #     channel = session.opens_channel
   #     channel.sends_exec "ls"
   #     channel.gets_data "result of ls"
+  #     channel.gets_extended_data "some error coming from ls"
   #     channel.gets_close
   #     channel.sends_close
   #   end
@@ -102,6 +103,14 @@ module Net; module SSH; module Test
     #   channel.gets_data "bar"
     def gets_data(data)
       script.gets_channel_data(self, data)
+    end
+
+    # Scripts the reception of a channel extended data packet from the remote
+    # end.
+    #
+    #   channel.gets_extended_data "whoops"
+    def gets_extended_data(data)
+      script.gets_channel_extended_data(self, data)
     end
 
     # Scripts the reception of an "exit-status" channel request packet.

--- a/lib/net/ssh/test/packet.rb
+++ b/lib/net/ssh/test/packet.rb
@@ -65,6 +65,7 @@ module Net; module SSH; module Test
         when CHANNEL_OPEN then [:string, :long, :long, :long]
         when CHANNEL_OPEN_CONFIRMATION then [:long, :long, :long, :long]
         when CHANNEL_DATA then [:long, :string]
+        when CHANNEL_EXTENDED_DATA then [:long, :long, :string]
         when CHANNEL_EOF, CHANNEL_CLOSE, CHANNEL_SUCCESS, CHANNEL_FAILURE then [:long]
         when CHANNEL_REQUEST
           parts = [:long, :string, :bool]

--- a/lib/net/ssh/test/script.rb
+++ b/lib/net/ssh/test/script.rb
@@ -111,6 +111,15 @@ module Net; module SSH; module Test
       events << RemotePacket.new(:channel_data, channel.local_id, data)
     end
 
+    # Scripts the reception of a channel extended data packet from the remote
+    # host by the given Net::SSH::Test::Channel +channel+. This will typically
+    # be called via Net::SSH::Test::Channel#gets_extended_data.
+    #
+    # Currently the only extended data type is stderr == 1.
+    def gets_channel_extended_data(channel, data)
+      events << RemotePacket.new(:channel_extended_data, channel.local_id, 1, data)
+    end
+
     # Scripts the reception of a channel request packet from the remote host by
     # the given Net::SSH::Test::Channel +channel+. This will typically be
     # called via Net::SSH::Test::Channel#gets_exit_status.


### PR DESCRIPTION
I was working on https://github.com/mkocher/soloist and ran straight into "don't know how to parse packet type 95" while testing stderr channel data.

I've added #gets_extended_data to the test channel in order to support this.
