### PR TITLE
rubocop: deprecation porting for 0.47.0

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -639,7 +639,7 @@ Style/LineEndConcatenation:
 
 # Offense count: 12
 # Cop supports --auto-correct.
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Exclude:
     - 'test/authentication/test_key_manager.rb'
     - 'test/connection/test_session.rb'

--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "minitest", "~> 5.10"
-  spec.add_development_dependency "rubocop", "~> 0.46.0"
+  spec.add_development_dependency "rubocop", "~> 0.47.0"
   spec.add_development_dependency "mocha", ">= 1.2.1"
 end


### PR DESCRIPTION
rubocop: deprecation porting for 0.47.0

in rubocop 0.47 `MethodCallParentheses` was renamed to
`MethodCallWithoutArgsParentheses`.
Port to new name to silence deprecation warnings.
