### PR TITLE
Fix NoMethodError `recv` in multithreaded usage of Net::SSH::Proxy::Command

### DIFF
--- a/lib/net/ssh/proxy/command.rb
+++ b/lib/net/ssh/proxy/command.rb
@@ -67,25 +67,23 @@ module Net; module SSH; module Proxy
         raise ConnectError, "#{e}: #{command_line}"
       end
       @command_line = command_line
-      class << io
-        if Gem.win_platform?
-          # read_nonblock and write_nonblock are not available on Windows
-          # pipe. Use sysread and syswrite as a replacement works.
-          def send(data, flag)
-            syswrite(data)
-          end
+      if Gem.win_platform?
+        # read_nonblock and write_nonblock are not available on Windows
+        # pipe. Use sysread and syswrite as a replacement works.
+        def io.send(data, flag)
+          syswrite(data)
+        end
 
-          def recv(size)
-            sysread(size)
-          end
-        else
-          def send(data, flag)
-            write_nonblock(data)
-          end
+        def io.recv(size)
+          sysread(size)
+        end
+      else
+        def io.send(data, flag)
+          write_nonblock(data)
+        end
 
-          def recv(size)
-            read_nonblock(size)
-          end
+        def io.recv(size)
+          read_nonblock(size)
         end
       end
       io


### PR DESCRIPTION
This fixes a longstanding bug discovered by users of SSHKit: https://github.com/capistrano/sshkit/issues/150.

To summarize: when SSH connections are made in multiple threads using `ProxyCommand`, there is a small possibility that `Net::SSH.start` will fail with an error like this:

```
NoMethodError: undefined method `recv' for #<IO:fd 47>
```

I traced the problem down to Ruby itself. Apparently, defining singleton methods using this syntax (as is done by `proxy/command.rb`) is not thread safe:

```ruby
class << io
  def send(data, flag)
    write_nonblock(data)
  end

  def recv(size)
    read_nonblock(size)
  end
end
```

When executed in parallel by many threads, there is a small chance that the `recv` method will not be defined. As strange as this bug may seem, you can reproduce it consistently with this test case:

```ruby
require "thread"

def define_singleton_methods_in_thread
  Thread.new do
    100_000.times do
      obj = Object.new
      class << obj
        def one
        end
        def two
        end
        def three
        end
      end
      puts "FAIL" unless obj.respond_to?(:three)
    end
  end
end

# Test with 2 threads
2.times.map { define_singleton_methods_in_thread }.map(&:join)
```

On my machine this outputs `FAIL` three times.

The good news is that there is another way to define singleton methods in Ruby that *is* thread safe:

```ruby
# Not thread safe :(
class << obj
  def one
  end
  def two
  end
  def three
  end
end

# Thread safe :)
def obj.one
end
def obj.two
end
def obj.three
end
```

This PR rewrites changes the way `send` and `recv` are declared to use the latter syntax.

I plan to also open a bug report for MRI, but for now this should work around the problem.