### PR TITLE
already initialized constant DL::RUBY_FREE #285

### DIFF
--- a/lib/net/ssh/authentication/pageant.rb
+++ b/lib/net/ssh/authentication/pageant.rb
@@ -12,8 +12,8 @@ else
 
   # For now map DL to Fiddler versus updating all the code below
   module DL
-    CPtr = Fiddle::Pointer
-    RUBY_FREE = Fiddle::RUBY_FREE
+    CPtr ||= Fiddle::Pointer
+    RUBY_FREE ||= Fiddle::RUBY_FREE
   end
 end
 


### PR DESCRIPTION
To avoid this message when the constants have been already initialized by other gem