### PR TITLE
Disabled enqueue packet test for ciphers with no packet data

### DIFF
--- a/test/transport/test_packet_stream.rb
+++ b/test/transport/test_packet_stream.rb
@@ -1678,7 +1678,7 @@ module Transport
     hmacs = Net::SSH::Transport::HMAC::MAP.keys
 
     ciphers.each do |cipher_name|
-      unless Net::SSH::Transport::CipherFactory.supported?(cipher_name)
+      unless Net::SSH::Transport::CipherFactory.supported?(cipher_name) && PACKETS.has_key?(cipher_name)
         puts "Skipping packet stream test for #{cipher_name}"
         next
       end


### PR DESCRIPTION
Fix for failing tests
