### PR TITLE
correct two typos and remote random spaces.

### DIFF
--- a/test/transport/test_packet_stream.rb
+++ b/test/transport/test_packet_stream.rb
@@ -1698,7 +1698,7 @@ module Transport
           define_method("test_next_packet_with_#{cipher_method_name}_and_#{hmac_method_name}_and_#{compress}_compression") do
             opts = { :shared => "123", :hash => "^&*", :digester => OpenSSL::Digest::SHA1  }
             cipher = Net::SSH::Transport::CipherFactory.get(cipher_name, opts.merge(:key => "ABC", :decrypt => true, :iv => "abc"))
-            hmac  = Net::SSH::Transport::HMAC.get(hmac_name, {}, opts)
+            hmac  = Net::SSH::Transport::HMAC.get(hmac_name, '', opts)
 
             stream.server.set :cipher => cipher, :hmac => hmac, :compression => compress
             stream.stubs(:recv).returns(PACKETS[cipher_name][hmac_name][compress])
@@ -1715,7 +1715,7 @@ module Transport
           define_method("test_enqueue_packet_with_#{cipher_method_name}_and_#{hmac_method_name}_and_#{compress}_compression") do
             opts = { :shared => "123", :digester => OpenSSL::Digest::SHA1, :hash => "^&*" }
             cipher = Net::SSH::Transport::CipherFactory.get(cipher_name, opts.merge(:key => "ABC", :iv => "abc", :encrypt => true))
-            hmac  = Net::SSH::Transport::HMAC.get(hmac_name, {}, opts)
+            hmac  = Net::SSH::Transport::HMAC.get(hmac_name, '', opts)
 
             srand(100)
             stream.client.set :cipher => cipher, :hmac => hmac, :compression => compress


### PR DESCRIPTION
Looked at the error output for https://travis-ci.org/net-ssh/net-ssh/jobs/30066590 and saw mention of issue at

```
Error: test_next_packet_with_aes256_gcm_openssh_com_and_none_and_standard_compression(Transport::TestPacketStream)

NoMethodError: undefined method `[]' for nil:NilClass

/home/travis/build/net-ssh/net-ssh/test/transport/test_packet_stream.rb:1704:in `block (4 levels) in <class:TestPacketStream>'
```

Looked at HMAC transport code and saw that it expects a hash as its parameter, not a string.
