### PR TITLE
Fix config load if home is not absolute path

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -57,8 +57,11 @@ module Net; module SSH
       # #translate for how to convert the OpenSSH options into Net::SSH
       # options.)
       def load(path, host, settings={})
-        file = File.expand_path(path)
-        return settings unless File.readable?(file)
+        begin
+          file = File.expand_path(path)
+        rescue ArgumentError
+        end
+        return settings unless file && File.readable?(file)
         
         globals = {}
         matched_host = nil

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -8,6 +8,13 @@ class TestConfig < Test::Unit::TestCase
     assert_equal({}, Net::SSH::Config.load(bogus_file, "host.name"))
   end
 
+  def test_load_for_relative_home_user_should_return_empty_hash
+    home, ENV["HOME"] = ENV["HOME"], "."
+    assert_equal({}, Net::SSH::Config.load("~/.ssh/config", "host.name"))
+  ensure
+    ENV["HOME"] = home
+  end
+
   def test_load_should_expand_path
     expected = File.expand_path("~/.ssh/config")
     File.expects(:readable?).with(expected).returns(false)


### PR DESCRIPTION
In setups where $HOME is not an absolute path, File.expand_path will
raise ArgumentError "non-absolute home" if the given argument includes a
tilde. This change handles such scenarios as if the file isn't readable.
