### PR TITLE
Adding minimum_dh_bits option to override default value

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -69,7 +69,7 @@ module Net
       :known_hosts, :global_known_hosts_file, :user_known_hosts_file, :host_key_alias,
       :host_name, :user, :properties, :passphrase, :keys_only, :max_pkt_size,
       :max_win_size, :send_env, :use_agent, :number_of_password_prompts,
-      :append_supported_algorithms, :non_interactive
+      :append_supported_algorithms, :non_interactive, :minimum_dh_bits
     ]
 
     # The standard means of starting a new SSH connection. When used with a

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -351,6 +351,7 @@ module Net; module SSH; module Transport
           :server_algorithm_packet => @server_packet,
           :client_algorithm_packet => @client_packet,
           :need_bytes => kex_byte_requirement,
+          :minimum_dh_bits => options[:minimum_dh_bits],
           :logger => logger)
         result = algorithm.exchange_keys
 

--- a/lib/net/ssh/transport/kex/diffie_hellman_group_exchange_sha1.rb
+++ b/lib/net/ssh/transport/kex/diffie_hellman_group_exchange_sha1.rb
@@ -23,8 +23,10 @@ module Net::SSH::Transport::Kex
         # for Compatibility: OpenSSH requires (need_bits * 2 + 1) length of parameter
         need_bits = data[:need_bytes] * 8 * 2 + 1
 
-        if need_bits < MINIMUM_BITS
-          need_bits = MINIMUM_BITS
+        data[:minimum_dh_bits] ||=  MINIMUM_BITS
+        
+        if need_bits < data[:minimum_dh_bits]
+          need_bits = data[:minimum_dh_bits]
         elsif need_bits > MAXIMUM_BITS
           need_bits = MAXIMUM_BITS
         end

--- a/lib/net/ssh/transport/kex/diffie_hellman_group_exchange_sha1.rb
+++ b/lib/net/ssh/transport/kex/diffie_hellman_group_exchange_sha1.rb
@@ -24,7 +24,7 @@ module Net::SSH::Transport::Kex
         need_bits = data[:need_bytes] * 8 * 2 + 1
 
         data[:minimum_dh_bits] ||=  MINIMUM_BITS
-        
+
         if need_bits < data[:minimum_dh_bits]
           need_bits = data[:minimum_dh_bits]
         elsif need_bits > MAXIMUM_BITS
@@ -40,7 +40,7 @@ module Net::SSH::Transport::Kex
         compute_need_bits
 
         # request the DH key parameters for the given number of bits.
-        buffer = Net::SSH::Buffer.from(:byte, KEXDH_GEX_REQUEST, :long, MINIMUM_BITS,
+        buffer = Net::SSH::Buffer.from(:byte, KEXDH_GEX_REQUEST, :long, data[:minimum_dh_bits],
           :long, data[:need_bits], :long, MAXIMUM_BITS)
         connection.send_message(buffer)
 


### PR DESCRIPTION
Hello,

I am adding minimum_dh_bits option to override default DH key size set by MINIMUM_BITS.

Please review and let me know if this can be merged to upstream.
