### PR TITLE
Fix duplicating entries in known_hosts when using proxy command

### DIFF
--- a/lib/net/ssh/transport/packet_stream.rb
+++ b/lib/net/ssh/transport/packet_stream.rb
@@ -14,6 +14,8 @@ module Net; module SSH; module Transport
   # per the SSH2 protocol. It also adds an abstraction for polling packets,
   # to allow for both blocking and non-blocking reads.
   module PacketStream
+    PROXY_COMMAND_HOST_IP = '<no hostip for proxy command>'.freeze
+
     include BufferedIo
 
     def self.extended(object)
@@ -64,7 +66,7 @@ module Net; module SSH; module Transport
           addr = getpeername
           Socket.getnameinfo(addr, Socket::NI_NUMERICHOST | Socket::NI_NUMERICSERV).first
         else
-          "<no hostip for proxy command>"
+          PROXY_COMMAND_HOST_IP
         end
     end
     

--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -93,11 +93,16 @@ module Net; module SSH; module Transport
       @host_as_string ||= begin
         string = "#{host}"
         string = "[#{string}]:#{port}" if port != DEFAULT_PORT
-        if socket.peer_ip != host
-          string2 = socket.peer_ip
+
+        peer_ip = socket.peer_ip
+
+        if peer_ip != Net::SSH::Transport::PacketStream::PROXY_COMMAND_HOST_IP &&
+           peer_ip != host
+          string2 = peer_ip
           string2 = "[#{string2}]:#{port}" if port != DEFAULT_PORT
           string << "," << string2
         end
+
         string
       end
     end

--- a/test/transport/test_packet_stream.rb
+++ b/test/transport/test_packet_stream.rb
@@ -45,6 +45,12 @@ module Transport
       assert_equal "1.2.3.4", stream.peer_ip
     end
 
+    def test_peer_ip_should_return_no_hostip_when_socket_has_no_peername
+      assert_equal false, stream.respond_to?(:getpeername)
+      assert_equal Net::SSH::Transport::PacketStream::PROXY_COMMAND_HOST_IP, stream.peer_ip
+      assert_equal '<no hostip for proxy command>', stream.peer_ip
+    end
+
     def test_available_for_read_should_return_nontrue_when_select_fails
       IO.expects(:select).returns(nil)
       assert !stream.available_for_read?

--- a/test/transport/test_session.rb
+++ b/test/transport/test_session.rb
@@ -69,6 +69,18 @@ module Transport
       assert_equal "[1.2.3.4]:1234", session.host_as_string
     end
 
+    def test_host_as_string_should_return_only_host_when_proxy_command_is_set
+      session!(:host => "1.2.3.4")
+      socket.stubs(:peer_ip).returns(Net::SSH::Transport::PacketStream::PROXY_COMMAND_HOST_IP)
+      assert_equal "1.2.3.4", session.host_as_string
+    end
+
+    def test_host_as_string_should_return_only_host_and_port_when_host_is_ip_and_port_is_not_default_and_proxy_command_is_set
+      session!(:host => "1.2.3.4", :port => 1234)
+      socket.stubs(:peer_ip).returns(Net::SSH::Transport::PacketStream::PROXY_COMMAND_HOST_IP)
+      assert_equal "[1.2.3.4]:1234", session.host_as_string
+    end
+
     def test_close_should_cleanup_and_close_socket
       session!
       socket.expects(:cleanup)


### PR DESCRIPTION
Fixes #107

OpenSSH does not store ip address when using proxy command like:

```
server.example.com ssh-rsa AAAAA.......
```

net-ssh was storing it like:

```
server.example.com,<no hostip for proxy command> ssh-rsa AAAA.....
```
