### PR TITLE
Remote forwarding: read opened port from server

### DIFF
--- a/lib/net/ssh/service/forward.rb
+++ b/lib/net/ssh/service/forward.rb
@@ -126,10 +126,12 @@ module Net; module SSH; module Service
     #
     #   ssh.forward.remote(80, "www.google.com", 1234, "0.0.0.0")
     #   ssh.loop { !ssh.forward.active_remotes.include?([1234, "0.0.0.0"]) }
-    def remote(port, host, remote_port, remote_host="127.0.0.1")
+    def remote(port, host, remote_port, remote_host="127.0.0.1",&blk)
       session.send_global_request("tcpip-forward", :string, remote_host, :long, remote_port) do |success, response|
         if success
+          remote_port = response.read_long if remote_port.zero?
           debug { "remote forward from remote #{remote_host}:#{remote_port} to #{host}:#{port} established" }
+          blk.call(remote_port) if blk
           @remote_forwarded_ports[[remote_port, remote_host]] = Remote.new(host, port)
         else
           error { "remote forwarding request failed" }


### PR DESCRIPTION
Using remote_port=0 allows the remote system to allocate
the port automatically.
