### PR TITLE
UTF-8 buffer building encoding fixes - backport of #407

### DIFF
--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -147,7 +147,7 @@ module Net
 
           if info[:key]
             return Net::SSH::Buffer.from(:string, identity.ssh_type,
-              :string, info[:key].ssh_do_sign(data.to_s)).to_s
+              :mstring, info[:key].ssh_do_sign(data.to_s)).to_s
           end
 
           if info[:from] == :agent

--- a/lib/net/ssh/buffer.rb
+++ b/lib/net/ssh/buffer.rb
@@ -34,6 +34,7 @@ module Net; module SSH
     # * :long => write a 4-byte integer (#write_long)
     # * :byte => write a single byte (#write_byte)
     # * :string => write a 4-byte length followed by character data (#write_string)
+    # * :mstring => same as string, but caller cannot resuse the string, avoids potential duplication (#write_moved)
     # * :bool => write a single byte, interpreted as a boolean (#write_bool)
     # * :bignum => write an SSH-encoded bignum (#write_bignum)
     # * :key => write an SSH-encoded key value (#write_key)
@@ -285,6 +286,13 @@ module Net; module SSH
       self
     end
 
+    # Optimized version of write where the caller gives up ownership of string
+    # to the method. This way we can mutate the string.
+    def write_moved(string)
+      @content << string.force_encoding('BINARY')
+      self
+    end
+
     # Writes each argument to the buffer as a network-byte-order-encoded
     # 64-bit integer (8 bytes). Does not alter the read position. Returns the
     # buffer object.
@@ -320,6 +328,19 @@ module Net; module SSH
         s = string.to_s
         write_long(s.bytesize)
         write(s)
+      end
+      self
+    end
+
+    # Writes each argument to the buffer as an SSH2-encoded string. Each
+    # string is prefixed by its length, encoded as a 4-byte long integer.
+    # Does not alter the read position. Returns the buffer object.
+    # Might alter arguments see write_moved
+    def write_mstring(*text)
+      text.each do |string|
+        s = string.to_s
+        write_long(s.bytesize)
+        write_moved(s)
       end
       self
     end

--- a/lib/net/ssh/buffer.rb
+++ b/lib/net/ssh/buffer.rb
@@ -182,7 +182,7 @@ module Net; module SSH
       consume!
       data
     end
-      
+
     # Return the next 8 bytes as a 64-bit integer (in network byte order).
     # Returns nil if there are less than 8 bytes remaining to be read in the
     # buffer.
@@ -281,7 +281,7 @@ module Net; module SSH
     # Writes the given data literally into the string. Does not alter the
     # read position. Returns the buffer object.
     def write(*data)
-      data.each { |datum| @content << datum }
+      data.each { |datum| @content << datum.dup.force_encoding('BINARY') }
       self
     end
 

--- a/lib/net/ssh/connection/session.rb
+++ b/lib/net/ssh/connection/session.rb
@@ -368,6 +368,7 @@ module Net; module SSH; module Connection
       channel.wait
 
       channel[:result] ||= "" unless block
+      channel[:result] &&= channel[:result].force_encoding("UTF-8") unless block
 
       return channel[:result]
     end

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -295,8 +295,8 @@ module Net; module SSH; module Transport
 
         Net::SSH::Buffer.from(:byte, KEXINIT,
           :long, [rand(0xFFFFFFFF), rand(0xFFFFFFFF), rand(0xFFFFFFFF), rand(0xFFFFFFFF)],
-          :string, [kex, host_key, encryption, encryption, hmac, hmac],
-          :string, [compression, compression, language, language],
+          :mstring, [kex, host_key, encryption, encryption, hmac, hmac],
+          :mstring, [compression, compression, language, language],
           :bool, false, :long, 0)
       end
 

--- a/lib/net/ssh/transport/kex/ecdh_sha2_nistp256.rb
+++ b/lib/net/ssh/transport/kex/ecdh_sha2_nistp256.rb
@@ -57,7 +57,7 @@ module Net; module SSH; module Transport; module Kex
       # send the KEXECDH_INIT message
       ## byte     SSH_MSG_KEX_ECDH_INIT
       ## string   Q_C, client's ephemeral public key octet string
-      buffer = Net::SSH::Buffer.from(:byte, init, :string, ecdh.public_key.to_bn.to_s(2))
+      buffer = Net::SSH::Buffer.from(:byte, init, :mstring, ecdh.public_key.to_bn.to_s(2))
       connection.send_message(buffer)
 
       # expect the following KEXECDH_REPLY message

--- a/lib/net/ssh/transport/openssl.rb
+++ b/lib/net/ssh/transport/openssl.rb
@@ -185,7 +185,7 @@ module OpenSSL
         def to_blob
           @blob ||= Net::SSH::Buffer.from(:string, ssh_type,
                                           :string, CurveNameAliasInv[self.group.curve_name],
-                                          :string, self.public_key.to_bn.to_s(2)).to_s
+                                          :mstring, self.public_key.to_bn.to_s(2)).to_s
           @blob
         end
 

--- a/test/integration/test_encoding.rb
+++ b/test/integration/test_encoding.rb
@@ -1,0 +1,23 @@
+require_relative 'common'
+require 'fileutils'
+require 'tmpdir'
+
+require 'net/ssh'
+
+class TestEncoding < NetSSHTest
+  def test_unicode_character
+    ret = Net::SSH.start("localhost", "net_ssh_1", password: 'foopwd') do |ssh|
+      ssh.exec! "echo \"hello from:$USER\" \u2603"
+    end
+    assert_equal ret, "hello from:net_ssh_1 \u2603\n"
+  end
+
+  def test_long_command_with_unicode_in_it
+    string = "eeeeeeeeeeeeeeeeeeeeeeeeeewwowowowìeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    command = "echo \"#{string}\""
+    ret = Net::SSH.start("localhost", "net_ssh_1", password: 'foopwd') do |ssh|
+      ssh.exec! command
+    end
+    assert_equal ret, "#{string}\n"
+  end
+end

--- a/test/test_buffer.rb
+++ b/test/test_buffer.rb
@@ -26,6 +26,21 @@ class TestBuffer < Test::Unit::TestCase
     assert_equal "\1\0\0\0\2\0\0\0\0\0\0\0\3\0\0\0\0014\1\0\000\000\000\004I\226\002\322something", buffer.to_s
   end
 
+  def test_from_should_build_new_buffer_that_includes_utf8_string_128_characters
+    length = 128
+    # letter A has a 1 byte UTF8 representation
+    buffer = Net::SSH::Buffer.from(:long, 2, :string, 'A' * length)
+    # long of 2 + length 128 as network endian + 128 A's
+    expected = "\x00\x00\x00\x02" + [length].pack('N*') + ("\x41" * length)
+    assert_equal expected, buffer.to_s
+  end
+
+  def test_from_should_build_new_buffer_with_frozen_strings
+    foo = 'foo'.freeze
+    buffer = Net::SSH::Buffer.from(:string, foo)
+    assert_equal "\0\0\0\3foo", buffer.to_s
+  end
+
   def test_from_with_array_argument_should_write_multiple_of_the_given_type
     buffer = Net::SSH::Buffer.from(:byte, [1,2,3,4,5])
     assert_equal "\1\2\3\4\5", buffer.to_s
@@ -33,7 +48,7 @@ class TestBuffer < Test::Unit::TestCase
 
   def test_from_should_measure_bytesize_of_utf_8_string_correctly
     buffer = Net::SSH::Buffer.from(:string, "\u2603") # Snowman is 3 bytes
-    assert_equal "\0\0\0\3\u2603", buffer.to_s
+    assert_equal "\0\0\0\3\u2603".force_encoding('BINARY'), buffer.to_s
   end
 
   def test_read_without_argument_should_read_to_end

--- a/test/test_buffer.rb
+++ b/test/test_buffer.rb
@@ -41,6 +41,19 @@ class TestBuffer < Test::Unit::TestCase
     assert_equal "\0\0\0\3foo", buffer.to_s
   end
 
+  def test_from_should_build_new_buffer_with_utf8_frozen_strings
+    foo = "\u2603".freeze
+    buffer = Net::SSH::Buffer.from(:string, foo)
+    assert_equal "\0\0\0\3\u2603".force_encoding('BINARY'), buffer.to_s
+  end
+
+  def test_from_should_not_change_regular_paramaters
+    foo = "\u2603"
+    buffer = Net::SSH::Buffer.from(:string, foo)
+    assert_equal "\0\0\0\3\u2603".force_encoding('BINARY'), buffer.to_s
+    assert_equal foo.encoding.to_s, "UTF-8"
+  end
+
   def test_from_with_array_argument_should_write_multiple_of_the_given_type
     buffer = Net::SSH::Buffer.from(:byte, [1,2,3,4,5])
     assert_equal "\1\2\3\4\5", buffer.to_s


### PR DESCRIPTION
This is a follow-on to backport #407 to the 3.x release branch.  This follows on from the discussion in #394 / #395 / #396 / #397 
