### PR TITLE
Don't try to keep sending buffered data on a closed socket.

### DIFF
--- a/lib/net/ssh/connection/session.rb
+++ b/lib/net/ssh/connection/session.rb
@@ -268,7 +268,7 @@ module Net; module SSH; module Connection
       end
 
       Array(writers).each do |writer|
-        writer.send_pending
+        writer.send_pending unless writer.closed?
       end
     end
 


### PR DESCRIPTION
This happens to me with net-sftp during `close_channel`, not sure exactly why. Tracing in `enqueue_message` the socket is open at the time the packet is buffered and then it gets closed part way through a processing loop. This might be the wrong fix, but I'm not super sure what else to fix specifically.