### PR TITLE
Switch pageant.rb to use Fiddle

### DIFF
--- a/lib/net/ssh/authentication/pageant.rb
+++ b/lib/net/ssh/authentication/pageant.rb
@@ -9,6 +9,12 @@ else
   require 'fiddle'
   require 'fiddle/types'
   require 'fiddle/import'
+
+  # For now map DL to Fiddler versus updating all the code below
+  module DL
+    CPtr = Fiddle::Pointer
+    RUBY_FREE = Fiddle::RUBY_FREE
+  end
 end
 
 require 'net/ssh/errors'

--- a/lib/net/ssh/authentication/pageant.rb
+++ b/lib/net/ssh/authentication/pageant.rb
@@ -1,10 +1,14 @@
-require 'dl/import'
-
 if RUBY_VERSION < "1.9"
+  require 'dl/import'
   require 'dl/struct'
-else
+elsif RUBY_VERSION < "2.2"
+  require 'dl/import'
   require 'dl/types'
   require 'dl'
+else
+  require 'fiddle'
+  require 'fiddle/types'
+  require 'fiddle/import'
 end
 
 require 'net/ssh/errors'
@@ -36,12 +40,17 @@ module Net; module SSH; module Authentication
         dlload 'advapi32'
 
         SIZEOF_DWORD = DL.sizeof('L')
-      else
+      elsif RUBY_VERSION < "2.2"
         extend DL::Importer
         dlload 'user32','kernel32', 'advapi32'
         include DL::Win32Types
 
         SIZEOF_DWORD = DL::SIZEOF_LONG
+      else
+        extend Fiddle::Importer
+        dlload 'user32','kernel32', 'advapi32'
+        include Fiddle::Win32Types
+        SIZEOF_DWORD = Fiddle::SIZEOF_LONG
       end
 
       typealias("LPCTSTR", "char *")         # From winnt.h


### PR DESCRIPTION
pageant.rb no longer works on Ruby 2.2 on Windows since the dl module has been removed.  This patch updates pageant.rb to use fiddle instead for ruby 2.2 and higher.  Pageant.rb tests all pass.