### PR TITLE
Fix agent detection on Windows

### DIFF
--- a/lib/net/ssh/authentication/agent.rb
+++ b/lib/net/ssh/authentication/agent.rb
@@ -71,7 +71,7 @@ module Net; module SSH; module Authentication
       @socket =
         if agent_socket_factory
           agent_socket_factory.call
-        elsif ENV['SSH_AUTH_SOCK'] && defined?(unix_socket_class)
+        elsif ENV['SSH_AUTH_SOCK'] && unix_socket_class
           unix_socket_class.open(ENV['SSH_AUTH_SOCK'])
         elsif Gem.win_platform? && RUBY_ENGINE != "jruby"
           Pageant::Socket.open
@@ -142,7 +142,7 @@ module Net; module SSH; module Authentication
     private
 
     def unix_socket_class
-      UNIXSocket
+      defined?(UNIXSocket) && UNIXSocket
     end
 
     # Send a new packet of the given type, with the associated data.


### PR DESCRIPTION
The agent detection fails if you have a mingw setup with a working ssh-agent. The ENV SSH_AUTH_SOCK is set, but windows fails to use the UnixSocket class.

```
E, [2017-01-25T09:46:15.783805 #75060] ERROR -- net.ssh.authentication.agent[24dcda0]: could not connect to ssh-agent: uninitialized constant Net::SSH::Authentication::Agent::UNIXSocket
Did you mean?  Socket
               IPSocket
               UDPSocket
```

Tested on:
```
$ ruby --version
ruby 2.3.3p222 (2016-11-21 revision 56859) [i386-mingw32]
```
