### PR TITLE
Support HTTP Proxy on SSL socket

### DIFF
--- a/lib/net/ssh/proxy/http.rb
+++ b/lib/net/ssh/proxy/http.rb
@@ -49,8 +49,7 @@ module Net; module SSH; module Proxy
     # Return a new socket connected to the given host and port via the
     # proxy that was requested when the socket factory was instantiated.
     def open(host, port, connection_options)
-      socket = Socket.tcp(proxy_host, proxy_port, nil, nil,
-                          connect_timeout: connection_options[:timeout])
+      socket = establish_connection(connection_options[:timeout])
       socket.write "CONNECT #{host}:#{port} HTTP/1.0\r\n"
 
       if options[:user]
@@ -68,7 +67,12 @@ module Net; module SSH; module Proxy
       raise ConnectError, resp.inspect
     end
 
-    private
+    protected
+
+      def establish_connection(connect_timeout)
+        Socket.tcp(proxy_host, proxy_port, nil, nil,
+                   connect_timeout: connect_timeout)
+      end
 
       def parse_response(socket)
         version, code, reason = socket.gets.chomp.split(/ /, 3)
@@ -89,7 +93,6 @@ module Net; module SSH; module Proxy
                  :headers => headers,
                  :body => body }
       end
-
   end
 
 end; end; end

--- a/lib/net/ssh/proxy/https.rb
+++ b/lib/net/ssh/proxy/https.rb
@@ -1,0 +1,49 @@
+require 'socket'
+require 'openssl'
+require 'net/ssh/proxy/errors'
+require 'net/ssh/proxy/http'
+
+module Net; module SSH; module Proxy
+
+  # A specialization of the HTTP proxy which encrypts the whole connection
+  # using OpenSSL. This has the advantage that proxy authentication
+  # information is not sent in plaintext.
+  class HTTPS < HTTP
+
+    # Create a new socket factory that tunnels via the given host and
+    # port. The +options+ parameter is a hash of additional settings that
+    # can be used to tweak this proxy connection. In addition to the options
+    # taken by Net::SSH::Proxy::HTTP it supports:
+    #
+    # * :ssl_context => the SSL configuration to use for the connection
+    def initialize(proxy_host, proxy_port=80, options={})
+      @ssl_context = options.delete(:ssl_context) ||
+                       OpenSSL::SSL::SSLContext.new
+      super(proxy_host, proxy_port, options)
+    end
+
+    protected
+
+      # Shim to make OpenSSL::SSL::SSLSocket behave like a regular TCPSocket
+      # for all intents and purposes of Net::SSH::BufferedIo
+      module SSLSocketCompatibility
+        def self.extended(object) #:nodoc:
+          object.define_singleton_method(:recv, object.method(:sysread))
+          object.sync_close = true
+        end
+
+        def send(data, _opts)
+          syswrite(data)
+        end
+      end
+
+      def establish_connection(connect_timeout)
+        plain_socket = super(connect_timeout)
+        OpenSSL::SSL::SSLSocket.new(plain_socket, @ssl_context).tap do |socket|
+          socket.extend(SSLSocketCompatibility)
+          socket.connect
+        end
+      end
+  end
+
+end; end; end


### PR DESCRIPTION
Since the HTTP Proxy only supports BASIC authentication, this adds the required infrastructure to connect to a SSL-enabled server. I kept the changes as local as possible and ran `rubocop` to check for style consistency.

I could not locate any tests for the HTTP proxy so I wasn't sure where to add one for HTTPS :confused: 