### PR TITLE
Make sure HOME is an absolute path

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -153,7 +153,7 @@ which should produce the following:
 
 Run the test suite from the net-ssh directory with the following command:
 
-     ruby -Ilib -Itest -rrubygems test/test_all.rb
+     bash -c 'unset HOME && ruby -Ilib -Itest -rrubygems test/test_all.rb'
 
 Run a single test file like this:
 

--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -1,6 +1,6 @@
 # Make sure HOME is set, regardless of OS, so that File.expand_path works
 # as expected with tilde characters.
-ENV['HOME'] ||= ENV['HOMEPATH'] ? "#{ENV['HOMEDRIVE']}#{ENV['HOMEPATH']}" : "."
+ENV['HOME'] ||= ENV['HOMEPATH'] ? "#{ENV['HOMEDRIVE']}#{ENV['HOMEPATH']}" : Dir.pwd
 
 require 'logger'
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -1,7 +1,12 @@
 require 'common'
 require 'net/ssh/config'
+require 'pathname'
 
 class TestConfig < Test::Unit::TestCase
+  def test_home_should_be_absolute_path
+    assert Pathname.new(ENV['HOME']).absolute?
+  end
+
   def test_load_for_non_existant_file_should_return_empty_hash
     bogus_file = File.expand_path("/bogus/file")
     File.expects(:readable?).with(bogus_file).returns(false)


### PR DESCRIPTION
In setups where $HOME is not set, the previous implementation set "." as
default. The problem is that File.expand_path will raise ArgumentError
"non-absolute home" if HOME is a relative path. This change makes sure
HOME is an absolute path.
