### PR TITLE
Correctly parse '+' in config files

### DIFF
--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -212,35 +212,8 @@ module Net; module SSH; module Transport
       def prepare_preferred_algorithms!
         options[:compression] = %w(zlib@openssh.com zlib) if options[:compression] == true
 
-        ALGORITHMS.each do |algorithm, list|
-          # apply the preferred algorithm order, if any
-          if options[algorithm]
-            option = Array(options[algorithm]).compact.uniq
-
-            if option.first && option.first.start_with?('+')
-              algorithms[algorithm] = list.dup
-              algorithms[algorithm] << option.first[1..-1]
-              algorithms[algorithm].concat(option[1..-1])
-              algorithms[algorithm].uniq!
-            else
-              algorithms[algorithm] = option
-
-              if options[:append_all_supported_algorithms]
-                list.each { |name| algorithms[algorithm] << name unless algorithms[algorithm].include?(name) }
-              end
-            end
-
-            unsupported = []
-            algorithms[algorithm].select! do |name|
-              supported = ALGORITHMS[algorithm].include?(name)
-              unsupported << name unless supported
-              supported
-            end
-
-            lwarn { "unsupported #{algorithm} algorithm: `#{unsupported}'" } unless unsupported.empty?
-          else
-            algorithms[algorithm] = list.dup
-          end
+        ALGORITHMS.each do |algorithm, supported|
+          algorithms[algorithm] = compose_algorithm_list(supported, options[algorithm], options[:append_all_supported_algorithms])
         end
 
         # for convention, make sure our list has the same keys as the server
@@ -262,6 +235,38 @@ module Net; module SSH; module Transport
           end
           algorithms[:host_key] = host_keys
         end
+      end
+
+      # Composes the list of algorithms by taking supported algorithms and matching with supplied options.
+      def compose_algorithm_list(supported, option, append_all_supported_algorithms = false)
+        return supported.dup unless option
+
+        list = []
+        option = Array(option).compact.uniq
+
+        if option.first && option.first.start_with?('+')
+          list = supported.dup
+          list << option.first[1..-1]
+          list.concat(option[1..-1])
+          list.uniq!
+        else
+          list = option
+
+          if append_all_supported_algorithms
+            supported.each { |name| list << name unless list.include?(name) }
+          end
+        end
+
+        unsupported = []
+        list.select! do |name|
+          is_supported = supported.include?(name)
+          unsupported << name unless is_supported
+          is_supported
+        end
+
+        lwarn { "unsupported #{algorithm} algorithm: `#{unsupported}'" } unless unsupported.empty?
+
+        list
       end
 
       # Parses a KEXINIT packet from the server.

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -215,15 +215,15 @@ module Net; module SSH; module Transport
         ALGORITHMS.each do |algorithm, list|
           # apply the preferred algorithm order, if any
           if options[algorithm]
-            optionals = Array(options[algorithm]).compact.uniq
+            option = Array(options[algorithm]).compact.uniq
 
-            if optionals.first.start_with?('+')
+            if option.first.start_with?('+')
               algorithms[algorithm] = list.dup
-              algorithms[algorithm] << optionals.first[1..-1]
-              algorithms[algorithm].concat(optionals[1..-1])
+              algorithms[algorithm] << option.first[1..-1]
+              algorithms[algorithm].concat(option[1..-1])
               algorithms[algorithm].uniq!
             else
-              algorithms[algorithm] = optionals
+              algorithms[algorithm] = option
 
               if options[:append_all_supported_algorithms]
                 list.each { |name| algorithms[algorithm] << name unless algorithms[algorithm].include?(name) }

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -217,7 +217,7 @@ module Net; module SSH; module Transport
           if options[algorithm]
             option = Array(options[algorithm]).compact.uniq
 
-            if option.first.start_with?('+')
+            if option.first && option.first.start_with?('+')
               algorithms[algorithm] = list.dup
               algorithms[algorithm] << option.first[1..-1]
               algorithms[algorithm].concat(option[1..-1])

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -225,18 +225,19 @@ module Net; module SSH; module Transport
             else
               algorithms[algorithm] = optionals
 
-              unsupported = []
-              algorithms[algorithm].select! do |name|
-                supported = ALGORITHMS[algorithm].include?(name)
-                unsupported << name unless supported
-                supported
-              end
-              lwarn { "unsupported #{algorithm} algorithm: `#{unsupported}'" } unless unsupported.empty?
-
               if options[:append_all_supported_algorithms]
                 list.each { |name| algorithms[algorithm] << name unless algorithms[algorithm].include?(name) }
               end
             end
+
+            unsupported = []
+            algorithms[algorithm].select! do |name|
+              supported = ALGORITHMS[algorithm].include?(name)
+              unsupported << name unless supported
+              supported
+            end
+
+            lwarn { "unsupported #{algorithm} algorithm: `#{unsupported}'" } unless unsupported.empty?
           else
             algorithms[algorithm] = list.dup
           end

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -131,7 +131,7 @@ module Transport
 
     def test_constructor_with_append_to_default
       default_host_keys = Net::SSH::Transport::Algorithms::ALGORITHMS[:host_key]
-      assert_equal default_host_keys + ["ecdsa-sha2-nistp256-cert-v01@openssh.com"], algorithms(host_key: '+ecdsa-sha2-nistp256-cert-v01@openssh.com')[:host_key]
+      assert_equal default_host_keys, algorithms(host_key: '+ssh-dss')[:host_key]
     end
 
     def test_initial_state_should_be_neither_pending_nor_initialized

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -129,6 +129,11 @@ module Transport
       assert_equal %w(none zlib zlib@openssh.com), algorithms(compression: %w(bogus none zlib), append_all_supported_algorithms: true)[:compression]
     end
 
+    def test_constructor_with_append_to_default
+      default_host_keys = Net::SSH::Transport::Algorithms::ALGORITHMS[:host_key]
+      assert_equal default_host_keys + ["ecdsa-sha2-nistp256-cert-v01@openssh.com"], algorithms(host_key: '+ecdsa-sha2-nistp256-cert-v01@openssh.com')[:host_key]
+    end
+
     def test_initial_state_should_be_neither_pending_nor_initialized
       assert !algorithms.pending?
       assert !algorithms.initialized?


### PR DESCRIPTION
Because I recently was also hit by https://github.com/net-ssh/net-ssh/issues/314, I wanted to help to get this feature into `Net::SSH`.

Two things I'm not totally sure about:

- when running `ssh -Q key` on my machine, I got a couple of algorithms that are not in the list of default ones. I guess that's fine, and that's also why I skipped validation for the algorithms added via `+` to the list
- I failed to find a reference (or lookup the source code of other implementations), but I think from the wording the `HostkeyAlgorithms` should only feature a single `+` sign, so that the whole line is added (vs a plus sign in front of each algorithm)

Let me know what you think - happy to update the PR!

Closes: #470 