### PR TITLE
Adding remote_user to valid ssh_options to support remote login

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -68,7 +68,7 @@ module Net
       :rekey_blocks_limit,:rekey_limit, :rekey_packet_limit, :timeout, :verbose,
       :global_known_hosts_file, :user_known_hosts_file, :host_key_alias,
       :host_name, :user, :properties, :passphrase, :keys_only, :max_pkt_size,
-      :max_win_size, :send_env
+      :max_win_size, :send_env, :remote_user
     ]
 
     # The standard means of starting a new SSH connection. When used with a

--- a/test/start/test_options.rb
+++ b/test/start/test_options.rb
@@ -31,6 +31,13 @@ module NetSSH
         Net::SSH.start('localhost', 'testuser', options)
       end
     end
+
+    def test_start_should_accept_remote_user_option
+      assert_nothing_raised do
+        options = { :remote_user => 'testuser' }
+        Net::SSH.start('localhost', 'testuser', options)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This adds remote_user to VALID_OPTIONS to support the code added here:
https://github.com/net-ssh/net-ssh/pull/139/files