### PR TITLE
Fixed missing requires in test files

### DIFF
--- a/test/transport/kex/test_diffie_hellman_group_exchange_sha256.rb
+++ b/test/transport/kex/test_diffie_hellman_group_exchange_sha256.rb
@@ -1,5 +1,6 @@
 require 'common'
 require 'net/ssh/transport/kex/diffie_hellman_group_exchange_sha1'
+require 'transport/kex/test_diffie_hellman_group_exchange_sha1'
 
 module Transport; module Kex
 

--- a/test/transport/kex/test_ecdh_sha2_nistp384.rb
+++ b/test/transport/kex/test_ecdh_sha2_nistp384.rb
@@ -3,6 +3,7 @@ require 'openssl'
 unless defined?(OpenSSL::PKey::EC)
   puts "Skipping tests for ecdh-sha2-nistp384 key exchange"
 else
+  require 'transport/kex/test_ecdh_sha2_nistp256'
   module Transport; module Kex
     class TestEcdhSHA2NistP384 < TestEcdhSHA2NistP256
 

--- a/test/transport/kex/test_ecdh_sha2_nistp521.rb
+++ b/test/transport/kex/test_ecdh_sha2_nistp521.rb
@@ -3,6 +3,7 @@ require 'openssl'
 unless defined?(OpenSSL::PKey::EC)
   puts "Skipping tests for ecdh-sha2-nistp521 key exchange"
 else
+  require 'transport/kex/test_ecdh_sha2_nistp256'
   module Transport; module Kex
     class TestEcdhSHA2NistP521 < TestEcdhSHA2NistP256
 


### PR DESCRIPTION
Missing requires in test files made them fail when run one at a time.
test_all.rb would sometimes fail when the test order changed, because of this.
