### PR TITLE
Improve automatic selection of pageant on cygwin and win32

### DIFF
--- a/lib/net/ssh/authentication/agent.rb
+++ b/lib/net/ssh/authentication/agent.rb
@@ -3,9 +3,11 @@ require 'net/ssh/errors'
 require 'net/ssh/loggable'
 
 module Net; module SSH; module Authentication
-  PLATFORM = File::ALT_SEPARATOR \
+  PLATFORM = RUBY_PLATFORM =~ /cygwin/ ? :win32 : # :win32 includes cygwin
+    (File::ALT_SEPARATOR \
     ? RUBY_PLATFORM =~ /java/ ? :java_win32 : :win32 \
-    : RUBY_PLATFORM =~ /java/ ? :java : :unix
+    : RUBY_PLATFORM =~ /java/ ? :java : :unix)
+  PLATFORM = :cygwin if RUBY_PLATFORM =~ /cygwin/
 
   # A trivial exception class for representing agent-specific errors.
   class AgentError < Net::SSH::Exception; end

--- a/lib/net/ssh/authentication/agent/socket.rb
+++ b/lib/net/ssh/authentication/agent/socket.rb
@@ -1,6 +1,6 @@
 require 'net/ssh/transport/server_version'
 
-# Only load pageant on Windows
+# Only load pageant on Windows or Cygwin
 if Net::SSH::Authentication::PLATFORM == :win32
   require 'net/ssh/authentication/pageant'
 end
@@ -133,7 +133,7 @@ module Net; module SSH; module Authentication
 
     # Returns the agent socket factory to use.
     def socket_class
-      if Net::SSH::Authentication::PLATFORM == :win32
+      if Net::SSH::Authentication::PLATFORM == :win32 and ENV[SSH_AUTH_SOCK].nil?
         Pageant::Socket
       else
         UNIXSocket


### PR DESCRIPTION
The logic for selecting an agent on Windows (including cygwin) is now
as follows:
- if ENV[SSH_AUTH_SOCK] is defined, use UNIXSocket
- otherwise, use Pageant::Socket

This addresses both https://github.com/net-ssh/net-ssh/issues/192 and
https://github.com/net-ssh/net-ssh/issues/361.
