### PR TITLE
handle nil returns on gets

### DIFF
--- a/lib/net/ssh/prompt.rb
+++ b/lib/net/ssh/prompt.rb
@@ -29,7 +29,12 @@ module Net; module SSH
         $stdout.flush
 
         set_echo(false) unless echo
-        $stdin.gets.chomp
+
+        # Since gets can return nil, handle this
+        # http://ruby-doc.org/core-2.2.0/Kernel.html#method-i-gets
+        indata = $stdin.gets
+        indata ||= ""
+        indata.chomp
       ensure
         if !echo
           set_echo(true)
@@ -70,7 +75,11 @@ module Net; module SSH
 
         $stdout.print(prompt)
         $stdout.flush
-        $stdin.gets.chomp
+        # Since gets can return nil, handle this
+        # http://ruby-doc.org/core-2.2.0/Kernel.html#method-i-gets
+        indata = $stdin.gets
+        indata ||= ""
+        indata.chomp
       end
     end
   end


### PR DESCRIPTION
This is a simple non-tested fix for an issue we had with this lib. Kernel#gets can return nil in some cases, and this should be handled in some way. You might know a way to do this tested and more dry, but I did not manage to be able to run the tests.