### PR TITLE
Fix for key_data ArgumentError on load

### DIFF
--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -232,16 +232,13 @@ module Net
                 identity
               end
 
-            rescue OpenSSL::PKey::RSAError, OpenSSL::PKey::DSAError, OpenSSL::PKey::ECError => e
+            rescue OpenSSL::PKey::RSAError, OpenSSL::PKey::DSAError, OpenSSL::PKey::ECError, ArgumentError => e
               if ignore_decryption_errors
                 identity
               else
                 process_identity_loading_error(identity, e)
                 nil
               end
-            rescue ArgumentError => e
-              process_identity_loading_error(identity, e)
-              nil
             rescue Exception => e
               process_identity_loading_error(identity, e)
               nil


### PR DESCRIPTION
Fixing #290 

Since OpenSSH wrapper produces argument errors when it fails to decode the key data without a password, adding it to the decryption errors rescue block.
AFAIK this shouldn't affect other scenarios since by the second run `ignore_decryption_errors` option will be set to `false`.