### PR TITLE
Refactor prompting to a class that can be customized

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -3,6 +3,7 @@
 ENV['HOME'] ||= ENV['HOMEPATH'] ? "#{ENV['HOMEDRIVE']}#{ENV['HOMEPATH']}" : Dir.pwd
 
 require 'logger'
+require 'etc'
 
 require 'net/ssh/config'
 require 'net/ssh/errors'
@@ -10,7 +11,7 @@ require 'net/ssh/loggable'
 require 'net/ssh/transport/session'
 require 'net/ssh/authentication/session'
 require 'net/ssh/connection/session'
-require 'etc'
+require 'net/ssh/prompt'
 
 module Net
 
@@ -70,7 +71,7 @@ module Net
       :known_hosts, :global_known_hosts_file, :user_known_hosts_file, :host_key_alias,
       :host_name, :user, :properties, :passphrase, :keys_only, :max_pkt_size,
       :max_win_size, :send_env, :use_agent, :number_of_password_prompts,
-      :append_supported_algorithms, :non_interactive
+      :append_supported_algorithms, :non_interactive, :password_prompt
     ]
 
     # The standard means of starting a new SSH connection. When used with a
@@ -192,6 +193,7 @@ module Net
     #   password auth method
     # * :non_interactive => non interactive applications should set it to true
     #   to prefer failing a password/etc auth methods vs asking for password
+    # * :password_prompt => a custom prompt object with ask method. See Net::SSH::Prompt
     #
     # If +user+ parameter is nil it defaults to USER from ssh_config, or
     # local username
@@ -213,6 +215,8 @@ module Net
       if options[:non_interactive]
         options[:number_of_password_prompts] = 0
       end
+
+      options[:password_prompt] ||= Prompt.default(options)
 
       if options[:verbose]
         options[:logger].level = case options[:verbose]

--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -221,11 +221,11 @@ module Net
                 key = KeyFactory.load_public_key(identity[:pubkey_file])
                 { :public_key => key, :from => :file, :file => identity[:privkey_file] }
               when :privkey_file
-                private_key = KeyFactory.load_private_key(identity[:privkey_file], options[:passphrase], ask_passphrase)
+                private_key = KeyFactory.load_private_key(identity[:privkey_file], options[:passphrase], ask_passphrase, options[:password_prompt])
                 key = private_key.send(:public_key)
                 { :public_key => key, :from => :file, :file => identity[:privkey_file], :key => private_key }
               when :data
-                private_key = KeyFactory.load_data_private_key(identity[:data], options[:passphrase], ask_passphrase)
+                private_key = KeyFactory.load_data_private_key(identity[:data], options[:passphrase], ask_passphrase, "<key in memory>", options[:password_prompt])
                 key = private_key.send(:public_key)
                 { :public_key => key, :from => :key_data, :data => identity[:data], :key => private_key }
               else

--- a/lib/net/ssh/authentication/methods/abstract.rb
+++ b/lib/net/ssh/authentication/methods/abstract.rb
@@ -22,6 +22,7 @@ module Net; module SSH; module Authentication; module Methods
       @session = session
       @key_manager = options[:key_manager]
       @options = options
+      @prompt = options[:password_prompt]
       self.logger = session.logger
     end
 
@@ -55,6 +56,9 @@ module Net; module SSH; module Authentication; module Methods
       buffer
     end
 
+    private
+
+    attr_reader :prompt
   end
 
 end; end; end; end

--- a/lib/net/ssh/authentication/session.rb
+++ b/lib/net/ssh/authentication/session.rb
@@ -70,7 +70,8 @@ module Net; module SSH; module Authentication
 
           debug { "trying #{name}" }
           begin
-            method = Methods.const_get(name.split(/\W+/).map { |p| p.capitalize }.join).new(self, :key_manager => key_manager)
+            auth_class = Methods.const_get(name.split(/\W+/).map { |p| p.capitalize }.join)
+            method = auth_class.new(self, key_manager: key_manager, password_prompt: options[:password_prompt])
           rescue NameError
             debug{"Mechanism #{name} was requested, but isn't a known type.  Ignoring it."}
             next

--- a/lib/net/ssh/prompt.rb
+++ b/lib/net/ssh/prompt.rb
@@ -1,93 +1,64 @@
+require 'io/console'
+
 module Net; module SSH
 
-  # A basic prompt module that can be mixed into other objects. If HighLine is
-  # installed, it will be used to display prompts and read input from the
-  # user. Otherwise, the termios library will be used. If neither HighLine
-  # nor termios is installed, a simple prompt that echos text in the clear
-  # will be used.
+  # Default prompt implementation, called for asking password from user.
+  # It will never be instantiated directly, but will instead be created for
+  # you automatically.
+  #
+  # A custom prompt objects can implement caching, or different UI. The prompt
+  # object should implemnted a start method, which should return something implementing
+  # ask and success. Net::SSH uses it like:
+  #
+  #   prompter = options[:password_prompt].start({type:'password'})
+  #   while !ok && max_retries < 3
+  #     user = prompter.ask("user: ", {}, true)
+  #     password = prompter.ask("password: ", {}, false)
+  #     ok = send(user, password)
+  #     prompter.sucess if ok
+  #   end
+  #
+  class Prompt
+    # factory
+    def self.default(options = {})
+      @default ||= new(options)
+    end
 
-  module PromptMethods
+    def initialize(options = {})
+    end
 
-    # Defines the prompt method to use if the Highline library is installed.
-    module Highline
-      # Uses Highline#ask to present a prompt and accept input. If +echo+ is
-      # +false+, the characters entered by the user will not be echoed to the
-      # screen.
-      def prompt(prompt, echo=true)
-        @highline ||= ::HighLine.new
-        @highline.ask(prompt + " ") { |q| q.echo = echo }
+    # default prompt object implementation. More sophisticated implemenetations
+    # might implement caching.
+    class Prompter
+      def initialize(info)
+        if info[:type] == 'keyboard-interactive' # rubocop:disable Style/GuardClause
+          $stdout.puts(info[:name]) unless info[:name].empty?
+          $stdout.puts(info[:instruction]) unless info[:instruction].empty?
+        end
+      end
+
+      # ask input from user, a prompter might ask for multiple inputs
+      # (like user and password) in a single session.
+      def ask(prompt, echo=true)
+        $stdout.print(prompt)
+        $stdout.flush
+        ret = $stdin.noecho(&:gets).chomp
+        $stdout.print("\n")
+        ret
+      end
+
+      # success method will be called when the password was accepted
+      # It's a good time to save password asked to a cache.
+      def success
       end
     end
 
-    # Defines the prompt method to use if the Termios library is installed.
-    module Termios
-      # Displays the prompt to $stdout. If +echo+ is false, the Termios
-      # library will be used to disable keystroke echoing for the duration of
-      # this method.
-      def prompt(prompt, echo=true)
-        $stdout.print(prompt)
-        $stdout.flush
-
-        set_echo(false) unless echo
-        $stdin.gets.chomp
-      ensure
-        if !echo
-          set_echo(true)
-          $stdout.puts
-        end
-      end
-
-      private
-
-        # Enables or disables keystroke echoing using the Termios library.
-        def set_echo(enable)
-          term = ::Termios.getattr($stdin)
-
-          if enable
-            term.c_lflag |= (::Termios::ECHO | ::Termios::ICANON)
-          else
-            term.c_lflag &= ~::Termios::ECHO
-          end
-
-          ::Termios.setattr($stdin, ::Termios::TCSANOW, term)
-        end
-    end
-
-    # Defines the prompt method to use when neither Highline nor Termios are
-    # installed.
-    module Clear
-      # Displays the prompt to $stdout and pulls the response from $stdin.
-      # Text is always echoed in the clear, regardless of the +echo+ setting.
-      # The first time a prompt is given and +echo+ is false, a warning will
-      # be written to $stderr recommending that either Highline or Termios
-      # be installed.
-      def prompt(prompt, echo=true)
-        @seen_warning ||= false
-        if !echo && !@seen_warning
-          $stderr.puts "Text will be echoed in the clear. Please install the HighLine or Termios libraries to suppress echoed text."
-          @seen_warning = true
-        end
-
-        $stdout.print(prompt)
-        $stdout.flush
-        $stdin.gets.chomp
-      end
+    # start password session. Multiple questions might be asked multiple times
+    # on the returned object. Info hash tries to uniquely identify the password
+    # session, so caching implementations can save passwords properly.
+    def start(info)
+      Prompter.new(info)
     end
   end
-
-  # Try to load Highline and Termios in turn, selecting the corresponding
-  # PromptMethods module to use. If neither are available, choose PromptMethods::Clear.
-  Prompt = begin
-      require 'highline'
-      HighLine.track_eof = false
-      PromptMethods::Highline
-    rescue LoadError
-      begin
-        require 'termios'
-        PromptMethods::Termios
-      rescue LoadError
-        PromptMethods::Clear
-      end
-    end
 
 end; end

--- a/test/authentication/methods/common.rb
+++ b/test/authentication/methods/common.rb
@@ -10,7 +10,7 @@ module Authentication; module Methods
       end
 
       def transport(options={})
-        @transport ||= MockTransport.new(options.merge(:socket => socket))
+        @transport ||= MockTransport.new(options.merge(socket: socket))
       end
 
       def session(options={})
@@ -21,6 +21,12 @@ module Authentication; module Methods
           end
           sess
         end
+      end
+
+      def reset_session(options = {})
+        @transport = nil
+        @session = nil
+        session(options)
       end
 
   end

--- a/test/authentication/methods/test_password.rb
+++ b/test/authentication/methods/test_password.rb
@@ -47,8 +47,9 @@ module Authentication; module Methods
         end
       end
 
-      subject.expects(:prompt).with("jamis@'s password:", false).returns("the-password-2")
-      subject.authenticate("ssh-connection", "jamis", "the-password")
+      prompt = MockPrompt.new
+      prompt.expects(:_ask).with("jamis@'s password:", {type: 'password', user: 'jamis', host: nil}, false).returns("the-password-2")
+      subject(password_prompt: prompt).authenticate("ssh-connection", "jamis", "the-password")
     end
 
     def test_authenticate_ask_for_password_if_not_given
@@ -63,8 +64,9 @@ module Authentication; module Methods
       end
 
       transport.instance_eval { @host='testhost' }
-      subject.expects(:prompt).with("bill@testhost's password:", false).returns("good-password")
-      subject.authenticate("ssh-connection", "bill", nil)
+      prompt = MockPrompt.new
+      prompt.expects(:_ask).with("bill@testhost's password:", {type: 'password', user: 'bill', host: 'testhost'}, false).returns("good-password")
+      subject(password_prompt: prompt).authenticate("ssh-connection", "bill", nil)
     end
 
     def test_authenticate_when_password_is_acceptible_should_return_true

--- a/test/common.rb
+++ b/test/common.rb
@@ -40,6 +40,20 @@ class NetSSHTest < Minitest::Test
   end
 end
 
+class MockPrompt
+  def start(info)
+    @info = info
+    self
+  end
+
+  def ask(message, echo)
+    _ask(message, @info, echo)
+  end
+
+  def success
+  end
+end
+
 class MockTransport < Net::SSH::Transport::Session
   class BlockVerifier
     def initialize(block)

--- a/test/integration/playbook.yml
+++ b/test/integration/playbook.yml
@@ -2,6 +2,7 @@
 - hosts: all
   sudo: yes
   vars:
+    no_rvm: no
     myuser: vagrant
     mygroup: vagrant
     homedir: /home/vagrant
@@ -42,6 +43,9 @@
       notify: restart sshd
     - name: sshd debug
       lineinfile: dest='/etc/ssh/sshd_config' line='LogLevel DEBUG' regexp=LogLevel
+      notify: restart sshd
+    - name: sshd allow interactive
+      lineinfile: dest='/etc/ssh/sshd_config' line='ChallengeResponseAuthentication yes' regexp='^ChallengeResponseAuthentication.+'
       notify: restart sshd
     - name: sshd allow forward
       lineinfile: dest='/etc/ssh/sshd_config' line='AllowTcpForwarding all' regexp=LogLevel

--- a/test/integration/test_forward.rb
+++ b/test/integration/test_forward.rb
@@ -14,7 +14,7 @@
 #
 # http://net-ssh.lighthouseapp.com/projects/36253/tickets/7
 
-require_relative './common'
+require_relative 'common'
 require 'net/ssh/buffer'
 require 'net/ssh'
 require 'net/ssh/proxy/command'

--- a/test/integration/test_id_rsa_keys.rb
+++ b/test/integration/test_id_rsa_keys.rb
@@ -1,4 +1,4 @@
-require 'common'
+require_relative 'common'
 require 'fileutils'
 require 'tmpdir'
 
@@ -86,9 +86,10 @@ class TestIDRSAPKeys < NetSSHTest
       options = {keys: [], key_data: [private_key]}
 
       #key_manager = Net::SSH::Authentication::KeyManager.new(nil, options)
-
-      Net::SSH::KeyFactory.expects(:prompt).with('Enter passphrase for :', false).returns('pwd12')
-      Net::SSH.start("localhost", "net_ssh_1", options) do |ssh|
+      prompt = MockPrompt.new
+      sha = Digest::SHA256.digest(private_key)
+      prompt.expects(:_ask).with('Enter passphrase for <key in memory>:', {type: 'private_key', filename: '<key in memory>', sha: sha}, false).returns('pwd12')
+      Net::SSH.start("localhost", "net_ssh_1", options.merge(password_prompt: prompt)) do |ssh|
         ssh.exec! 'whoami'
       end
     end

--- a/test/integration/test_password.rb
+++ b/test/integration/test_password.rb
@@ -1,0 +1,50 @@
+require_relative 'common'
+require 'net/ssh'
+
+class TestPassword < NetSSHTest
+  include IntegrationTestHelpers
+
+  def test_with_password_parameter
+    ret = Net::SSH.start("localhost", "net_ssh_1", password: 'foopwd') do |ssh|
+      ssh.exec! 'echo "hello from:$USER"'
+    end
+    assert_equal ret, "hello from:net_ssh_1\n"
+  end
+
+  def test_keyboard_interactive_with_good_password
+    ps = Object.new
+    pt = Object.new
+    pt.expects(:start).with(type: 'keyboard-interactive', name: '', instruction: '').returns(ps)
+    ps.expects(:ask).with('Password: ', false).returns("foopwd")
+    ps.expects(:success)
+    ret = Net::SSH.start("localhost", "net_ssh_1", auth_methods: ['keyboard-interactive'], password_prompt: pt) do |ssh|
+      ssh.exec! 'echo "hello from:$USER"'
+    end
+    assert_equal ret, "hello from:net_ssh_1\n"
+  end
+
+  def test_keyboard_interactive_with_one_failed_attempt
+    ps = Object.new
+    pt = Object.new
+    pt.expects(:start).with(type: 'keyboard-interactive', name: '', instruction: '').returns(ps)
+    ps.expects(:ask).twice.with('Password: ', false).returns("badpwd").then.with('Password: ', false).returns("foopwd")
+    ps.expects(:success)
+    ret = Net::SSH.start("localhost", "net_ssh_1", auth_methods: ['keyboard-interactive'], password_prompt: pt) do |ssh|
+      ssh.exec! 'echo "hello from:$USER"'
+    end
+    assert_equal ret, "hello from:net_ssh_1\n"
+  end
+
+  def test_password_with_good_password
+    ps = Object.new
+    pt = Object.new
+    pt.expects(:start).with(type: 'password', user: 'net_ssh_1', host: 'localhost').returns(ps)
+    ps.expects(:ask).with("net_ssh_1@localhost's password:", false).returns("foopwd")
+    ps.expects(:success)
+
+    ret = Net::SSH.start("localhost", "net_ssh_1", auth_methods: ['password'], password_prompt: pt) do |ssh|
+      ssh.exec! 'echo "hello from:$USER"'
+    end
+    assert_equal ret, "hello from:net_ssh_1\n"
+  end
+end

--- a/test/integration/test_proxy.rb
+++ b/test/integration/test_proxy.rb
@@ -1,4 +1,4 @@
-require_relative './common'
+require_relative 'common'
 require 'net/ssh/buffer'
 require 'net/ssh'
 require 'timeout'


### PR DESCRIPTION
Fixes: #91, and fixes #254, and fixes #293 

Changes:

- We use io/console so no termios/highline is required
- Password prompt logic now customizable via ```:password_prompt``` option. It should be possible to implement caching logic
- Keyboard interactive now asks multiple times if the provided credentials are incorrect