### PR TITLE
Activate the faster container based travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
Builds starts quicker and we avoid the annoying warning at the start of the log.