### PR TITLE
set default options before checking for nils

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -207,6 +207,8 @@ module Net
         raise ArgumentError, "invalid option(s): #{invalid_options.join(', ')}"
       end
 
+      assign_defaults(options)
+
       if options.values.include? nil
         nil_options = options.keys.select { |k| options[k].nil? }
         raise ArgumentError, "Value(s) have been set to nil: #{nil_options.join(', ')}"
@@ -216,16 +218,9 @@ module Net
       options = configuration_for(host, options.fetch(:config, true)).merge(options)
       host = options.fetch(:host_name, host)
 
-      if !options.key?(:logger)
-        options[:logger] = Logger.new(STDERR)
-        options[:logger].level = Logger::FATAL
-      end
-
       if options[:non_interactive]
         options[:number_of_password_prompts] = 0
       end
-
-      options[:password_prompt] ||= Prompt.default(options)
 
       if options[:verbose]
         options[:logger].level = case options[:verbose]
@@ -277,6 +272,15 @@ module Net
         end
 
       Net::SSH::Config.for(host, files)
+    end
+
+    def self.assign_defaults(options)
+      if !options[:logger]
+        options[:logger] = Logger.new(STDERR)
+        options[:logger].level = Logger::FATAL
+      end
+
+      options[:password_prompt] ||= Prompt.default(options)
     end
   end
 end

--- a/test/start/test_options.rb
+++ b/test/start/test_options.rb
@@ -55,16 +55,23 @@ module NetSSH
 
     def test_constructor_should_reject_options_set_to_nil
       assert_raises(ArgumentError) do
-        options = { :remote_user => nil}
+        options = { :remote_user => nil }
         Net::SSH.start('localhost', 'testuser', options)
       end
     end
 
     def test_constructor_should_reject_invalid_options
       assert_raises(ArgumentError) do
-        options = { :some_invalid_option => "some setting"}
+        options = { :some_invalid_option => "some setting" }
         Net::SSH.start('localhost', 'testuser', options)
       end
+    end
+
+    def test_constructor_should_set_default_options
+      options = { :logger => nil, :password_prompt => nil }
+      Net::SSH.start('localhost', 'testuser', options)
+      assert !options[:logger].nil?
+      assert !options[:password_prompt].nil?
     end
   end
 end


### PR DESCRIPTION
Allows it to handle logger being set explicitly to nil which may happen if options are wrapped by another program. Some discussion in #357 