### PR TITLE
Add Rubinius to Build Matrix with Allowed Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,3 @@ matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: 1.8.7
-    - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - jruby-head
   - jruby-19mode
   - 1.8.7
+  - rbx-2
 
 install: gem install test-unit mocha
 
@@ -16,3 +17,4 @@ matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: 1.8.7
+    - rvm: rbx-2


### PR DESCRIPTION
Please add Rubinius to the build matrix with failure allowed.

I am trying to add this to ensure this Gem works in Rubinius and to complete this dashboard: http://bjfish.github.io/rubinius-gem-build-status/page2/.