### PR TITLE
Accept existing option `remote_user` as valid

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -62,7 +62,7 @@ module Net
     # Net::SSH.start for a description of each option.
     VALID_OPTIONS = [
       :auth_methods, :bind_address, :compression, :compression_level, :config,
-      :encryption, :forward_agent, :hmac, :host_key,
+      :encryption, :forward_agent, :hmac, :host_key, :remote_user,
       :keepalive, :keepalive_interval, :keepalive_maxcount, :kex, :keys, :key_data,
       :languages, :logger, :paranoid, :password, :port, :proxy,
       :rekey_blocks_limit,:rekey_limit, :rekey_packet_limit, :timeout, :verbose,

--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -169,6 +169,7 @@ module Net
     # * :user => the user name to log in as; this overrides the +user+
     #   parameter, and is primarily only useful when provided via an SSH
     #   configuration file.
+    # * :remote_user => used for substitution into the '%r' part of a ProxyCommand
     # * :user_known_hosts_file => the location of the user known hosts file.
     #   Set to an array to specify multiple user known hosts files.
     #   Defaults to %w(~/.ssh/known_hosts ~/.ssh/known_hosts2).

--- a/test/configs/proxy_remote_user
+++ b/test/configs/proxy_remote_user
@@ -1,0 +1,2 @@
+Host behind-proxy
+  ProxyCommand ssh %r@proxy -W %h:%p

--- a/test/start/test_options.rb
+++ b/test/start/test_options.rb
@@ -45,6 +45,13 @@ module NetSSH
         Net::SSH.start('localhost', 'testuser', options)
       end
     end
+
+    def test_start_should_accept_remote_user_option
+      assert_nothing_raised do
+        options = { :remote_user => 'foo' }
+        Net::SSH.start('localhost', 'testuser', options)
+      end
+    end
   end
 end
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -213,6 +213,12 @@ class TestConfig < Test::Unit::TestCase
     assert_equal [/^GIT_.*$/, /^LANG$/, /^LC_.*$/], net_ssh[:send_env]
   end
 
+  def test_load_with_remote_user
+    config = Net::SSH::Config.load(config(:proxy_remote_user), "behind-proxy")
+    net_ssh = Net::SSH::Config.translate(config)
+    assert net_ssh[:proxy]
+  end
+
   private
 
     def config(name)


### PR DESCRIPTION
Fixes #189 

The existing option is used here: https://github.com/net-ssh/net-ssh/blob/master/lib/net/ssh/proxy/command.rb#L45

The fact that `remote_user` wasn't added to `VALID_OPTIONS` seems to have been noted in the original PR to add support for `%r` to proxy commands, here: https://github.com/net-ssh/net-ssh/pull/139#issuecomment-35518045

Tests included, although there's not really anything to test `%r` *and* `remote_user` together.