### PR TITLE
Allow rbnacl 4 and better description on what to install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,15 +32,15 @@ matrix:
 install:
   - export JRUBY_OPTS='--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -Xcext.enabled=false -J-Xss2m -Xcompile.invokedynamic=false'
   - sudo pip install ansible
-  - gem install bundler -v "= 1.11.2"
-  - bundle _1.11.2_ install
-  - BUNDLE_GEMFILE=./Gemfile.norbnacl bundle _1.11.2_ install
+  - gem install bundler -v "= 1.13.7"
+  - bundle _1.13.7_ install
+  - BUNDLE_GEMFILE=./Gemfile.norbnacl bundle _1.13.7_ install
   - sudo ansible-galaxy install rvm_io.ruby
   - sudo chown -R travis:travis /home/travis/.ansible
   - ansible-playbook ./test/integration/playbook.yml -i "localhost," --become -c local -e 'no_rvm=true' -e 'myuser=travis' -e 'mygroup=travis' -e 'homedir=/home/travis'
 
 script:
-  - bundle _1.11.2_ exec rake test
-  - BUNDLE_GEMFILE=./Gemfile.norbnacl bundle _1.11.2_ exec rake test
-  - bundle _1.11.2_ exec rake test_test
-  - bundle _1.11.2_ exec rubocop
+  - bundle _1.13.7_ exec rake test
+  - BUNDLE_GEMFILE=./Gemfile.norbnacl bundle _1.13.7_ exec rake test
+  - bundle _1.13.7_ exec rake test_test
+  - bundle _1.13.7_ exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,10 @@ if !Gem.win_platform? && RUBY_ENGINE == "mri"
   gem 'byebug', group: [:development, :test]
 end
 
+if (Gem::Version.new(RUBY_VERSION) <=> Gem::Version.new("2.2.6")) < 0
+  gem 'rbnacl', '< 4.0'
+end
+
 if ENV["CI"]
   gem 'codecov', require: false, group: :test
   gem 'simplecov', require: false, group: :test

--- a/Gemfile.norbnacl.lock
+++ b/Gemfile.norbnacl.lock
@@ -1,29 +1,29 @@
 PATH
   remote: .
   specs:
-    net-ssh (4.0.0.rc1)
+    net-ssh (4.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.2.0)
+    ast (2.3.0)
     metaclass (0.0.4)
-    minitest (5.8.4)
-    mocha (1.1.0)
+    minitest (5.10.1)
+    mocha (1.2.1)
       metaclass (~> 0.0.1)
-    parser (2.3.1.0)
+    parser (2.3.3.1)
       ast (~> 2.2)
     powerpack (0.1.1)
     rainbow (2.1.0)
-    rake (11.1.2)
-    rubocop (0.39.0)
-      parser (>= 2.3.0.7, < 3.0)
+    rake (12.0.0)
+    rubocop (0.46.0)
+      parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.0)
-    unicode-display_width (1.0.5)
+    ruby-progressbar (1.8.1)
+    unicode-display_width (1.1.2)
 
 PLATFORMS
   ruby
@@ -31,11 +31,11 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.11)
-  minitest (~> 5.0)
-  mocha (>= 1.1.0)
+  minitest (~> 5.10)
+  mocha (>= 1.2.1)
   net-ssh!
-  rake (~> 11.1)
-  rubocop (~> 0.39.0)
+  rake (~> 12.0)
+  rubocop (~> 0.46.0)
 
 BUNDLED WITH
    1.13.6

--- a/lib/net/ssh/authentication/ed25519.rb
+++ b/lib/net/ssh/authentication/ed25519.rb
@@ -1,6 +1,5 @@
-gem 'rbnacl-libsodium', '>= 1.0.10'
-gem 'rbnacl', '>= 3.2.0', '< 4.0'
-gem 'bcrypt_pbkdf', '~> 1.0.0' unless RUBY_PLATFORM == "java"
+gem 'rbnacl', '>= 3.2.0', '< 5.0'
+gem 'bcrypt_pbkdf', '~> 1.0' unless RUBY_PLATFORM == "java"
 
 require 'rbnacl/libsodium'
 require 'rbnacl'

--- a/lib/net/ssh/authentication/ed25519_loader.rb
+++ b/lib/net/ssh/authentication/ed25519_loader.rb
@@ -1,7 +1,7 @@
 module Net; module SSH; module Authentication
 
 # Loads ED25519 support which requires optinal dependecies like
-# rbnacl-libsodium, rbnacl, bcrypt_pbkdf
+# rbnacl, bcrypt_pbkdf
 module ED25519Loader
 
 begin
@@ -14,7 +14,17 @@ rescue LoadError => e
 end
 
 def self.raiseUnlessLoaded(message)
-  raise NotImplementedError, "#{message} -- see #{ERROR}" unless LOADED
+  description = dependenciesRequiredForED25519 if ERROR.is_a?(Gem::LoadError)
+  description << "#{ERROR.class} : \"#{ERROR.message}\"\n" if ERROR
+  raise NotImplementedError, "#{message}\n#{description}" unless LOADED
+end
+
+def self.dependenciesRequiredForED25519
+  result = "net-ssh requires the following gems for ed25519 support:\n"
+  result << " * rbnacl (>= 3.2, < 5.0)\n"
+  result << " * rbnacl-libsodium, if your system doesn't have libsodium installed.\n"
+  result << " * bcrypt_pbkdf (>= 1.0, < 2.0)\n" unless RUBY_PLATFORM == "java"
+  result << "See https://github.com/net-ssh/net-ssh/issues/478 for more information\n"
 end
 
 end

--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   unless ENV['NET_SSH_NO_RBNACL']
-    spec.add_development_dependency("rbnacl-libsodium", "~> 1.0.10")
-    spec.add_development_dependency("rbnacl", "~> 3.4.0")
-    spec.add_development_dependency("bcrypt_pbkdf", "~> 1.0.0") unless RUBY_PLATFORM == "java"
+    spec.add_development_dependency("rbnacl-libsodium", "~> 1.0.11")
+    spec.add_development_dependency("rbnacl", ['>= 3.2.0','< 5.0'])
+    spec.add_development_dependency("bcrypt_pbkdf", "~> 1.0") unless RUBY_PLATFORM == "java"
   end
 
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
Closes: #476

Improves error message if required dependencies not yet installed.

```sh
$ BUNDLE_GEMFILE=./Gemfile.norbnacl bundle exec irb
2.3.0 :001 > require 'net/ssh'
 => true 
2.3.0 :002 > Net::SSH.start('localhost','foo', {keys: 'test/keys/id_ed25519_pwd'})
NotImplementedError: unsupported key type `ssh-ed25519'
net-ssh requires the following gems for ed25519 support:
 * rbnacl (>= 3.2, < 5.0)
 * rbnacl-libsodium, if your system doesn't have libsodium installed.
 * bcrypt_pbkdf (>= 1.0, < 2.0)
See https://github.com/net-ssh/net-ssh/issues/478 for more information
Gem::LoadError : "rbnacl is not part of the bundle. Add it to Gemfile."
```