### PR TITLE
Adds minimum_dh_bits option.

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -71,7 +71,8 @@ module Net
       :known_hosts, :global_known_hosts_file, :user_known_hosts_file, :host_key_alias,
       :host_name, :user, :properties, :passphrase, :keys_only, :max_pkt_size,
       :max_win_size, :send_env, :use_agent, :number_of_password_prompts,
-      :append_supported_algorithms, :non_interactive, :password_prompt, :agent_socket_factory
+      :append_supported_algorithms, :non_interactive, :password_prompt, :agent_socket_factory,
+      :minimum_dh_bits
     ]
 
     # The standard means of starting a new SSH connection. When used with a

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -357,6 +357,7 @@ module Net; module SSH; module Transport
           :server_algorithm_packet => @server_packet,
           :client_algorithm_packet => @client_packet,
           :need_bytes => kex_byte_requirement,
+          :minimum_dh_bits => options[:minimum_dh_bits],
           :logger => logger)
         result = algorithm.exchange_keys
 

--- a/lib/net/ssh/transport/kex/diffie_hellman_group_exchange_sha1.rb
+++ b/lib/net/ssh/transport/kex/diffie_hellman_group_exchange_sha1.rb
@@ -23,8 +23,10 @@ module Net::SSH::Transport::Kex
         # for Compatibility: OpenSSH requires (need_bits * 2 + 1) length of parameter
         need_bits = data[:need_bytes] * 8 * 2 + 1
 
-        if need_bits < MINIMUM_BITS
-          need_bits = MINIMUM_BITS
+        data[:minimum_dh_bits] ||= MINIMUM_BITS
+
+        if need_bits < data[:minimum_dh_bits]
+          need_bits = data[:minimum_dh_bits]
         elsif need_bits > MAXIMUM_BITS
           need_bits = MAXIMUM_BITS
         end
@@ -38,7 +40,7 @@ module Net::SSH::Transport::Kex
         compute_need_bits
 
         # request the DH key parameters for the given number of bits.
-        buffer = Net::SSH::Buffer.from(:byte, KEXDH_GEX_REQUEST, :long, MINIMUM_BITS,
+        buffer = Net::SSH::Buffer.from(:byte, KEXDH_GEX_REQUEST, :long, data[:minimum_dh_bits],
           :long, data[:need_bits], :long, MAXIMUM_BITS)
         connection.send_message(buffer)
 

--- a/test/transport/kex/test_diffie_hellman_group_exchange_sha1.rb
+++ b/test/transport/kex/test_diffie_hellman_group_exchange_sha1.rb
@@ -47,11 +47,8 @@ module Transport; module Kex
       end
 
       def need_minimum(bits=1024)
-        if @dh_options && @dh_options[:minimum_dh_bits]
-          return @dh_options[:minimum_dh_bits]
-        else
-          return bits
-        end
+        return @dh_options[:minimum_dh_bits] if @dh_options && @dh_options[:minimum_dh_bits]
+        bits
       end
 
       def default_p

--- a/test/transport/kex/test_diffie_hellman_group_exchange_sha1.rb
+++ b/test/transport/kex/test_diffie_hellman_group_exchange_sha1.rb
@@ -16,6 +16,12 @@ module Transport; module Kex
       assert_nothing_raised { exchange! }
     end
 
+    def test_exchange_with_optional_minimum_bits_declared
+      dh_options :minimum_dh_bits => 4096
+      assert_equal 4096, need_bits
+      assert_nothing_raised { exchange! }
+    end
+
     def test_exchange_with_fewer_than_maximum_bits_uses_need_bits
       dh_options :need_bytes => 500
       need_bits(8001)
@@ -37,7 +43,15 @@ module Transport; module Kex
     private
 
       def need_bits(bits=1024)
-        @need_bits ||= bits
+        @need_bits ||= need_minimum(bits)
+      end
+
+      def need_minimum(bits=1024)
+        if @dh_options && @dh_options[:minimum_dh_bits]
+          return @dh_options[:minimum_dh_bits]
+        else
+          return bits
+        end
       end
 
       def default_p
@@ -47,7 +61,7 @@ module Transport; module Kex
       def exchange!(options={})
         connection.expect do |t, buffer|
           assert_equal KEXDH_GEX_REQUEST, buffer.type
-          assert_equal 1024, buffer.read_long
+          assert_equal need_minimum, buffer.read_long
           assert_equal need_bits, buffer.read_long
           assert_equal 8192, buffer.read_long
           t.return(KEXDH_GEX_GROUP, :bignum, bn(options[:p] || default_p), :bignum, bn(options[:g] || 2))

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -235,6 +235,7 @@ module Transport
             :server_algorithm_packet => kexinit.to_s,
             :client_algorithm_packet => buffer.to_s,
             :need_bytes => 20,
+            :minimum_dh_bits => nil,
             :logger => nil).
           returns(stub("kex", :exchange_keys => { :shared_secret => shared_secret, :session_id => session_id, :hashing_algorithm => hashing_algorithm }))
       end


### PR DESCRIPTION
This commit introduces a new option, minimum_dh_bits. This option allows
the user to specify the minimum required bits for a diffie helman key
exchange in situations where the minimum hardcoded value of 1024 is too
weak.