### PR TITLE
Don't use ssh-agent if :keys_only is true (fixes net-ssh/net-ssh#137)

### DIFF
--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -12,7 +12,7 @@ module Net
 
       # This class encapsulates all operations done by clients on a user's
       # private keys. In practice, the client should never need a reference
-      # to a private key; instead, they grab a list of "identities" (public 
+      # to a private key; instead, they grab a list of "identities" (public
       # keys) that are available from the KeyManager, and then use
       # the KeyManager to do various private key operations using those
       # identities.
@@ -37,12 +37,13 @@ module Net
         attr_reader :options
 
         # Create a new KeyManager. By default, the manager will
-        # use the ssh-agent (if it is running).
+        # use the ssh-agent if it is running and the `:keys_only` option
+        # is not true.
         def initialize(logger, options={})
           self.logger = logger
           @key_files = []
           @key_data = []
-          @use_agent = true
+          @use_agent = !options[:keys_only]
           @known_identities = {}
           @agent = nil
           @options = options
@@ -91,9 +92,8 @@ module Net
         # ssh-agent. Note that identities from an ssh-agent are always listed
         # first in the array, with other identities coming after.
         #
-        # If key manager was created with :keys_only option, any identity
-        # from ssh-agent will be ignored unless it present in key_files or
-        # key_data.
+        # If key manager was created with :keys_only option, no identities
+        # from ssh-agent will be loaded.
         def each_identity
           prepared_identities = prepare_identities_from_files + prepare_identities_from_data
 
@@ -139,7 +139,7 @@ module Net
           if info[:key].nil? && info[:from] == :file
             begin
               info[:key] = KeyFactory.load_private_key(info[:file], options[:passphrase], true)
-            rescue Exception, OpenSSL::OpenSSLError => e 
+            rescue Exception, OpenSSL::OpenSSLError => e
               raise KeyManagerError, "the given identity is known, but the private key could not be loaded: #{e.class} (#{e.message})"
             end
           end

--- a/test/authentication/test_key_manager.rb
+++ b/test/authentication/test_key_manager.rb
@@ -18,7 +18,7 @@ module Authentication
       manager.add "/second"
       manager.add "/third"
       manager.add "/second"
-      assert_true manager.key_files.length == 3
+      assert_equal 3, manager.key_files.length
       final_files = manager.key_files.map {|item| item.split('/').last}
       assert_equal %w(first second third), final_files
     end
@@ -30,12 +30,16 @@ module Authentication
       assert !manager.use_agent?
     end
 
+    def test_use_agent_is_false_if_keys_only
+      assert !manager(:keys_only => true).use_agent?
+    end
+
     def test_each_identity_should_load_from_key_files
       manager.stubs(:agent).returns(nil)
       first = File.expand_path("/first")
       second = File.expand_path("/second")
       stub_file_private_key first, rsa
-      stub_file_private_key second, dsa      
+      stub_file_private_key second, dsa
 
       identities = []
       manager.each_identity { |identity| identities << identity }
@@ -43,7 +47,7 @@ module Authentication
       assert_equal 2, identities.length
       assert_equal rsa.to_blob, identities.first.to_blob
       assert_equal dsa.to_blob, identities.last.to_blob
-      
+
       assert_equal({:from => :file, :file => first, :key => rsa}, manager.known_identities[rsa])
       assert_equal({:from => :file, :file => second, :key => dsa}, manager.known_identities[dsa])
     end


### PR DESCRIPTION
Since the `:keys_only` option should prevent any ssh-agent identities from being used unless they were already being provided, there is no apparent need to consult ssh-agent at all.  This patch bypasses the agent connection if `:keys_only` is true.
