### PR TITLE
don't prompt for passphrases in non-interactive mode

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -204,7 +204,6 @@ module Net
 
       if options[:non_interactive]
         options[:number_of_password_prompts] = 0
-        options[:passphrase] = false
       end
 
       if options[:verbose]

--- a/test/authentication/test_key_manager.rb
+++ b/test/authentication/test_key_manager.rb
@@ -56,6 +56,15 @@ module Authentication
       assert_equal({:from => :file, :file => second, :key => dsa}, manager.known_identities[dsa])
     end
 
+    def test_each_identity_should_not_prompt_for_passphrase_in_non_interactive_mode
+      manager(:non_interactive => true).stubs(:agent).returns(nil)
+      first = File.expand_path("/first")
+      stub_file_private_key first, rsa, :passphrase => :should_not_be_asked
+      identities = []
+      manager.each_identity { |identity| identities << identity }
+      assert_equal(identities, [])
+    end
+
     def test_identities_should_load_from_agent
       manager.stubs(:agent).returns(agent)
 


### PR DESCRIPTION
allow options[:passphrase] to be used with options[:non_interactive]