### PR TITLE
Remove the -T from the rake build command

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -175,7 +175,7 @@ Run a single test file like this:
 
 Since building the gem requires the private key if you want to build a .gem locally please use the NET_SSH_NOKEY=1 envirnoment variable:
 
-     rake -T build NET_SSH_NOKEY=1
+     rake build NET_SSH_NOKEY=1
 
 === PORT FORWARDING TESTS
 


### PR DESCRIPTION
By including the -T argument rake is returning the help for the task rather than running the task as expected.
