### PR TITLE
Add ProxyJump support

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -27,6 +27,7 @@ module Net; module SSH
   # * Port => :port
   # * PreferredAuthentications => maps to the :auth_methods option
   # * ProxyCommand => maps to the :proxy option
+  # * ProxyJump => maps to the :proxy option
   # * PubKeyAuthentication => maps to the :auth_methods option
   # * RekeyLimit => :rekey_limit
   # * User => :user
@@ -224,6 +225,11 @@ module Net; module SSH
             if value and !(value =~ /^none$/)
               require 'net/ssh/proxy/command'
               hash[:proxy] = Net::SSH::Proxy::Command.new(value)
+            end
+          when 'proxyjump'
+            if value
+              require 'net/ssh/proxy/jump'
+              hash[:proxy] = Net::SSH::Proxy::Jump.new(value)
             end
           when 'pubkeyauthentication'
             if value

--- a/lib/net/ssh/proxy/jump.rb
+++ b/lib/net/ssh/proxy/jump.rb
@@ -1,0 +1,53 @@
+require 'uri'
+require 'net/ssh/proxy/command'
+
+module Net; module SSH; module Proxy
+
+  # An implementation of a jump proxy. To use it, instantiate it,
+  # then pass the instantiated object via the :proxy key to
+  # Net::SSH.start:
+  #
+  #   require 'net/ssh/proxy/jump'
+  #
+  #   proxy = Net::SSH::Proxy::Jump.new('user@proxy')
+  #   Net::SSH.start('host', 'user', :proxy => proxy) do |ssh|
+  #     ...
+  #   end
+  class Jump < Command
+
+    # The jump proxies
+    attr_reader :jump_proxies
+
+    # Create a new socket factory that tunnels via multiple jump proxes as
+    # [user@]host[:port].
+    def initialize(jump_proxies)
+      @jump_proxies = jump_proxies
+    end
+
+    # Return a new socket connected to the given host and port via the jump
+    # proxy that was requested when the socket factory was instantiated.
+    def open(host, port, connection_options = nil)
+      build_proxy_command_equivalent(connection_options)
+      super
+    end
+
+    # We cannot build the ProxyCommand template until we know if the :config
+    # option was specified during `Net::SSH.start`.
+    def build_proxy_command_equivalent(connection_options = nil)
+      first_jump, extra_jumps = jump_proxies.split(",", 2)
+      config = connection_options && connection_options[:config]
+      uri = URI.parse("ssh://#{first_jump}")
+
+      template = "ssh"
+      template << " -l #{uri.user}"    if uri.user
+      template << " -p #{uri.port}"    if uri.port
+      template << " -J #{extra_jumps}" if extra_jumps
+      template << " -F #{config}" if config != true && config
+      template << " -W %h:%p "
+      template << uri.host
+
+      @command_line_template = template
+    end
+  end
+
+end; end; end

--- a/test/configs/proxy_jump
+++ b/test/configs/proxy_jump
@@ -1,0 +1,5 @@
+Host behind-proxy
+  ProxyJump user@proxy
+
+Host behind-three-proxies
+  ProxyJump user1@proxy1,user2@proxy2,user3@proxy3

--- a/test/integration/test_proxy.rb
+++ b/test/integration/test_proxy.rb
@@ -4,6 +4,7 @@ require 'net/ssh'
 require 'timeout'
 require 'tempfile'
 require 'net/ssh/proxy/command'
+require 'net/ssh/proxy/jump'
 
 class TestProxy < NetSSHTest
   include IntegrationTestHelpers
@@ -87,6 +88,16 @@ class TestProxy < NetSSHTest
       end
     ensure
       system("sudo sh -c 'echo 1048576 > /proc/sys/fs/pipe-max-size'")
+    end
+  end
+
+  def test_proxy_jump_through_localhost
+    setup_ssh_env do
+      proxy = Net::SSH::Proxy::Jump.new("#{user}@localhost")
+      output = Net::SSH.start(*ssh_start_params(proxy: proxy)) do |ssh|
+        ssh.exec! "echo \"$USER:echo123\""
+      end
+      assert_equal "net_ssh_1:echo123\n", output
     end
   end
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -269,6 +269,12 @@ class TestConfig < NetSSHTest
     assert net_ssh[:proxy]
   end
 
+  def test_load_with_proxy_jump
+    config = Net::SSH::Config.load(config(:proxy_jump), "behind-proxy")
+    net_ssh = Net::SSH::Config.translate(config)
+    assert net_ssh[:proxy]
+  end
+
   def test_load_with_include_keyword
     config = Net::SSH::Config.load(config(:include), "xyz")
     net_ssh = Net::SSH::Config.translate(config)

--- a/test/test_proxy_jump.rb
+++ b/test/test_proxy_jump.rb
@@ -1,0 +1,51 @@
+require_relative 'common'
+require 'net/ssh/proxy/jump'
+
+class TestProxyJump < NetSSHTest
+  def test_is_a_proxy_command
+    proxy = Net::SSH::Proxy::Jump.new("user@jumphost")
+    assert proxy.is_a?(Net::SSH::Proxy::Command)
+  end
+
+  def test_host
+    proxy = Net::SSH::Proxy::Jump.new("jumphost")
+    proxy.build_proxy_command_equivalent
+    assert_equal "ssh -W %h:%p jumphost", proxy.command_line_template
+  end
+
+  def test_user_host
+    proxy = Net::SSH::Proxy::Jump.new("sally@proxy")
+    proxy.build_proxy_command_equivalent
+    assert_equal "ssh -l sally -W %h:%p proxy", proxy.command_line_template
+  end
+
+  def test_user_host_port
+    proxy = Net::SSH::Proxy::Jump.new("bob@jump:2222")
+    proxy.build_proxy_command_equivalent
+    assert_equal "ssh -l bob -p 2222 -W %h:%p jump", proxy.command_line_template
+  end
+
+  def test_multiple_jump_proxies
+    proxy = Net::SSH::Proxy::Jump.new("user1@proxy1,user2@proxy2,user3@proxy3")
+    proxy.build_proxy_command_equivalent
+    assert_equal "ssh -l user1 -J user2@proxy2,user3@proxy3 -W %h:%p proxy1", proxy.command_line_template
+  end
+
+  def test_config_override
+    proxy = Net::SSH::Proxy::Jump.new("proxy")
+    proxy.build_proxy_command_equivalent(config: "/home/user/.ssh/config2")
+    assert_equal "ssh -F /home/user/.ssh/config2 -W %h:%p proxy", proxy.command_line_template
+  end
+
+  def test_config_false
+    proxy = Net::SSH::Proxy::Jump.new("proxy")
+    proxy.build_proxy_command_equivalent(config: false)
+    assert_equal "ssh -W %h:%p proxy", proxy.command_line_template
+  end
+
+  def test_config_true
+    proxy = Net::SSH::Proxy::Jump.new("proxy")
+    proxy.build_proxy_command_equivalent(config: true)
+    assert_equal "ssh -W %h:%p proxy", proxy.command_line_template
+  end
+end


### PR DESCRIPTION
Closes #430 

This implementation was heavily based on the OpenSSH implementation of `ProxyJump`:
https://github.com/openssh/openssh-portable/blob/dda78a03af32e7994f132d923c2046e98b7c56c8/ssh.c#L1096

It's worth noting that this implementation ironically depends on an underlying OpenSSH command-line installation. But if you already had a reliance on `ProxyCommand` or `ProxyJump` ssh_config directives, that dependency should already be met. I suppose, ideally, this `ProxyJump` implementation might later be better implemented as a native Net::SSH proxy without having to rely on an `ssh` executable, but the recursive complexities of that might outweigh the benefits.