### PR TITLE
Fix Secure#verify call to process_cache_miss

### DIFF
--- a/lib/net/ssh/verifiers/secure.rb
+++ b/lib/net/ssh/verifiers/secure.rb
@@ -30,7 +30,7 @@ module Net; module SSH; module Verifiers
       # If a match was found, return true. Otherwise, raise an exception
       # indicating that the key was not recognized.
       unless found
-        process_cache_miss(host_keys, HostKeyMismatch, "does not match")
+        process_cache_miss(host_keys, arguments, HostKeyMismatch, "does not match")
       end
 
       found


### PR DESCRIPTION
The regression was introduced in #320 

```
net/ssh/verifiers/secure.rb:41:in `process_cache_miss'
net/ssh/verifiers/secure.rb:33:in `verify'
net/ssh/verifiers/strict.rb:16:in `verify'
net/ssh/verifiers/lenient.rb:15:in `verify'
net/ssh/transport/kex/diffie_hellman_group1_sha1.rb:173:in `verify_server_key'
net/ssh/transport/kex/diffie_hellman_group1_sha1.rb:68:in `exchange_keys'
net/ssh/transport/algorithms.rb:363:in `exchange_keys'
net/ssh/transport/algorithms.rb:200:in `proceed!'
net/ssh/transport/algorithms.rb:191:in `send_kexinit'
net/ssh/transport/algorithms.rb:146:in `accept_kexinit'
net/ssh/transport/session.rb:209:in `block in poll_message'
net/ssh/transport/session.rb:187:in `loop'
net/ssh/transport/session.rb:187:in `poll_message'
net/ssh/transport/session.rb:224:in `block in wait'
net/ssh/transport/session.rb:222:in `loop'
net/ssh/transport/session.rb:222:in `wait'
net/ssh/transport/session.rb:87:in `initialize'
net/ssh.rb:228:in `new'
net/ssh.rb:228:in `start'
```

@mfazekas 