### PR TITLE
Update outdated security certificate details in README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -102,8 +102,8 @@ However, in order to be sure the code you're installing hasn't been tampered wit
 
     # Add the public key as a trusted certificate
     # (You only need to do this once)
-    $ curl -O https://raw.github.com/net-ssh/net-ssh/master/gem-public_cert.pem
-    $ gem cert --add gem-public_cert.pem
+    $ curl -O https://raw.githubusercontent.com/net-ssh/net-ssh/master/net-ssh-public_cert.pem
+    $ gem cert --add net-ssh-public_cert.pem
 
 Then, when install the gem, do so with high security:
 


### PR DESCRIPTION
Security certificate details in the install section of the readme are referring to a certificate that no longer exists.