### PR TITLE
Fix Invalid key size in JRuby

### DIFF
--- a/lib/net/ssh/test/kex.rb
+++ b/lib/net/ssh/test/kex.rb
@@ -32,7 +32,7 @@ module Net; module SSH; module Test
       raise Net::SSH::Exception, "expected NEWKEYS" unless buffer.type == NEWKEYS
 
       { :session_id        => "abc-xyz",
-        :server_key        => OpenSSL::PKey::RSA.new(32),
+        :server_key        => OpenSSL::PKey::RSA.new(512),
         :shared_secret     => OpenSSL::BN.new("1234567890", 10),
         :hashing_algorithm => OpenSSL::Digest::SHA1 }
     end


### PR DESCRIPTION
While using Net::SSH::Test in JRuby-1.7.0 I got this exception:

```
OpenSSL::PKey::RSAError:
   Invalid key sizes
```

I traced this to http://jira.codehaus.org/browse/JRUBY-6690, which says that 512 bits is the minimum key size in Java.
