### PR TITLE
Always use Net::SSH::Config.expandable_default_files

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -262,7 +262,7 @@ module Net
     # See Net::SSH::Config for the full description of all supported options.
     def self.configuration_for(host, use_ssh_config)
       files = case use_ssh_config
-        when true then Net::SSH::Config.default_files
+        when true then Net::SSH::Config.expandable_default_files
         when false, nil then return {}
         else Array(use_ssh_config)
         end

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -248,18 +248,19 @@ module Net; module SSH
         merge_challenge_response_with_keyboard_interactive(ret)
       end
 
-      private
-
-        def expandable_default_files
-          default_files.keep_if do |path|
-            begin
-              File.expand_path(path)
-              true
-            rescue ArgumentError
-              false
-            end
+      # Filters default_files down to the files that are expandable.
+      def expandable_default_files
+        default_files.keep_if do |path|
+          begin
+            File.expand_path(path)
+            true
+          rescue ArgumentError
+            false
           end
         end
+      end
+
+      private
 
         # Converts an ssh_config pattern into a regex for matching against
         # host names.

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -210,6 +210,14 @@ class TestConfig < NetSSHTest
     assert_equal %w(hostbased keyboard-interactive none password publickey), config[:auth_methods].sort
   end
 
+  def test_configuration_for_when_HOME_is_null_should_not_raise
+    with_home_env(nil) do
+      with_restored_default_files do
+        Net::SSH.configuration_for("test.host", true)
+      end
+    end
+  end
+
   def test_config_for_when_HOME_is_null_should_not_raise
     with_home_env(nil) do
       with_restored_default_files do


### PR DESCRIPTION
#351 partially fixed the expandable default files problem, but
Net::SSH.configuration_for still passes in the unfiltered default files,
bypassing the filtered defaults. This change exposes the
`expandable_default_files` method to allow Net::SSH to fall back to it,
to avoid the error:
```
ArgumentError: couldn't find HOME environment -- expanding `~'
```