### PR TITLE
Handle ssh-rsa and ssh-dss certificate files

### DIFF
--- a/lib/net/ssh/buffer.rb
+++ b/lib/net/ssh/buffer.rb
@@ -243,14 +243,14 @@ module Net; module SSH
     # a key. Only RSA, DSA, and ECDSA keys are supported.
     def read_keyblob(type)
       case type
-        when "ssh-dss"
+        when /^ssh-dss(-cert-v01@openssh\.com)?$/
           key = OpenSSL::PKey::DSA.new
           key.p = read_bignum
           key.q = read_bignum
           key.g = read_bignum
           key.pub_key = read_bignum
 
-        when "ssh-rsa"
+        when /^ssh-rsa(-cert-v01@openssh\.com)?$/
           key = OpenSSL::PKey::RSA.new
           key.e = read_bignum
           key.n = read_bignum


### PR DESCRIPTION
This does not implement certificate based authentication (described here
http://www.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.certkeys?rev=HEAD)
but instead makes it so that if the certificate is not needed for
authentication net-ssh doesn't cause the entire application to die.

The net-ssh test suite continues to pass. On my own machine I did tests
with certificates loaded and verified that although authentication could
not proceed to a host requiring a certificate it at least did not die.

I also verified that I can continue to use normal rsa and dsa keys to
ssh to hosts that do not require certificates even when the certificates
are loaded into my ssh-agent instance.

This is a potential solution to issue #124 and an alternative to the one
presented in pull request #134.
