### PR TITLE
Added ability to specify agent socket

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -71,7 +71,7 @@ module Net
       :known_hosts, :global_known_hosts_file, :user_known_hosts_file, :host_key_alias,
       :host_name, :user, :properties, :passphrase, :keys_only, :max_pkt_size,
       :max_win_size, :send_env, :use_agent, :number_of_password_prompts,
-      :append_supported_algorithms, :non_interactive, :password_prompt
+      :append_supported_algorithms, :non_interactive, :password_prompt, :agent_socket_factory
     ]
 
     # The standard means of starting a new SSH connection. When used with a
@@ -195,6 +195,9 @@ module Net
     #   to prefer failing a password/etc auth methods vs asking for password
     # * :password_prompt => a custom prompt object with ask method. See Net::SSH::Prompt
     #
+    # * :agent_socket_factory => enables the user to pass a lambda/block that will serve as the socket factory
+    #    Net::SSH::start(user,host,agent_socket_factory: ->{ UNIXSocket.open('/foo/bar') })
+    #    example: ->{ UNIXSocket.open('/foo/bar')}
     # If +user+ parameter is nil it defaults to USER from ssh_config, or
     # local username
     def self.start(host, user=nil, options={}, &block)

--- a/lib/net/ssh/authentication/agent/java_pageant.rb
+++ b/lib/net/ssh/authentication/agent/java_pageant.rb
@@ -19,7 +19,7 @@ module Net; module SSH; module Authentication
 
     # Instantiates a new agent object, connects to a running SSH agent,
     # negotiates the agent protocol version, and returns the agent object.
-    def self.connect(logger=nil)
+    def self.connect(logger=nil, agent_socket_factory)
       agent = new(logger)
       agent.connect!
       agent

--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -176,7 +176,7 @@ module Net
         # or if the agent is otherwise not available.
         def agent
           return unless use_agent?
-          @agent ||= Agent.connect(logger)
+          @agent ||= Agent.connect(logger, options[:agent_socket_factory])
         rescue AgentNotAvailable
           @use_agent = false
           nil

--- a/lib/net/ssh/service/forward.rb
+++ b/lib/net/ssh/service/forward.rb
@@ -357,7 +357,7 @@ module Net; module SSH; module Service
         channel[:invisible] = true
 
         begin
-          agent = Authentication::Agent.connect(logger)
+          agent = Authentication::Agent.connect(logger, session.options[:agent_socket_factory])
           if (agent.socket.is_a? ::IO)
             prepare_client(agent.socket, channel, :agent)
           else

--- a/test/authentication/test_agent.rb
+++ b/test/authentication/test_agent.rb
@@ -32,6 +32,11 @@ module Authentication
       agent(false).connect!
     end
 
+    def test_connect_should_use_agent_socket_factory_instead_of_factory
+      assert_equal agent.connect!, socket
+      assert_equal agent.connect!(agent_socket_factory), "/foo/bar.sock"
+    end
+
     def test_connect_should_raise_error_if_connection_could_not_be_established
       factory.expects(:open).raises(SocketError)
       assert_raises(Net::SSH::Authentication::AgentNotAvailable) { agent(false).connect! }
@@ -213,12 +218,15 @@ module Authentication
       def agent(auto=:connect)
         @agent ||= begin
           agent = Net::SSH::Authentication::Agent.new
-          agent.stubs(:agent_socket_factory).returns(factory)
+          agent.stubs(:socket_class).returns(factory)
           agent.connect! if auto == :connect
           agent
         end
       end
 
+      def agent_socket_factory
+        @agent_socket_factory ||= ->{"/foo/bar.sock"}
+      end
   end
 
 end


### PR DESCRIPTION
Adding the option to specify a socket that will be used, this is useful in case we have multiple agents running and multiple users using the net-ssh at the same time (that's why changing the ENV variable is not really practical).