### PR TITLE
Added an optional "options" argument to test socket open method, as the ...

### DIFF
--- a/lib/net/ssh/test/socket.rb
+++ b/lib/net/ssh/test/socket.rb
@@ -39,7 +39,7 @@ module Net; module SSH; module Test
 
     # Allows the socket to also mimic a socket factory, simply returning
     # +self+.
-    def open(host, port)
+    def open(host, port, options={})
       @host, @port = host, port
       self
     end


### PR DESCRIPTION
...transport session use it with three arguments. Test socket worked with 2.7.0 version but failed with 2.8.0.
