### PR TITLE
Check if SSH key is a file

### DIFF
--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -188,9 +188,9 @@ module Net
         def prepare_identities_from_files
           key_files.map do |file|
             public_key_file = file + ".pub"
-            if File.readable?(public_key_file)
-              { :load_from => :pubkey_file, :file => file }
-            elsif File.readable?(file)
+            if File.file?(public_key_file) and File.readable?(public_key_file)
+              { :load_from => :pubkey_file, :file => public_key_file }
+            elsif File.file?(file) and File.readable?(file)
               { :load_from => :privkey_file, :file => file }
             end
           end.compact
@@ -209,7 +209,7 @@ module Net
             begin
               case identity[:load_from]
               when :pubkey_file
-                key = KeyFactory.load_public_key(identity[:file] + ".pub")
+                key = KeyFactory.load_public_key(identity[:file])
                 { :public_key => key, :from => :file, :file => identity[:file] }
               when :privkey_file
                 private_key = KeyFactory.load_private_key(identity[:file], options[:passphrase], ask_passphrase)

--- a/test/authentication/test_key_manager.rb
+++ b/test/authentication/test_key_manager.rb
@@ -156,7 +156,9 @@ module Authentication
 
       def stub_file_private_key(name, key, options = {})
         manager.add(name)
+        File.stubs(:file?).with(name).returns(true)
         File.stubs(:readable?).with(name).returns(true)
+        File.stubs(:file?).with(name + ".pub").returns(true)
         File.stubs(:readable?).with(name + ".pub").returns(false)
 
         case options.fetch(:passphrase, :indifferently)
@@ -179,7 +181,9 @@ module Authentication
 
       def stub_file_public_key(name, key)
         manager.add(name)
+        File.stubs(:file?).with(name).returns(true)
         File.stubs(:readable?).with(name).returns(false)
+        File.stubs(:file?).with(name + ".pub").returns(true)
         File.stubs(:readable?).with(name + ".pub").returns(true)
 
         Net::SSH::KeyFactory.expects(:load_public_key).with(name + ".pub").returns(key).at_least_once


### PR DESCRIPTION
For one of servers which I have access to I need to use custom SSH key. I'm not using my default SSH key, so I made a custom entry in my `~/.ssh/config` to handle that. I specified value for IdentityFile pointing to correct id_rsa file. I am able to ssh to the server with no issues at all. However, when I try to deploy using Capistano, it fails with an error `connection failed for: dev.domain.com (Errno::EISDIR: Is a directory @ io_fread - /home/kiela/workspace/ruby/project`. I started digging in Capistrano but found nothing which can cause this. I moved to Net::SSH and noticed that when no key was specified in options for `Net::SSH.start` it somehow sets keys to current directory and tries to open that directory as a file. `File.readable?` returns `true` as directory can be read but the `KeyFactor.load_public_key` tries to read it and raises an `Errno::EISDIR` exception.
After checking if a key is a file and can be read, everything starts working like a charm.

I assume that there could be different issue with this, but we should check if specified SSH key is a file before we try to read it content.