### PR TITLE
add direct-streamlocal@openssh.com support in Forward class

### DIFF
--- a/test/integration/playbook.yml
+++ b/test/integration/playbook.yml
@@ -40,6 +40,23 @@
         line='net_ssh_1 ALL=(ALL) NOPASSWD:ALL' regexp=net_ssh_1
     - lineinfile: dest=/etc/sudoers.d/net_ssh_1 mode=0440 state=present create=yes
         line='net_ssh_2 ALL=(ALL) NOPASSWD:ALL' regexp=net_ssh_2
+    - unarchive:
+        src: https://ftp.spline.de/pub/OpenBSD/OpenSSH/portable/openssh-7.4p1.tar.gz
+        dest: /tmp
+        remote_src: True
+    - name: building and installing openssh 7.4 (used in forward test)
+      command: sh -c "./configure --prefix=/opt/net-ssh-openssh && make && sudo make install"
+      args:
+        chdir: /tmp/openssh-7.4p1/
+    - name: drop installed openssh etc/ in favor of symlink
+      file:
+        state: absent
+        path: /opt/net-ssh-openssh/etc
+    - name: creating symlink between system etc/ssh/ and our etc/
+      file:
+        src: /etc/ssh
+        dest: /opt/net-ssh-openssh/etc
+        state: link
     - command: ssh-keygen -A
       args:
         creates: /etc/ssh/ssh_host_ed25519_key


### PR DESCRIPTION
- creates a unix domain socket on localhost
- requests a `direct-streamlocal@openssh.com` channel 
- sshd connects to remote unix domain socket

The channeling works exactly like `direct-tcpip`, only the "setup" part is different. This works with openssh 6.7+ https://github.com/openssh/openssh-portable/commit/7acefbbcbeab725420ea07397ae35992f505f702

I am a tad unsure how to properly test this. The current integration tests use ubuntu/trusty in vagrant, and trusty only had openssh 6.6. Options are probably to switch to ubuntu/xenial (16.04 LTS) or pretend there isn't much to test here (which actually is true given the only new code is creating a socket and the different channel type string).

Anyway, some input would be greatly appreciated.