### PR TITLE
Support %r in ProxyCommand configuration in ssh_config files as defined in OpenSSH.

### DIFF
--- a/lib/net/ssh/proxy/command.rb
+++ b/lib/net/ssh/proxy/command.rb
@@ -33,13 +33,20 @@ module Net; module SSH; module Proxy
 
     # Return a new socket connected to the given host and port via the
     # proxy that was requested when the socket factory was instantiated.
-    def open(host, port)
+    def open(host, port, connection_options = nil)
       command_line = @command_line_template.gsub(/%(.)/) {
         case $1
         when 'h'
           host
         when 'p'
           port.to_s
+        when 'r'
+          remote_user = connection_options && connection_options[:remote_user]
+          if remote_user
+            remote_user
+          else
+            raise ArgumentError, "remote user name not available"
+          end
         when '%'
           '%'
         else

--- a/lib/net/ssh/proxy/http.rb
+++ b/lib/net/ssh/proxy/http.rb
@@ -48,7 +48,7 @@ module Net; module SSH; module Proxy
 
     # Return a new socket connected to the given host and port via the
     # proxy that was requested when the socket factory was instantiated.
-    def open(host, port)
+    def open(host, port, connection_options = nil)
       socket = TCPSocket.new(proxy_host, proxy_port)
       socket.write "CONNECT #{host}:#{port} HTTP/1.0\r\n"
 

--- a/lib/net/ssh/proxy/socks4.rb
+++ b/lib/net/ssh/proxy/socks4.rb
@@ -47,7 +47,7 @@ module Net
 
         # Return a new socket connected to the given host and port via the
         # proxy that was requested when the socket factory was instantiated.
-        def open(host, port)
+        def open(host, port, connection_options)
           socket = TCPSocket.new(proxy_host, proxy_port)
           ip_addr = IPAddr.new(Resolv.getaddress(host))
           

--- a/lib/net/ssh/proxy/socks5.rb
+++ b/lib/net/ssh/proxy/socks5.rb
@@ -62,7 +62,7 @@ module Net
 
         # Return a new socket connected to the given host and port via the
         # proxy that was requested when the socket factory was instantiated.
-        def open(host, port)
+        def open(host, port, connection_options = nil)
           socket = TCPSocket.new(proxy_host, proxy_port)
 
           methods = [METHOD_NO_AUTH]

--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -64,7 +64,13 @@ module Net; module SSH; module Transport
 
       debug { "establishing connection to #{@host}:#{@port}" }
       factory = options[:proxy] || TCPSocket
-      @socket = timeout(options[:timeout] || 0) { @bind_address.nil? || options[:proxy] ? factory.open(@host, @port) : factory.open(@host,@port,@bind_address) }
+      @socket = timeout(options[:timeout] || 0) {
+        case
+        when options[:proxy] then factory.open(@host, @port, options)
+        when @bind_address.nil? then factory.open(@host, @port)
+        else factory.open(@host, @port, @bind_address)
+        end
+      }
       @socket.extend(PacketStream)
       @socket.logger = @logger
 


### PR DESCRIPTION
This is a fix of #25 in github, and #38 in lighthouse.
http://net-ssh.lighthouseapp.com/projects/36253/tickets/38-netssh-doesnt-work-if-a-proxy-takes-a-r

This commit changes the API of Net::SSH::Proxy#open().  Although this commit also let subclasses of Net::SSH::Proxy follow the change, please let me know if you have any other concern.
