### PR TITLE
Automatically forward environment variables defined in OpenSSH config files

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -68,7 +68,7 @@ module Net
       :rekey_blocks_limit,:rekey_limit, :rekey_packet_limit, :timeout, :verbose,
       :global_known_hosts_file, :user_known_hosts_file, :host_key_alias,
       :host_name, :user, :properties, :passphrase, :keys_only, :max_pkt_size,
-      :max_win_size
+      :max_win_size, :send_env
     ]
 
     # The standard means of starting a new SSH connection. When used with a
@@ -157,6 +157,8 @@ module Net
     # * :rekey_blocks_limit => the max number of blocks to process before rekeying
     # * :rekey_limit => the max number of bytes to process before rekeying
     # * :rekey_packet_limit => the max number of packets to process before rekeying
+    # * :send_env => an array of local environment variable names to export to the
+    #   remote environment. Names may be given as String or Regexp.
     # * :timeout => how long to wait for the initial connection to be made
     # * :user => the user name to log in as; this overrides the +user+
     #   parameter, and is primarily only useful when provided via an SSH

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -176,6 +176,9 @@ module Net; module SSH
             hash[:user] = value
           when 'userknownhostsfile'
             hash[:user_known_hosts_file] = value
+          when 'sendenv'
+            multi_send_env = value.to_s.split(/\s+/)
+            hash[:send_env] = multi_send_env.map { |e| Regexp.new pattern2regex(e).source, false }
           end
           hash
         end

--- a/test/configs/send_env
+++ b/test/configs/send_env
@@ -1,0 +1,2 @@
+Host 1234
+	SendEnv GIT_* LANG LC_*

--- a/test/start/test_options.rb
+++ b/test/start/test_options.rb
@@ -24,6 +24,13 @@ module NetSSH
         Net::SSH.start('localhost', 'testuser', options)
       end
     end
+
+    def test_start_should_accept_send_env_option
+      assert_nothing_raised do
+        options = { :send_env => [ /^LC_.*$/, "LANG" ] }
+        Net::SSH.start('localhost', 'testuser', options)
+      end
+    end
   end
 end
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -86,7 +86,8 @@ class TestConfig < Test::Unit::TestCase
       'passwordauthentication'  => true,
       'port'                    => 1234,
       'pubkeyauthentication'    => true,
-      'rekeylimit'              => 1024
+      'rekeylimit'              => 1024,
+      'sendenv'                 => "LC_*"
     }
 
     net_ssh = Net::SSH::Config.translate(open_ssh)
@@ -103,6 +104,7 @@ class TestConfig < Test::Unit::TestCase
     assert_equal 1234,      net_ssh[:port]
     assert_equal 1024,      net_ssh[:rekey_limit]
     assert_equal "127.0.0.1", net_ssh[:bind_address]
+    assert_equal [/^LC_.*$/], net_ssh[:send_env]
   end
   
   def test_load_with_plus_sign_hosts
@@ -134,7 +136,13 @@ class TestConfig < Test::Unit::TestCase
     net_ssh = Net::SSH::Config.translate(config)
     assert_equal 'prefix.1234.sufix', net_ssh[:host_name]
   end
-  
+
+  def test_load_with_send_env
+    config = Net::SSH::Config.load(config(:send_env), "1234")
+    net_ssh = Net::SSH::Config.translate(config)
+    assert_equal [/^GIT_.*$/, /^LANG$/, /^LC_.*$/], net_ssh[:send_env]
+  end
+
   private
 
     def config(name)


### PR DESCRIPTION
Also accept `:send_env` option on `Net::SSH.start`
