### PR TITLE
Fix ArgumentError: Could not parse PKey: no start line

### DIFF
--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -187,11 +187,10 @@ module Net
         # Prepares identities from user key_files for loading, preserving their order and sources.
         def prepare_identities_from_files
           key_files.map do |file|
-            public_key_file = file + ".pub"
-            if readable_file?(public_key_file)
-              { :load_from => :pubkey_file, :file => public_key_file }
-            elsif readable_file?(file)
+            if readable_file?(file)
               { :load_from => :privkey_file, :file => file }
+            elsif readable_file?(public_key_file = file + ".pub")
+              { :load_from => :pubkey_file, :file => public_key_file }
             end
           end.compact
         end


### PR DESCRIPTION
Capistrano 2.15.5 and net-ssh 2.9.3.beta1 and standart linux pub/pkey locations:
~/.ssh/id_rsa
~/.ssh/id_rsa.pub

Capistrano fails with ArgumentError: Could not parse PKey

After some time of exploration I've found that for this situation public key is checked first and :load_from => :pubkey_file identity appears. After that I'm totally cannot understand how :pubkey_branch works in load_identities - there is no setting of private key at all. So it's just a workaround for my situation, but it definetly can be done better with help of people that know the internals.