### PR TITLE
Fix channel open failure for packet size too big and support user-specified max packet + window sizes.

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -66,7 +66,8 @@ module Net
       :languages, :logger, :paranoid, :password, :port, :proxy, 
       :rekey_blocks_limit,:rekey_limit, :rekey_packet_limit, :timeout, :verbose,
       :global_known_hosts_file, :user_known_hosts_file, :host_key_alias,
-      :host_name, :user, :properties, :passphrase, :keys_only
+      :host_name, :user, :properties, :passphrase, :keys_only, :max_pkt_size,
+      :max_win_size
     ]
 
     # The standard means of starting a new SSH connection. When used with a
@@ -133,6 +134,10 @@ module Net
     #   option is intended for situations where ssh-agent offers many different
     #   identites.
     # * :logger => the logger instance to use when logging
+    # * :max_pkt_size => maximum size we tell the other side that is supported per
+    #   packet.
+    # * :max_win_size => maximum size we tell the other side that is supported for
+    #   the window.
     # * :paranoid => either false, true, :very, or :secure specifying how
     #   strict host-key verification should be (in increasing order here)
     # * :passphrase => the passphrase to use when loading a private key (default

--- a/lib/net/ssh/connection/channel.rb
+++ b/lib/net/ssh/connection/channel.rb
@@ -107,15 +107,15 @@ module Net; module SSH; module Connection
     # that time (see #do_open_confirmation).
     #
     # This also sets the default maximum packet size and maximum window size.
-    def initialize(connection, type, local_id, &on_confirm_open)
+    def initialize(connection, type, local_id, max_pkt_size = 0x8000, max_win_size = 0x20000, &on_confirm_open)
       self.logger = connection.logger
 
       @connection = connection
       @type       = type
       @local_id   = local_id
 
-      @local_maximum_packet_size = 0x10000
-      @local_window_size = @local_maximum_window_size = 0x20000
+      @local_maximum_packet_size = max_pkt_size
+      @local_window_size = @local_maximum_window_size = max_win_size
 
       @on_confirm_open = on_confirm_open
 


### PR DESCRIPTION
Per section 6.1 of RFC 4253 an SSH implementation MUST support a packet
size of 32768 bytes, however, any size above this is not mandatory.
Currently, the max packet size is 64Kb and can cause a channel open
failure for hosts which only support the required 32Kb packet size.

As a result, we now first open a channel to the host and will reduce the
max packet size to RFC required length if there is a failure. For
performance, once we have tested for this condition a single time, we
will not do so again. If the max packet size has been configured to the
RFC required value (or less) we do not perform this test at all.

Additionally, the user can now manually define the maximum packet and
window size, should they choose to.

Updated version to 2.6.7
