### PR TITLE
detach proxycommand processes to avoid them becoming zombies

### DIFF
--- a/lib/net/ssh/proxy/command.rb
+++ b/lib/net/ssh/proxy/command.rb
@@ -56,6 +56,7 @@ module Net; module SSH; module Proxy
       }
       begin
         io = IO.popen(command_line, "r+")
+        Process.detach(io.pid)
         if result = Net::SSH::Compat.io_select([io], nil, [io], 60)
           if result.last.any?
             raise "command failed"


### PR DESCRIPTION
In Unix/Linux/etc, you must call one of the wait methods (eg. Process.wait) to retrieve the exit code of a terminated process.  Until you do this, the process sits in the process table as a zombie process, and over time as a number of connections get made and closed through a proxycommand-style proxy they pile up like this:

$ pstree|grep -F '(ssh)'|wc -l
      12
$ pstree|grep -F '(ssh)'|wc -l
      15
$ pstree|grep -F '(ssh)'|wc -l
      28

Since we have no interest in the exit code of the proxycommand process (we have never checked it before), we can detach the process instead, so that it doesn't becomes a zombie (technically the PID 1 process waits for it instead).

We still have open IO handles to the process, so there's no change to how long that process lives.