### PR TITLE
Guard against nil socket.gets responses

### DIFF
--- a/lib/net/ssh/proxy/http.rb
+++ b/lib/net/ssh/proxy/http.rb
@@ -73,7 +73,7 @@ module Net; module SSH; module Proxy
         version, code, reason = socket.gets.chomp.split(/ /, 3)
         headers = {}
 
-        while (line = socket.gets.chomp) != ""
+        while (line = socket.gets) && (line.chomp! != "")
           name, value = line.split(/:/, 2)
           headers[name.strip] = value.strip
         end


### PR DESCRIPTION
In the situation where the socket has only one line to respond with, any
following gets to the socket need to take care to not assume there is a
non-nil response.
