### PR TITLE
Fix SSH on Cisco 2960 and 2960Gs

### DIFF
--- a/lib/net/ssh/transport/packet_stream.rb
+++ b/lib/net/ssh/transport/packet_stream.rb
@@ -84,11 +84,7 @@ module Net; module SSH; module Transport
     def next_packet(mode=:nonblock)
       case mode
       when :nonblock then
-        if available_for_read?
-          if fill <= 0
-            raise Net::SSH::Disconnect, "connection closed by remote host"
-          end
-        end
+	  fill if available_for_read?
         poll_next_packet
 
       when :block then


### PR DESCRIPTION
This fix reverts commit: aa5c5028b66ca52d28529df996f7194fb517d408

There is a bug in the Cisco 2960/2960G where they send a zero-byte packet to the client. 
This causes the previous logic to fail because it assumes the connection has been disconnected.

This should detect an EOF on the socket, rather then assume that empty data is a dead socket.