### PR TITLE
Small DRY fix

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -252,7 +252,7 @@ module Net
     # to read.
     #
     # See Net::SSH::Config for the full description of all supported options.
-    def self.configuration_for(host, use_ssh_config=true)
+    def self.configuration_for(host, use_ssh_config)
       files = case use_ssh_config
         when true then Net::SSH::Config.default_files
         when false, nil then return {}


### PR DESCRIPTION
First attempt at Git Hub.. When calling 'configuration_for' there is no reason that I can find to specify a default value for ' use_ssh_config' because Hash#fetch called on 'options' will always either return what the user specified or True. Just a small Do not repeat yourself.