### PR TITLE
Fix libsodium errors

### DIFF
--- a/lib/net/ssh/authentication/ed25519.rb
+++ b/lib/net/ssh/authentication/ed25519.rb
@@ -1,7 +1,12 @@
 gem 'rbnacl', '>= 3.2.0', '< 5.0'
 gem 'bcrypt_pbkdf', '~> 1.0' unless RUBY_PLATFORM == "java"
 
-require 'rbnacl/libsodium'
+begin
+  require 'rbnacl/libsodium'
+rescue LoadError => e
+  raise LoadError.new(e.message + ', your system does not provide libsodium, install the rbnacl-libsodium gem')
+end
+
 require 'rbnacl'
 require 'rbnacl/signatures/ed25519/verify_key'
 require 'rbnacl/signatures/ed25519/signing_key'

--- a/lib/net/ssh/authentication/ed25519_loader.rb
+++ b/lib/net/ssh/authentication/ed25519_loader.rb
@@ -14,7 +14,7 @@ rescue LoadError => e
 end
 
 def self.raiseUnlessLoaded(message)
-  description = dependenciesRequiredForED25519 if ERROR.is_a?(Gem::LoadError)
+  description = ERROR.is_a?(Gem::LoadError) ? dependenciesRequiredForED25519 : ''
   description << "#{ERROR.class} : \"#{ERROR.message}\"\n" if ERROR
   raise NotImplementedError, "#{message}\n#{description}" unless LOADED
 end


### PR DESCRIPTION
This PR fixes two issues that happen with the system does not provide `libsodium` and you're using ed25519 keys:

* Fixes whiny nil when the error is not a `Gem::LoadError` (string left uninitialized, next line pushes onto nil)
* Adds better error message when `rbnacl` is installed but the system doesn't provide `libsodium`

I can smash it down to a single commit but wanted to leave the two separate for clarity.