### PR TITLE
Socket factory

### DIFF
--- a/lib/net/ssh/known_hosts.rb
+++ b/lib/net/ssh/known_hosts.rb
@@ -61,7 +61,7 @@ module Net; module SSH
       # Search for all known keys for the given host, in every file given in
       # the +files+ array. Returns the list of keys.
       def search_in(files, host)
-        files.map { |file| KnownHosts.new(file).keys_for(host) }.flatten
+        files.flat_map { |file| KnownHosts.new(file).keys_for(host) }
       end
 
       # Looks in the given +options+ hash for the :user_known_hosts_file and
@@ -141,7 +141,7 @@ module Net; module SSH
 
           hostlist = scanner.scan(/\S+/).split(/,/)
           found = entries.all? { |entry| hostlist.include?(entry) } ||
-            known_host_hash?(hostlist, entries, scanner)
+            known_host_hash?(hostlist, entries)
           next unless found
 
           scanner.skip(/\s*/)
@@ -160,7 +160,7 @@ module Net; module SSH
 
     # Indicates whether one of the entries matches an hostname that has been
     # stored as a HMAC-SHA1 hash in the known hosts.
-    def known_host_hash?(hostlist, entries, scanner)
+    def known_host_hash?(hostlist, entries)
       if hostlist.size == 1 && hostlist.first =~ /\A\|1(\|.+){2}\z/
         chunks = hostlist.first.split(/\|/)
         salt = Base64.decode64(chunks[2])

--- a/lib/net/ssh/service/forward.rb
+++ b/lib/net/ssh/service/forward.rb
@@ -343,7 +343,12 @@ module Net; module SSH; module Service
           raise Net::SSH::ChannelOpenFailed.new(1, "unknown request from remote forwarded connection on #{connected_address}:#{connected_port}")
         end
 
-        client = TCPSocket.new(remote.host, remote.port)
+        client = if (factory = session.options[:session_socket_factory])
+          factory.open(remote.host, remote.port)
+        else
+          Socket.tcp(remote.host, remote.port, nil, nil,
+            connect_timeout: session.options[:forward_connect_timeout])
+        end
         info { "connected #{connected_address}:#{connected_port} originator #{originator_address}:#{originator_port}" }
 
         prepare_client(client, channel, :remote)

--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -64,7 +64,7 @@ module Net; module SSH; module Transport
       debug { "establishing connection to #{@host}:#{@port}" }
 
       @socket =
-        if (factory = options[:proxy])
+        if (factory = options[:proxy] || options[:session_socket_factory])
           factory.open(@host, @port, options)
         else
           Socket.tcp(@host, @port, @bind_address, nil,


### PR DESCRIPTION
added factory option for set tcp socket class (Defaults to ruby TCPSocket, establishes entrypoints for other event loops with custom socket classes like `celluloid-io` or `em-synchrony`)
