### PR TITLE
Support for `Include` directive

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -77,7 +77,7 @@ module Net; module SSH
         return settings unless File.readable?(file)
 
         globals = {}
-        matched_host = nil
+        host_matched = false
         seen_host = false
         IO.foreach(file) do |line|
           next if line =~ /^\s*(?:#.*)?$/
@@ -108,12 +108,12 @@ module Net; module SSH
 
             # Check for negative patterns first. If the host matches, that overrules any other positive match.
             # The host substring code is used to strip out the starting "!" so the regexp will be correct.
-            negative_match = negative_hosts.select { |h| host =~ pattern2regex(h[1..-1]) }.first
+            negative_matched = negative_hosts.any? { |h| host =~ pattern2regex(h[1..-1]) }
 
-            if negative_match
-              matched_host = nil
+            if negative_matched
+              host_matched = false
             else
-              matched_host = positive_hosts.select { |h| host =~ pattern2regex(h) }.first
+              host_matched = positive_hosts.any? { |h| host =~ pattern2regex(h) }
             end
 
             seen_host = true
@@ -129,7 +129,7 @@ module Net; module SSH
             else
               globals[key] = value unless settings.key?(key)
             end
-          elsif !matched_host.nil?
+          elsif host_matched
             case key
             when 'identityfile'
               (settings[key] ||= []) << value

--- a/test/configs/conf.d/subset2
+++ b/test/configs/conf.d/subset2
@@ -1,0 +1,2 @@
+User foo
+IdentitiesOnly yes

--- a/test/configs/conf.d/subset3
+++ b/test/configs/conf.d/subset3
@@ -1,0 +1,1 @@
+HostName example.com

--- a/test/configs/include
+++ b/test/configs/include
@@ -1,0 +1,4 @@
+Include subset1
+
+Host xyz
+  Include conf.d/*

--- a/test/configs/subset1
+++ b/test/configs/subset1
@@ -1,0 +1,2 @@
+IdentityFile ~/.ssh/id.pem
+Port 2345

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -260,6 +260,16 @@ class TestConfig < NetSSHTest
     assert net_ssh[:proxy]
   end
 
+  def test_load_with_include_keyword
+    config = Net::SSH::Config.load(config(:include), "xyz")
+    net_ssh = Net::SSH::Config.translate(config)
+    assert_equal 'example.com', net_ssh[:host_name]
+    assert_equal 'foo', net_ssh[:user]
+    assert_equal 2345, net_ssh[:port]
+    assert net_ssh[:keys_only]
+    assert_equal %w(~/.ssh/id.pem), net_ssh[:keys]
+  end
+
   private
 
     def with_home_env(value,&block)


### PR DESCRIPTION
Net::SSH supports for `Include` keyword since OpenSSH added an include directive for ssh_config on v7.3.
Ref: https://www.openssh.com/txt/release-7.3

Include directives are very useful for breaking down a large ssh_config into smaller files.

```
$ man ssh_config
...
     Include
             Include the specified configuration file(s).  Multiple pathnames may be
             specified and each pathname may contain glob(3) wildcards and, for user
             configurations, shell-like ``~'' references to user home directories.
             Files without absolute paths are assumed to be in ~/.ssh if included in a
             user configuration file or /etc/ssh if included from the system configu-
             ration file.  Include directive may appear inside a Match or Host block
             to perform conditional inclusion.
...
```