### PR TITLE
Add Net::SSH::Test::Channel#sends_request_pty for scripting PTY requests

### DIFF
--- a/lib/net/ssh/test/channel.rb
+++ b/lib/net/ssh/test/channel.rb
@@ -98,6 +98,13 @@ module Net; module SSH; module Test
       script.sends_channel_close(self)
     end
 
+    # Scripts the sending of a "request pty" request packet across the channel.
+    #
+    #   channel.sends_request_pty
+    def sends_request_pty
+      script.sends_channel_request_pty(self)
+    end
+
     # Scripts the reception of a channel data packet from the remote end.
     #
     #   channel.gets_data "bar"

--- a/lib/net/ssh/test/packet.rb
+++ b/lib/net/ssh/test/packet.rb
@@ -72,6 +72,7 @@ module Net; module SSH; module Test
           case @data[1]
           when "exec", "subsystem" then parts << :string
           when "exit-status" then parts << :long
+          when "pty-req" then parts += [:string, :long, :long, :long, :long, :string]
           else raise "don't know what to do about #{@data[1]} channel request"
           end
         else raise "don't know how to parse packet type #{@type}"

--- a/lib/net/ssh/test/script.rb
+++ b/lib/net/ssh/test/script.rb
@@ -104,6 +104,15 @@ module Net; module SSH; module Test
       events << LocalPacket.new(:channel_close, channel.remote_id)
     end
 
+    # Scripts the sending of a channel request pty packets from the given
+    # Net::SSH::Test::Channel +channel+. This will typically be called via
+    # Net::SSH::Test::Channel#sends_request_pty.
+    def sends_channel_request_pty(channel)
+      data = ['pty-req', false]
+      data += Net::SSH::Connection::Channel::VALID_PTY_OPTIONS.merge(:modes => "\0").values
+      events << LocalPacket.new(:channel_request, channel.remote_id, *data)
+    end
+
     # Scripts the reception of a channel data packet from the remote host by
     # the given Net::SSH::Test::Channel +channel+. This will typically be
     # called via Net::SSH::Test::Channel#gets_data.


### PR DESCRIPTION
Fixes net-ssh/net-ssh#184

It does not support scripting custom PTY request arguments, but I believe it's useful even in this state. Since I haven't found any tests for `Net::SSH::Test`, I haven't added any, but tested this manually.