### PR TITLE
Ignore errors during ssh agent negotiation

### DIFF
--- a/lib/net/ssh/authentication/agent/socket.rb
+++ b/lib/net/ssh/authentication/agent/socket.rb
@@ -77,6 +77,8 @@ module Net; module SSH; module Authentication
 
       if type == SSH2_AGENT_VERSION_RESPONSE
         raise AgentNotAvailable, "SSH2 agents are not yet supported"
+      elsif type == SSH2_AGENT_FAILURE
+        debug { "Unexpected response type==#{type}, this will be ignored" }
       elsif type != SSH_AGENT_RSA_IDENTITIES_ANSWER1 && type != SSH_AGENT_RSA_IDENTITIES_ANSWER2
         raise AgentNotAvailable, "unknown response from agent: #{type}, #{body.to_s.inspect}"
       end


### PR DESCRIPTION
- Support Apache's SSHD implementation of a SSH Agent
- Discovered while trying to use Jenkins' SSH Agent Plugin with capistrano

Also discover by @jasiek
http://jasiek.me/2013/11/27/jenkins-capistrano-ssh-agent-plugin.html
