### PR TITLE
implement a experimental keepalive feature #115

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -62,7 +62,8 @@ module Net
     # Net::SSH.start for a description of each option.
     VALID_OPTIONS = [
       :auth_methods, :bind_address, :compression, :compression_level, :config,
-      :encryption, :forward_agent, :hmac, :host_key, :kex, :keys, :key_data,
+      :encryption, :forward_agent, :hmac, :host_key,
+      :keepalive, :keepalive_interval, :kex, :keys, :key_data,
       :languages, :logger, :paranoid, :password, :port, :proxy,
       :rekey_blocks_limit,:rekey_limit, :rekey_packet_limit, :timeout, :verbose,
       :global_known_hosts_file, :user_known_hosts_file, :host_key_alias,
@@ -124,6 +125,11 @@ module Net
     #   specified in an SSH configuration file. It lets you specify an
     #   "alias", similarly to adding an entry in /etc/hosts but without needing
     #   to modify /etc/hosts.
+    #   :keepalive => set to +true+ to send a keepalive packet to the SSH server
+    #   when there's no traffic between the SSH server and Net::SSH client for
+    #   the keepalive_interval seconds. Defaults to +false+.
+    #   :keepalive_interval => the interval seconds for keepalive.
+    #   Defaults to +300+ seconds.
     # * :kex => the key exchange algorithm (or algorithms) to use
     # * :keys => an array of file names of private keys to use for publickey
     #   and hostbased authentication

--- a/test/start/test_options.rb
+++ b/test/start/test_options.rb
@@ -1,0 +1,29 @@
+require 'common'
+require 'net/ssh'
+
+module NetSSH
+  class TestStartOptions < Test::Unit::TestCase
+    def setup
+      authentication_session = mock('authentication_session')
+      authentication_session.stubs(:authenticate).returns(true)
+      Net::SSH::Authentication::Session.stubs(:new).returns(authentication_session)
+      Net::SSH::Transport::Session.stubs(:new).returns(mock('transport_session'))
+      Net::SSH::Connection::Session.stubs(:new).returns(mock('connection_session'))
+    end
+
+    def test_start_should_accept_keepalive_option
+      assert_nothing_raised do
+        options = { :keepalive => true }
+        Net::SSH.start('localhost', 'testuser', options)
+      end
+    end
+
+    def test_start_should_accept_keepalive_interval_option
+      assert_nothing_raised do
+        options = { :keepalive_interval => 10 }
+        Net::SSH.start('localhost', 'testuser', options)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
To avoid the issue #115, I implement a simple keepalive function only using the current net-ssh's methods (using no threads).
- Add a function that sending a SSH_MSG_IGNORE packet when the IO.select was timed out.
- To control the keepalive behavior, add two options to the start method. 'keepalive' and 'keepalive-interval'.

I think that this patch would not change the current Net::SSH's behavior, if the keepalive option would be set to true. 
