### PR TITLE
gemspec fixes for jruby sepcifics

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -105,7 +105,7 @@ If you don't add the public key, you'll see an error like "Couldn't verify data 
 
 * Ruby 1.8.x is supported up until the net-ssh 2.5.1 release.
 * Ruby 1.9.x is supported up until the net-ssh 2.9.x release.
-* Current net-ssh releases require Ruby 2.0 or later.
+* Current net-ssh releases require Ruby 2.0 or later. JRuby 1.7+ (with `compat.version=2.0` set) or JRuby 9k+
 
 == RUNNING TESTS
 

--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -16,12 +16,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Net::SSH: a pure-Ruby implementation of the SSH2 client protocol. It allows you to write programs that invoke and interact with processes on remote servers, via SSH2.}
   spec.homepage      = "https://github.com/net-ssh/net-ssh"
   spec.license       = "MIT"
-  case RUBY_ENGINE
-  when 'ruby'
-    spec.required_ruby_version = Gem::Requirement.new(">= 2.0")
-  when 'jruby'
-    
-  end
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.0")
 
   spec.extra_rdoc_files = [
     "LICENSE.txt",

--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -16,7 +16,12 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Net::SSH: a pure-Ruby implementation of the SSH2 client protocol. It allows you to write programs that invoke and interact with processes on remote servers, via SSH2.}
   spec.homepage      = "https://github.com/net-ssh/net-ssh"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.0")
+  case RUBY_ENGINE
+  when 'ruby'
+    spec.required_ruby_version = Gem::Requirement.new(">= 2.0")
+  when 'jruby'
+    
+  end
 
   spec.extra_rdoc_files = [
     "LICENSE.txt",
@@ -41,5 +46,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mocha", ">= 1.1.0"
   spec.add_development_dependency("byebug") if RUBY_ENGINE == "ruby"
 
-  spec.add_dependency('jruby-pageant', '>= 1.1.1') if RUBY_PLATFORM == 'jruby'
+  spec.add_dependency('jruby-pageant', '>= 1.1.1') if RUBY_ENGINE == 'jruby'
 end


### PR DESCRIPTION
This gem doesn't install with JRuby because of the required Ruby version. It's looking for MRI > 2.0. This patch removes that dependency for MRI, and also fixes the `jruby-pageant` dependency. `RUBY_PLATFORM` returns 'java' for JRuby, so I changed it to `RUBY_ENGINE`.