### PR TITLE
Prevents users explicitly passing in nils in options by accident whic…

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -178,7 +178,7 @@ module Net
     # * :user_known_hosts_file => the location of the user known hosts file.
     #   Set to an array to specify multiple user known hosts files.
     #   Defaults to %w(~/.ssh/known_hosts ~/.ssh/known_hosts2).
-    # * :use_agent => Set false to disable the use of ssh-agent. Defaults to 
+    # * :use_agent => Set false to disable the use of ssh-agent. Defaults to
     #   true
     # * :non_interactive => set to true if your app is non interactive and prefers
     #   authentication failure vs password prompt
@@ -201,6 +201,11 @@ module Net
       invalid_options = options.keys - VALID_OPTIONS
       if invalid_options.any?
         raise ArgumentError, "invalid option(s): #{invalid_options.join(', ')}"
+      end
+
+      if options.values.include? nil
+        nil_options = options.keys.select { |k| options[k].nil? }
+        raise ArgumentError, "Value(s) have been set to nil: #{nil_options.join(', ')}"
       end
 
       options[:user] = user if user

--- a/test/start/test_options.rb
+++ b/test/start/test_options.rb
@@ -52,6 +52,20 @@ module NetSSH
         Net::SSH.start('localhost', 'testuser', options)
       end
     end
+
+    def test_constructor_should_reject_options_set_to_nil
+      assert_raises(ArgumentError) do
+        options = { :remote_user => nil}
+        Net::SSH.start('localhost', 'testuser', options)
+      end
+    end
+
+    def test_constructor_should_reject_invalid_options
+      assert_raises(ArgumentError) do
+        options = { :some_invalid_option => "some setting"}
+        Net::SSH.start('localhost', 'testuser', options)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
…h could lead to no method errors further down

I think this fixes https://github.com/net-ssh/net-ssh/issues/316