### PR TITLE
Password auth will ask for password up to number_of_password_prompts tim...

### DIFF
--- a/lib/net/ssh/authentication/methods/password.rb
+++ b/lib/net/ssh/authentication/methods/password.rb
@@ -1,4 +1,5 @@
 require 'net/ssh/errors'
+require 'net/ssh/prompt'
 require 'net/ssh/authentication/methods/abstract'
 
 module Net
@@ -8,25 +9,36 @@ module Net
 
         # Implements the "password" SSH authentication method.
         class Password < Abstract
-          # Attempt to authenticate the given user for the given service. If
-          # the password parameter is nil, this will never do anything except
-          # return false.
-          def authenticate(next_service, username, password=nil)
-            return false unless password
+          include Prompt
 
-            send_message(userauth_request(username, next_service, "password", false, password))
-            message = session.next_message
+          # Attempt to authenticate the given user for the given service. If
+          # the password parameter is nil, this will ask for password
+          def authenticate(next_service, username, password=nil)
+            retries = 0
+            max_retries =  get_max_retries
+            return false if !password && max_retries == 0
+
+            begin
+              password_to_send = password || ask_password(username)
+
+              send_message(userauth_request(username, next_service, "password", false, password_to_send))
+              message = session.next_message
+              retries += 1
+
+              if message.type == USERAUTH_FAILURE
+                debug { "password failed" }
+
+                raise Net::SSH::Authentication::DisallowedMethod unless
+                  message[:authentications].split(/,/).include? 'password'
+                password = nil
+              end
+            end until (message.type != USERAUTH_FAILURE || retries >= max_retries)
 
             case message.type
               when USERAUTH_SUCCESS
                 debug { "password succeeded" }
                 return true
               when USERAUTH_FAILURE
-                debug { "password failed" }
-
-                raise Net::SSH::Authentication::DisallowedMethod unless
-                  message[:authentications].split(/,/).include? 'password'
-
                 return false
               when USERAUTH_PASSWD_CHANGEREQ
                 debug { "password change request received, failing" }
@@ -34,6 +46,19 @@ module Net
               else
                 raise Net::SSH::Exception, "unexpected reply to USERAUTH_REQUEST: #{message.type} (#{message.inspect})"
             end
+          end
+
+          private
+
+          NUMBER_OF_PASSWORD_PROMPTS = 3
+
+          def ask_password(username)
+            echo = false
+            prompt("#{username}@#{session.transport.host}'s password:", echo)
+          end
+
+          def get_max_retries
+            (session.transport.options||{})[:number_of_password_prompts] || NUMBER_OF_PASSWORD_PROMPTS
           end
         end
 

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -31,6 +31,7 @@ module Net; module SSH
   # * RekeyLimit => :rekey_limit
   # * User => :user
   # * UserKnownHostsFile => :user_known_hosts_file
+  # * NumberOfPasswordPrompts => :number_of_password_prompts
   #
   # Note that you will never need to use this class directly--you can control
   # whether the OpenSSH configuration files are read by passing the :config
@@ -219,6 +220,8 @@ module Net; module SSH
           when 'sendenv'
             multi_send_env = value.to_s.split(/\s+/)
             hash[:send_env] = multi_send_env.map { |e| Regexp.new pattern2regex(e).source, false }
+          when 'numberofpasswordprompts'
+            hash[:number_of_password_prompts] = value.to_i
           end
           hash
         end

--- a/test/authentication/methods/test_password.rb
+++ b/test/authentication/methods/test_password.rb
@@ -1,6 +1,8 @@
 require 'common'
 require 'net/ssh/authentication/methods/password'
+require 'net/ssh/authentication/session'
 require 'authentication/methods/common'
+
 
 module Authentication; module Methods
 
@@ -22,6 +24,47 @@ module Authentication; module Methods
       assert_raises Net::SSH::Authentication::DisallowedMethod do
         subject.authenticate("ssh-connection", "jamis", "the-password")
       end
+    end
+
+    def test_authenticate_ask_for_password_for_second_time_when_password_is_incorrect
+      transport.expect do |t,packet|
+        assert_equal USERAUTH_REQUEST, packet.type
+        assert_equal "jamis", packet.read_string
+        assert_equal "ssh-connection", packet.read_string
+        assert_equal "password", packet.read_string
+        assert_equal false, packet.read_bool
+        assert_equal "the-password", packet.read_string
+        t.return(USERAUTH_FAILURE, :string, "publickey,password")
+
+        t.expect do |t2, packet2|
+          assert_equal USERAUTH_REQUEST, packet2.type
+          assert_equal "jamis", packet2.read_string
+          assert_equal "ssh-connection", packet2.read_string
+          assert_equal "password", packet2.read_string
+          assert_equal false, packet2.read_bool
+          assert_equal "the-password-2", packet2.read_string
+          t.return(USERAUTH_SUCCESS)
+        end
+      end
+
+      subject.expects(:prompt).with("jamis@'s password:", false).returns("the-password-2")
+      subject.authenticate("ssh-connection", "jamis", "the-password")
+    end
+
+    def test_authenticate_ask_for_password_if_not_given
+      transport.expect do |t,packet|
+        assert_equal USERAUTH_REQUEST, packet.type
+        assert_equal "bill", packet.read_string
+        assert_equal "ssh-connection", packet.read_string
+        assert_equal "password", packet.read_string
+        assert_equal false, packet.read_bool
+        assert_equal "good-password", packet.read_string
+        t.return(USERAUTH_SUCCESS)
+      end
+
+      transport.instance_eval { @host='testhost' }
+      subject.expects(:prompt).with("bill@testhost's password:", false).returns("good-password")
+      subject.authenticate("ssh-connection", "bill", nil)
     end
 
     def test_authenticate_when_password_is_acceptible_should_return_true

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -93,7 +93,8 @@ class TestConfig < Test::Unit::TestCase
       'port'                    => 1234,
       'pubkeyauthentication'    => true,
       'rekeylimit'              => 1024,
-      'sendenv'                 => "LC_*"
+      'sendenv'                 => "LC_*",
+      'numberofpasswordprompts' => '123'
     }
 
     net_ssh = Net::SSH::Config.translate(open_ssh)
@@ -111,6 +112,7 @@ class TestConfig < Test::Unit::TestCase
     assert_equal 1024,      net_ssh[:rekey_limit]
     assert_equal "127.0.0.1", net_ssh[:bind_address]
     assert_equal [/^LC_.*$/], net_ssh[:send_env]
+    assert_equal 123,       net_ssh[:number_of_password_prompts]
   end
 
   def test_translate_should_turn_off_authentication_methods


### PR DESCRIPTION
...es

Make password auth prompt for passwords just like in openssh. `number_of_password_prompts:0` in net/ssh and `ssh/config`'s `NumberOfPasswordPrompts` can be used to get back old behaviour of not asking for password.

Should improve #164
