### PR TITLE
As a special case, ignore nil :password options

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -209,6 +209,8 @@ module Net
 
       assign_defaults(options)
 
+      options.delete(:password) if options.has_key?(:password) && options[:password].nil?
+
       if options.values.include? nil
         nil_options = options.keys.select { |k| options[k].nil? }
         raise ArgumentError, "Value(s) have been set to nil: #{nil_options.join(', ')}"

--- a/test/start/test_options.rb
+++ b/test/start/test_options.rb
@@ -60,6 +60,13 @@ module NetSSH
       end
     end
 
+    def test_constructor_should_not_reject_nil_password_options_for_cap_v2_compatibility
+      assert_nothing_raised do
+        options = { :password => nil }
+        Net::SSH.start('localhost', 'testuser', options)
+      end
+    end
+
     def test_constructor_should_reject_invalid_options
       assert_raises(ArgumentError) do
         options = { :some_invalid_option => "some setting" }


### PR DESCRIPTION
To avoid breaking capistrano v2, which has the code mentioned on #357.