### PR TITLE
Add max_select_wait_time method

### DIFF
--- a/lib/net/ssh/connection/session.rb
+++ b/lib/net/ssh/connection/session.rb
@@ -462,6 +462,13 @@ module Net; module SSH; module Connection
       end
     end
 
+    # If the #preprocess and #postprocess callbacks for this session need to run
+    # periodically, this method returns the maximum number of seconds which may
+    # pass between callbacks.
+    def max_select_wait_time
+      @keepalive.interval if @keepalive.enabled?
+    end
+
 
     private
 
@@ -622,11 +629,7 @@ module Net; module SSH; module Connection
       end
 
       def io_select_wait(wait)
-        if @keepalive.enabled?
-          [wait, @keepalive.interval].compact.min
-        else
-          wait
-        end
+        [wait, max_select_wait_time].compact.min
       end
 
       MAP = Constants.constants.inject({}) do |memo, name|

--- a/test/connection/test_session.rb
+++ b/test/connection/test_session.rb
@@ -496,6 +496,16 @@ module Connection
       assert_equal "", session.exec!('ls')
     end
 
+    def test_max_select_wait_time_should_return_keepalive_interval_when_keepalive_enabled
+      options = { :keepalive => true, :keepalive_interval => 5 }
+      assert_equal 5, session(options).max_select_wait_time
+    end
+
+    def test_max_select_wait_time_should_return_nil_when_keepalive_disabled
+      options = {}
+      assert_nil session(options).max_select_wait_time
+    end
+
     private
 
       def prep_exec(command, *data)


### PR DESCRIPTION
Related to https://github.com/net-ssh/net-ssh-multi/pull/17.

This is required in `Net::SSH::Multi`, so that the aggregated event loop can decide how frequently to wake up and run the callbacks.