### PR TITLE
Allowing agent to skip unimplemented key types.

### DIFF
--- a/lib/net/ssh/authentication/agent/socket.rb
+++ b/lib/net/ssh/authentication/agent/socket.rb
@@ -92,10 +92,15 @@ module Net; module SSH; module Authentication
 
       identities = []
       body.read_long.times do
-        key = Buffer.new(body.read_string).read_key
-        key.extend(Comment)
-        key.comment = body.read_string
-        identities.push key
+        begin
+          key = Buffer.new(body.read_string).read_key
+        rescue NotImplementedError => e
+          info { e.message }
+        else
+          key.extend(Comment)
+          key.comment = body.read_string
+          identities.push key
+        end
       end
 
       return identities


### PR DESCRIPTION
When net-ssh reads keys from the SSH agent it breaks when it encounters an unknown key type. Since the library does not implement certified RSA keys this is somewhat noticeable. The pull request is by no means a fix: the real solution is to implement the cert keys. I recognize that with my patch the agent will fail almost-silently, but I consider that the lesser of two evils.
