### PR TITLE
fix for 'Could not parse PKey: no start line' error on private keys with passphrases

### DIFF
--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -232,7 +232,6 @@ module Net
             rescue ArgumentError => e
               process_identity_loading_error(identity, e)
               nil
-              #Net::SSH::Exception or ::Exception?
             rescue Exception => e
               process_identity_loading_error(identity, e)
               nil


### PR DESCRIPTION
Fix for issues:

https://github.com/net-ssh/net-ssh/issues/101
https://github.com/capistrano/capistrano/issues/286

Also, maybe rescue Exception => e should use ::Exception instead of Net::SSH:Exception?
