### PR TITLE
Removing warnings

### DIFF
--- a/lib/net/ssh/authentication/methods/keyboard_interactive.rb
+++ b/lib/net/ssh/authentication/methods/keyboard_interactive.rb
@@ -42,7 +42,7 @@ module Net
                   puts(instruction) unless instruction.empty?
                 end
 
-                lang_tag = message.read_string
+                _ = message.read_string # lang_tag
                 responses =[]
   
                 message.read_long.times do

--- a/lib/net/ssh/authentication/session.rb
+++ b/lib/net/ssh/authentication/session.rb
@@ -54,7 +54,7 @@ module Net; module SSH; module Authentication
       debug { "beginning authentication of `#{username}'" }
 
       transport.send_message(transport.service_request("ssh-userauth"))
-      message = expect_message(SERVICE_ACCEPT)
+      expect_message(SERVICE_ACCEPT)
 
       key_manager = KeyManager.new(logger, options)
       keys.each { |key| key_manager.add(key) } unless keys.empty?
@@ -70,7 +70,7 @@ module Net; module SSH; module Authentication
           debug { "trying #{name}" }
           begin 
             method = Methods.const_get(name.split(/\W+/).map { |p| p.capitalize }.join).new(self, :key_manager => key_manager)
-          rescue NameError => ne
+          rescue NameError
             debug{"Mechanism #{name} was requested, but isn't a known type.  Ignoring it."}
             next
           end

--- a/lib/net/ssh/buffer.rb
+++ b/lib/net/ssh/buffer.rb
@@ -261,7 +261,7 @@ module Net; module SSH
           else
             begin
               key = OpenSSL::PKey::EC.read_keyblob($1, self)
-            rescue OpenSSL::PKey::ECError => e
+            rescue OpenSSL::PKey::ECError
               raise NotImplementedError, "unsupported key type `#{type}'"
             end
           end

--- a/lib/net/ssh/key_factory.rb
+++ b/lib/net/ssh/key_factory.rb
@@ -105,7 +105,7 @@ module Net; module SSH
       # the file describes an RSA or DSA key, and will load it
       # appropriately. The new public key is returned.
       def load_data_public_key(data, filename="")
-        type, blob = data.split(/ /)
+        _, blob = data.split(/ /)
 
         raise Net::SSH::Exception, "public key at #{filename} is not valid" if blob.nil?
 

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -263,7 +263,7 @@ module Net; module SSH; module Transport
         # TODO: if first_kex_packet_follows, we need to try to skip the
         # actual kexinit stuff and try to guess what the server is doing...
         # need to read more about this scenario.
-        first_kex_packet_follows = packet.read_bool
+        # first_kex_packet_follows = packet.read_bool
 
         return data
       end

--- a/lib/net/ssh/transport/key_expander.rb
+++ b/lib/net/ssh/transport/key_expander.rb
@@ -22,5 +22,5 @@ module Net; module SSH; module Transport
 
     return k
   end
-end
+  end
 end; end; end

--- a/lib/net/ssh/transport/openssl.rb
+++ b/lib/net/ssh/transport/openssl.rb
@@ -153,7 +153,7 @@ module OpenSSL
             key.public_key = point
 
             return key
-          rescue OpenSSL::PKey::ECError => e
+          rescue OpenSSL::PKey::ECError
             raise NotImplementedError, "unsupported key type `#{type}'"
           end
 

--- a/lib/net/ssh/transport/packet_stream.rb
+++ b/lib/net/ssh/transport/packet_stream.rb
@@ -219,7 +219,6 @@ module Net; module SSH; module Transport
         padding_length = @packet.read_byte
 
         payload = @packet.read(@packet_length - padding_length - 1)
-        padding = @packet.read(padding_length) if padding_length > 0
 
         my_computed_hmac = server.hmac.digest([server.sequence_number, @packet.content].pack("NA*"))
         raise Net::SSH::Exception, "corrupted mac detected" if real_hmac != my_computed_hmac

--- a/lib/net/ssh/transport/server_version.rb
+++ b/lib/net/ssh/transport/server_version.rb
@@ -46,7 +46,7 @@ module Net; module SSH; module Transport
             begin
               b = socket.readpartial(1)
               raise Net::SSH::Disconnect, "connection closed by remote host" if b.nil?
-            rescue EOFError => e
+            rescue EOFError
               raise Net::SSH::Disconnect, "connection closed by remote host"
             end
             @version << b


### PR DESCRIPTION
This pull request fixes some warnings that occur when running with -w.

The list of warnings was (path changed in the messages below):

```
/Path/to/.rvm/gems/ruby-1.9.3-p327/gems/net-ssh-2.6.2/lib/net/ssh/transport/algorithms.rb:266: warning: assigned but unused variable - first_kex_packet_follows
/Path/to/.rvm/gems/ruby-1.9.3-p327/gems/net-ssh-2.6.2/lib/net/ssh/buffer.rb:264: warning: assigned but unused variable - e
/Path/to/.rvm/gems/ruby-1.9.3-p327/gems/net-ssh-2.6.2/lib/net/ssh/transport/openssl.rb:156: warning: assigned but unused variable - e
/Path/to/.rvm/gems/ruby-1.9.3-p327/gems/net-ssh-2.6.2/lib/net/ssh/transport/key_expander.rb:25: warning: mismatched indentations at 'end' with 'module' at 2
/Path/to/.rvm/gems/ruby-1.9.3-p327/gems/net-ssh-2.6.2/lib/net/ssh/transport/server_version.rb:49: warning: assigned but unused variable - e
/Path/to/.rvm/gems/ruby-1.9.3-p327/gems/net-ssh-2.6.2/lib/net/ssh/transport/packet_stream.rb:218: warning: assigned but unused variable - padding
/Path/to/.rvm/gems/ruby-1.9.3-p327/gems/net-ssh-2.6.2/lib/net/ssh/authentication/session.rb:73: warning: assigned but unused variable - ne
/Path/to/.rvm/gems/ruby-1.9.3-p327/gems/net-ssh-2.6.2/lib/net/ssh/authentication/session.rb:57: warning: assigned but unused variable - message
/Path/to/.rvm/gems/ruby-1.9.3-p327/gems/net-ssh-2.6.2/lib/net/ssh/key_factory.rb:108: warning: assigned but unused variable - type
/Path/to/.rvm/gems/ruby-1.9.3-p327/gems/net-ssh-2.6.2/lib/net/ssh/authentication/methods/keyboard_interactive.rb:45: warning: assigned but unused variable - lang_tag
```

I've tried to make appropriate changes, but not being very familiar with the codebase, I'm not sure I succeeded... ;] 

Tests all pass in MRI 1.9.3 (including the port forwarding tests) and after running setup.rb the warnings disappeared on my machine.

I noticed that under MRI 1.9.2 the tests below fail, but that was happening prior to my changes already, so I don't think I introduced new problems there.
- test_load_unencrypted_private_ecdsa_sha2_nistp256_key_should_return_key
- test_load_unencrypted_private_ecdsa_sha2_nistp384_key_should_return_key
- test_load_unencrypted_private_ecdsa_sha2_nistp521_key_should_return_key

MRI 1.9.1 just doesn't seem to work at all for me, so I didn't dig much into that. I'm not sure if the current Net::SSH is still supposed to be compatible with 1.9.1.

Under JRuby-1.7.1 all the enabled tests passed, but the port forwarding tests did not all pass (see below for the list). Again, this is similar to MRI 1.9.2 in that those tests also failed prior to my changes.
- test_forward_local_unix_socket_to_remote_port
- test_loop_should_not_abort_when_local_side_of_forward_is_closed

Note that I've used the [_ (underscore) variable](http://stackoverflow.com/questions/9559561/where-and-how-is-the-underscore-variable-specified-in-ruby) to suppress warnings in `lib/net/ssh/authentication/methods/keyboard_interactive.rb` and `lib/net/ssh/key_factory.rb` since the variables they declared don't seem to be used anywhere.

I commented out the `first_kex_packet_follows` variable assignment since that seems to be part of a TODO anyway.
