### PR TITLE
Fixed string interpolation issue (#483)

### DIFF
--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -263,7 +263,7 @@ module Net; module SSH; module Transport
           is_supported
         end
 
-        lwarn { "unsupported #{algorithm} algorithm: `#{unsupported}'" } unless unsupported.empty?
+        lwarn { %(unsupported algorithm: `#{unsupported}') } unless unsupported.empty?
 
         list
       end


### PR DESCRIPTION
Removed the interpolation of a missing variable which would raise a `NameError` when a `Session` or `Algorithms` instance had a valid `logger` object regardless of log level.

Added a test that exercises the method in question, including an assertion that the output log includes the expected string.