### PR TITLE
Memoize session host keys

### DIFF
--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -242,8 +242,7 @@ module Net; module SSH; module Transport
           # make sure the host keys are specified in preference order, where any
           # existing known key for the host has preference.
 
-          known_hosts = options.fetch(:known_hosts, KnownHosts)
-          existing_keys = known_hosts.search_for(options[:host_key_alias] || session.host_as_string, options)
+          existing_keys = session.host_keys
           host_keys = existing_keys.map { |key| key.ssh_type }.uniq
           algorithms[:host_key].each do |name|
             host_keys << name unless host_keys.include?(name)

--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -89,6 +89,13 @@ module Net; module SSH; module Transport
       raise Net::SSH::ConnectionTimeout
     end
 
+    def host_keys
+      @host_keys ||= begin
+        known_hosts = options.fetch(:known_hosts, KnownHosts)
+        known_hosts.search_for(options[:host_key_alias] || host_as_string, options)
+      end
+    end
+
     # Returns the host (and possibly IP address) in a format compatible with
     # SSH known-host files.
     def host_as_string

--- a/lib/net/ssh/verifiers/secure.rb
+++ b/lib/net/ssh/verifiers/secure.rb
@@ -16,7 +16,7 @@ module Net; module SSH; module Verifiers
       options = arguments[:session].options
       host = options[:host_key_alias] || arguments[:session].host_as_string
       known_hosts = options.fetch(:known_hosts, KnownHosts)
-      matches = known_hosts.search_for(host, arguments[:session].options)
+      matches = arguments[:session].host_keys
 
       # We've never seen this host before, so raise an exception.
       if matches.empty?

--- a/test/common.rb
+++ b/test/common.rb
@@ -41,6 +41,7 @@ class MockTransport < Net::SSH::Transport::Session
   attr_accessor :mock_enqueue
 
   def initialize(options={})
+    @options = options
     self.logger = options[:logger]
     self.host_as_string = "net.ssh.test,127.0.0.1"
     self.server_version = OpenStruct.new(:version => "SSH-2.0-Ruby/Net::SSH::Test")


### PR DESCRIPTION
As discussed here: https://github.com/net-ssh/net-ssh/pull/308#issuecomment-179682869

`KnownHosts.search_for` always re-parse from zero and is called twice per session. This PR centralize and memoize that lookup.

It has been identified as a hot spot during profiling. See https://github.com/capistrano/sshkit/issues/326#issuecomment-178899236 for more details.

@mfazekas @TiagoCardoso1983 how does it look?