### PR TITLE
dont raise from exec if server closes transport after

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,8 @@
 === 4.0.0.beta4
 
+ * Don't raise from exec if server closes transport just after channel close [Miklós Fazekas, #450]
  * Removed java_pageant, as jruby should be using regular pagent impl [Miklós Fazekas, ]
- * Use SSH_AUTH_SOCK if possible on windows (cygwin) [Miklós Fazekas, Martin Dürst, #365]
+ * Use SSH_AUTH_SOCK if possible on windows (cygwin) [Miklós Fazekas, Martin Dürst, #365, #361]
  * HTTPS proxy support [Marcus Ilgner, #432]
  * Supports ruby 2.4.0.dev new exception type from OpenSSL::PKey.read
 

--- a/test/integration/test_channel.rb
+++ b/test/integration/test_channel.rb
@@ -30,6 +30,64 @@ class TestChannel < NetSSHTest
     end
   end
 
+  def ssh_exec(ssh, command, channel_success_handler, &block)
+    ssh.open_channel do |channel|
+      channel.exec(command) do |_ch, success|
+        raise "could not execute command: #{command.inspect}" unless success
+        channel_success_handler.call
+        channel.on_data do |ch2, data|
+          yield(ch2, :stdout, data)
+        end
+
+        channel.on_extended_data do |ch2, _type, data|
+          yield(ch2, :stderr, data)
+        end
+      end
+    end
+  end
+
+  def test_transport_close_before_channel_close_should_raise
+    setup_ssh_env do
+      proxy = Net::SSH::Proxy::Command.new("/bin/nc localhost 22")
+      res = nil
+      Net::SSH.start(*ssh_start_params(proxy: proxy)) do |ssh|
+        chanell_success_handler = lambda do
+          sleep(0.1)
+          system("killall /bin/nc")
+        end
+        channel = ssh_exec(ssh, "echo Begin ; sleep 100 ; echo End", chanell_success_handler) do |ch, _type, data|
+          ch[:result] ||= ""
+          ch[:result] << data
+        end
+        assert_raises(IOError) { channel.wait }
+        res = channel[:result]
+        assert_equal(res, "Begin\n")
+      end
+      assert_equal(res, "Begin\n")
+    end
+  end
+
+  def test_transport_close_after_channel_close_should_not_raise
+    setup_ssh_env do
+      proxy = Net::SSH::Proxy::Command.new("/bin/nc localhost 22")
+      res = nil
+      Net::SSH.start(*ssh_start_params(proxy: proxy)) do |ssh|
+        chanell_success_handler = lambda do
+          sleep(0.1)
+          system("killall /bin/nc")
+        end
+        channel = ssh_exec(ssh, "echo Hello!", chanell_success_handler) do |ch, _type, data|
+          ch[:result] ||= ""
+          ch[:result] << data
+        end
+        channel.wait
+        res = channel[:result]
+        assert_equal(res, "Hello!\n")
+      end
+      assert_equal(res, "Hello!\n")
+    end
+  end
+
   def test_transport_close_should_remote_close_channels
     setup_ssh_env do
       Net::SSH.start(*ssh_start_params) do |ssh|
@@ -46,4 +104,5 @@ class TestChannel < NetSSHTest
       end
     end
   end
+
 end


### PR DESCRIPTION
When we have an exec and server closes transports  just afer sucessfull response to exec then we should not raise from the exec.

Fixes: #429 