### PR TITLE
make the authentication error message more useful

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -212,7 +212,7 @@ module Net
         end
       else
         transport.close
-        raise AuthenticationFailed, user
+        raise AuthenticationFailed, "Authentication failed for user #{user}@#{host}"
       end
     end
 


### PR DESCRIPTION
If class name of exception is not printed, exception containing just some username isn't very useful.
