### PR TITLE
Allow to substitute Net::SSH::KnownHosts with a custom implementation

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -66,7 +66,7 @@ module Net
       :keepalive, :keepalive_interval, :keepalive_maxcount, :kex, :keys, :key_data,
       :languages, :logger, :paranoid, :password, :port, :proxy,
       :rekey_blocks_limit,:rekey_limit, :rekey_packet_limit, :timeout, :verbose,
-      :global_known_hosts_file, :user_known_hosts_file, :host_key_alias,
+      :known_hosts, :global_known_hosts_file, :user_known_hosts_file, :host_key_alias,
       :host_name, :user, :properties, :passphrase, :keys_only, :max_pkt_size,
       :max_win_size, :send_env, :use_agent, :number_of_password_prompts,
       :append_supported_algorithms, :non_interactive
@@ -114,6 +114,8 @@ module Net
     # * :encryption => the encryption cipher (or ciphers) to use
     # * :forward_agent => set to true if you want the SSH agent connection to
     #   be forwarded
+    # * :known_hosts => a custom object holding known hosts records.
+    #   It must implement #search_for and #add.
     # * :global_known_hosts_file => the location of the global known hosts
     #   file. Set to an array if you want to specify multiple global known
     #   hosts files. Defaults to %w(/etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2).

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -242,7 +242,8 @@ module Net; module SSH; module Transport
           # make sure the host keys are specified in preference order, where any
           # existing known key for the host has preference.
 
-          existing_keys = KnownHosts.search_for(options[:host_key_alias] || session.host_as_string, options)
+          known_hosts = options.fetch(:known_hosts, KnownHosts)
+          existing_keys = known_hosts.search_for(options[:host_key_alias] || session.host_as_string, options)
           host_keys = existing_keys.map { |key| key.ssh_type }.uniq
           algorithms[:host_key].each do |name|
             host_keys << name unless host_keys.include?(name)


### PR DESCRIPTION
Fix: https://github.com/net-ssh/net-ssh/issues/307
Fix: https://github.com/net-ssh/net-ssh/issues/232
Ref: https://github.com/capistrano/sshkit/issues/326

As suggested in https://github.com/net-ssh/net-ssh/issues/307#issuecomment-179345555.

I initially defaulted with `options[:known_hosts] = KnownHosts` in `Net::SSH.start`, but then I figured that some people might use only parts of `Net::SSH`, and so I think it's better to check the options in all the sub components.

@mfazekas @TiagoCardoso1983 what do you think of this implementation?