### PR TITLE
re-raise Errno::ETIMEDOU from Socket.tcp as Net::SSH::ConnectionTimeout

### DIFF
--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -85,6 +85,8 @@ module Net; module SSH; module Transport
 
       @algorithms = Algorithms.new(self, options)
       wait { algorithms.initialized? }
+    rescue Errno::ETIMEDOUT
+      raise Net::SSH::ConnectionTimeout
     end
 
     # Returns the host (and possibly IP address) in a format compatible with


### PR DESCRIPTION
Keep backward compatibility with 2.9 at connection timeout exceptions. 