### PR TITLE
Add a wait to the loop in close

### DIFF
--- a/lib/net/ssh/connection/session.rb
+++ b/lib/net/ssh/connection/session.rb
@@ -110,7 +110,7 @@ module Net; module SSH; module Connection
     def close
       info { "closing remaining channels (#{channels.length} open)" }
       channels.each { |id, channel| channel.close }
-      loop { channels.any? }
+      loop(0.1) { channels.any? }
       transport.close
     end
 


### PR DESCRIPTION
This is possibly blocking in cases where the connection is now unresponsive, and also potentially blocking timeouts which wrap the calling of the close method.
