### PR TITLE
Clarified prompt when key is supplied from data

### DIFF
--- a/lib/net/ssh/key_factory.rb
+++ b/lib/net/ssh/key_factory.rb
@@ -82,7 +82,11 @@ module Net; module SSH
           if encrypted_key && ask_passphrase
             tries += 1
             if tries <= 3
-              passphrase = prompt("Enter passphrase for #{filename}:", false)
+              if filename.blank?
+                passphrase = prompt("Enter passphrase for the encrypted key:", false)
+              else
+                passphrase = prompt("Enter passphrase for #{filename}:", false)
+              end
               retry
             else
               raise


### PR DESCRIPTION
Fixing #293 - minor UI change after my last change, to make the prompt:
`Enter passphrase for the encrypted key:`
Instead of:
`Enter passphrase for  :`

From what I see tests should be ok, since they define the prompt as: 
`reader.expect(/Enter passphrase for .*:/) { |data| puts data }`
, however, let's see what Travis reports.