### PR TITLE
Fix event loop lock ups when using net-ssh-gateway and multiple server connections

### DIFF
--- a/lib/net/ssh/connection/channel.rb
+++ b/lib/net/ssh/connection/channel.rb
@@ -59,6 +59,9 @@ module Net; module SSH; module Connection
     # The remote id for this channel, assigned by the remote host.
     attr_reader :remote_id
 
+    # used to store the local port used by this channel
+    attr_accessor :local_port
+
     # The type of this channel, usually "session".
     attr_reader :type
 
@@ -124,7 +127,7 @@ module Net; module SSH; module Connection
       @properties = {}
 
       @pending_requests = []
-      @on_open_failed = @on_data = @on_extended_data = @on_process = @on_close = @on_eof = nil
+      @on_open_failed = @on_data = @on_extended_data = @on_process = @on_close = @on_eof = @local_port = nil
       @on_request = {}
       @closing = @eof = @sent_eof = false
     end

--- a/lib/net/ssh/connection/session.rb
+++ b/lib/net/ssh/connection/session.rb
@@ -95,6 +95,11 @@ module Net; module SSH; module Connection
       @properties[key] = value
     end
 
+    # used to retreive the channels id from a channel local port number
+    def lookup_channel_id_from_localport(port)
+      channels.select { |id, channel| channel.local_port == port }.keys.first
+    end
+
     # Returns the name of the host that was given to the transport layer to
     # connect to.
     def host
@@ -298,6 +303,10 @@ module Net; module SSH; module Connection
       local_id = get_next_channel_id
 
       channel = Channel.new(self, type, local_id, @max_pkt_size, @max_win_size, &on_confirm)
+
+      # store the channels local port so the channel id can be looked up using this info
+      channel.local_port = extra.last if type == 'direct-tcpip'
+
       msg = Buffer.from(:byte, CHANNEL_OPEN, :string, type, :long, local_id,
         :long, channel.local_maximum_window_size,
         :long, channel.local_maximum_packet_size, *extra)
@@ -330,7 +339,7 @@ module Net; module SSH; module Connection
       open_channel do |channel|
         channel.exec(command) do |ch, success|
           raise "could not execute command: #{command.inspect}" unless success
-          
+
           channel.on_data do |ch2, data|
             if block
               block.call(ch2, :stdout, data)
@@ -551,7 +560,8 @@ module Net; module SSH; module Connection
       def channel_open_failure(packet)
         error { "channel_open_failed: #{packet[:local_id]} #{packet[:reason_code]} #{packet[:description]}" }
         channel = channels.delete(packet[:local_id])
-        channel.do_open_failed(packet[:reason_code], packet[:description])
+        error { "channel_open_failure: seems the channel is nil"} if channel.nil?
+        channel.do_open_failed(packet[:reason_code], packet[:description]) unless channel.nil?
       end
 
       def channel_window_adjust(packet)


### PR DESCRIPTION
As per https://github.com/net-ssh/net-ssh-gateway/issues/4 and https://github.com/net-ssh/net-ssh/issues/269 the PR fixes for me several problems I had when using persistent net-ssh-gateway sessions.

For some background info, I connect to several hundred servers located in various private/public clouds. These are only accessible via a jump server/bastion host. When I tried to open one net-ssh-gateway session to each of these gateway hosts and then connect onwards to the various servers.. my sessions would lock up and hang after a short amount of time. There wasn’t any real pattern or useful debug messages. It just seems to crash and burn.

After digging around and isolating the problem to the event loop it seems some channels were in strange states, or not being cleaned up correctly.

These changes allow me to connect to various jump servers via net-ssh-gateway and then connect to 100’s servers and run various commands without any problems.
