### PR TITLE
Prevent encoding issues building UTF8 buffers (2.9 branch)

### DIFF
--- a/lib/net/ssh/buffer.rb
+++ b/lib/net/ssh/buffer.rb
@@ -182,7 +182,7 @@ module Net; module SSH
       consume!
       data
     end
-      
+
     # Return the next 8 bytes as a 64-bit integer (in network byte order).
     # Returns nil if there are less than 8 bytes remaining to be read in the
     # buffer.
@@ -281,9 +281,10 @@ module Net; module SSH
     # Writes the given data literally into the string. Does not alter the
     # read position. Returns the buffer object.
     def write(*data)
-      data.each { |datum| @content << datum }
+      data.each { |datum| @content << (datum.frozen? ? datum.encode('BINARY') : datum.force_encoding('BINARY')) }
       self
     end
+
 
     # Writes each argument to the buffer as a network-byte-order-encoded
     # 64-bit integer (8 bytes). Does not alter the read position. Returns the

--- a/test/test_buffer.rb
+++ b/test/test_buffer.rb
@@ -26,6 +26,21 @@ class TestBuffer < Test::Unit::TestCase
     assert_equal "\1\0\0\0\2\0\0\0\0\0\0\0\3\0\0\0\0014\1\0\000\000\000\004I\226\002\322something", buffer.to_s
   end
 
+  def test_from_should_build_new_buffer_that_includes_utf8_string_128_characters
+    length = 128
+    # letter A has a 1 byte UTF8 representation
+    buffer = Net::SSH::Buffer.from(:long, 2, :string, 'A' * length)
+    # long of 2 + length 128 as network endian + 128 A's
+    expected = "\x00\x00\x00\x02" + [length].pack('N*') + ("\x41" * length)
+    assert_equal expected, buffer.to_s
+  end
+
+  def test_from_should_build_new_buffer_with_frozen_strings
+    foo = 'foo'.freeze
+    buffer = Net::SSH::Buffer.from(:string, foo)
+    assert_equal "\0\0\0\3foo", buffer.to_s
+  end
+
   def test_from_with_array_argument_should_write_multiple_of_the_given_type
     buffer = Net::SSH::Buffer.from(:byte, [1,2,3,4,5])
     assert_equal "\1\2\3\4\5", buffer.to_s
@@ -33,7 +48,7 @@ class TestBuffer < Test::Unit::TestCase
 
   def test_from_should_measure_bytesize_of_utf_8_string_correctly
     buffer = Net::SSH::Buffer.from(:string, "\u2603") # Snowman is 3 bytes
-    assert_equal "\0\0\0\3\u2603", buffer.to_s
+    assert_equal "\0\0\0\3\u2603".force_encoding('BINARY'), buffer.to_s
   end
 
   def test_read_without_argument_should_read_to_end


### PR DESCRIPTION
- Prior to this change, attempting to send UTF8 commands through
  SSH, or attempting to copy files with UTF8 filenames could fail.
  This was particularly easy to trigger by attempting to execute
  commands that were 128 bytes or longer.
- monkey patch net-ssh gem to allow UTF-8 strings >= 128 bytes
  
  The buffer @content is often built as a UTF-8 string, until the
  point at which it appends data that cannot be encoded as a UTF-8
  sequence.
  
  One case occurs when the call to write_string is made to append a
  string that exceeds 127 bytes in length.  The SSH2 format says
  that strings must be length prefixed, and when the value [128]
  has pack("N*") called against it, the resultant 4 byte network
  order representation does not have a valid UTF-8 equivalent,
  resulting in an ASCII-8BIT / BINARY string.
  
  [127].pack('N*').encode('utf-8')
  => "\u0000\u0000\u0000\u007F"
  
  [128].pack('N*').encode('utf-8')
  Encoding::UndefinedConversionError: "\x80" from ASCII-8BIT to UTF-8
  
  Ruby has a subtle behavior where appending a BINARY string to
  an existing UTF-8 string is allowed and the resultant string
  changes encoding to BINARY.  However, once this has happened,
  the string can no longer have UTF-8 encoded strings appended as
  Ruby will raise an Encoding:CompatibilityError
  
  Appending BINARY to UTF-8 always creates BINARY:
  "foo".encode('utf-8') << [128].pack('N*')
  => "foo\x00\x00\x00\x80"
  
  Appending UTF-8 representable strings to existing strings:
  
  Ruby 2.1.7 keeps the string as its default UTF-8
  "foo" << [127].pack('N*')
  => "foo\u0000\u0000\u0000\u007F"
  
  Ruby 1.9.3 keeps UTF-8 strings as UTF-8
  "foo".encode('utf-8') << [127].pack('N*')
  => "foo\u0000\u0000\u0000\u007F"
  
  Ruby 1.9.3 defaults to US-ASCII which changes it to BINARY
  pry(main)> "foo" << [127].pack('N*')
  => "foo\x00\x00\x00\x7F"
  
  The simple solution is to call force_encoding on UTF-8 strings
  prior to appending them to @content, given it's always OK to
  append ASCII-8BIT / BINARY strings to existing strings, but
  appending UTF-8 to BINARY raises errors.
  
  "\x80".force_encoding('ASCII-8BIT') << "\u16A0"
  Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and UTF-8
  
  force_encoding in this case, will simply translate a valid UTF-8
  string to its BINARY equivalent
  
  "\u16A0".force_encoding('BINARY')
  => "\xE1\x9A\xA0"
  Correct conversion per http://www.fileformat.info/info/unicode/char/16a0/index.htm
