### PR TITLE
Fix "ConnectionError" typo

### DIFF
--- a/lib/net/ssh/proxy/socks5.rb
+++ b/lib/net/ssh/proxy/socks5.rb
@@ -108,7 +108,7 @@ module Net
             ipv6addr hostname = socket.recv(16)
           else
             socket.close
-            raise ConnectionError, "Illegal response type"
+            raise ConnectError, "Illegal response type"
           end
           portnum = socket.recv(2)
           


### PR DESCRIPTION
I got following error when I use SOCKS5:

```
connection failed for: xxx (NameError: uninitialized constant Net::SSH::Proxy::SOCKS5::ConnectionError)
```

I guess `ConnectionError` is typo and `ConnectError` (`Net::SSH::Proxy::ConnectError`) is correct.
