### PR TITLE
Use minimum timeout when calling IO#select

### DIFF
--- a/lib/net/ssh/connection/session.rb
+++ b/lib/net/ssh/connection/session.rb
@@ -609,9 +609,11 @@ module Net; module SSH; module Connection
       end
 
       def io_select_wait(wait)
-        return wait if wait
-        return wait unless @keepalive.enabled?
-        @keepalive.interval
+        if @keepalive.enabled?
+          [wait, @keepalive.interval].compact.min
+        else
+          wait
+        end
       end
 
       MAP = Constants.constants.inject({}) do |memo, name|

--- a/test/connection/test_session.rb
+++ b/test/connection/test_session.rb
@@ -427,6 +427,14 @@ module Connection
       session(options).process
     end
 
+    def test_process_should_call_io_select_with_wait_if_provided_and_minimum
+      timeout = 10
+      wait = 5
+      options = { :keepalive => true, :keepalive_interval => timeout }
+      IO.expects(:select).with([socket],[],nil,wait).returns([[],[],[]])
+      session(options).process(wait)
+    end
+
     def test_loop_should_call_process_until_process_returns_false
       IO.stubs(:select).with([socket],[],nil,nil).returns([[],[],[]])
       session.expects(:process).with(nil).times(4).returns(true,true,true,false).yields


### PR DESCRIPTION
@mfazekas noticed this when reviewing https://github.com/net-ssh/net-ssh-multi/pull/8.

If keepalive is enabled and the wait parameter is given when starting the event loop, we should pass the minimum of the two values through to `IO#select`. Otherwise the event loop could block for too long, and keepalive packets would not be sent as often as they should be.