### PR TITLE
This should fix #85

### DIFF
--- a/lib/net/ssh/authentication/pageant.rb
+++ b/lib/net/ssh/authentication/pageant.rb
@@ -2,9 +2,7 @@ require 'dl/import'
 
 if RUBY_VERSION < "1.9"
   require 'dl/struct'
-end
-
-if RUBY_VERSION =~ /^1.9/
+else
   require 'dl/types'
   require 'dl'
 end
@@ -34,9 +32,7 @@ module Net; module SSH; module Authentication
 
         dlload 'user32'
         dlload 'kernel32'
-      end
-
-      if RUBY_VERSION =~ /^1.9/
+      else
         extend DL::Importer
         dlload 'user32','kernel32'
         include DL::Win32Types


### PR DESCRIPTION
It's prefered to fallback to the newer api instead of checking for
versions before 1.9 and 1.9 and leaving others open to breakage.
