### PR TITLE
Document that Net::SSH::Connection::Session#exec! returns nil if there is no output from the remote command

### DIFF
--- a/lib/net/ssh/connection/session.rb
+++ b/lib/net/ssh/connection/session.rb
@@ -351,8 +351,8 @@ module Net; module SSH; module Connection
     end
 
     # Same as #exec, except this will block until the command finishes. Also,
-    # if a block is not given, this will return all output (stdout and stderr)
-    # as a single string.
+    # if no block is given, this will return all output (stdout and stderr)
+    # as a single string or nil if there was no output from the command.
     #
     #   matches = ssh.exec!("grep something /some/files")
     def exec!(command, &block)

--- a/test/connection/test_session.rb
+++ b/test/connection/test_session.rb
@@ -473,6 +473,11 @@ module Connection
       assert_equal "some data", session.exec!("ls")
     end
 
+    def test_exec_bang_without_block_should_return_nil_for_empty_command_output
+      prep_exec('ls', :stdout, '')
+      assert_equal nil, session.exec!('ls')
+    end
+
     private
 
       def prep_exec(command, *data)
@@ -488,10 +493,8 @@ module Connection
 
             t2.return(CHANNEL_SUCCESS, :long, p[:remote_id])
 
-            0.step(data.length-1, 2) do |index|
-              type = data[index]
-              datum = data[index+1]
-
+            data.each_slice(2) do |type, datum|
+              next if datum.empty?
               if type == :stdout
                 t2.return(CHANNEL_DATA, :long, p[:remote_id], :string, datum)
               else


### PR DESCRIPTION
The docs state that #exec will return a string, and an empty string would be consistent.  Currently `nil` is returned, and this should be documented.
