### PR TITLE
Playbook fix

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -15,7 +15,7 @@ Setup:
 
 # Debugging on travis
 
-Logging the ssh logs might be usefull:
+Logging the ssh logs might be useful:
 
 ```yml
 script:

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -10,7 +10,7 @@ Setup:
     ansible-galaxy install rvm_io.ruby
     vagrant up ; vagrant ssh
     rvmsudo_secure_path=1 rvmsudo rvm all do gem install bundler
-    rvm all do bundle
+    rvm all do sh -c 'rm Gemfile.lock; bundle'
     rvm all do rake test
 
 # Debugging on travis

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -9,6 +9,7 @@ Setup:
 
     ansible-galaxy install rvm_io.ruby
     vagrant up ; vagrant ssh
+    rvmsudo_secure_path=1 rvmsudo rvm all do gem install bundler
     rvm all do bundle
     rvm all do rake test
 

--- a/test/integration/playbook.yml
+++ b/test/integration/playbook.yml
@@ -27,6 +27,7 @@
         rvm1_user: 'root',
         rvm1_rubies: "{{ ruby_versions }}",
         rvm1_install_path: "{{rvm_install_path}}",
+        rvm1_install_flags: '--auto-dotfiles', # Make sure RVM sets itself up so the user has access to it
         rvm1_gpg_key_server: pool.sks-keyservers.net,
         when: "'{{current_ruby_version.stdout|default()}}' != '{{ruby_version}}' and not no_rvm" }
   tasks:

--- a/test/integration/playbook.yml
+++ b/test/integration/playbook.yml
@@ -75,11 +75,6 @@
         - pv
         - libgmp3-dev
         - git
-    - gem: name="{{ item[1] }}" state=present user_install=no executable=/usr/local/rvm/wrappers/ruby-{{ item[0] }}/gem
-      with_nested:
-        - "{{ruby_versions}}"
-        - [ 'byebug', 'rake', 'jeweler', 'mocha', 'rbnacl', 'rbnacl-libsodium', 'minitest' ]
-      when: "not no_rvm"
     - copy: content='echo "cd /net-ssh ; rake integration-test"' dest=/etc/update-motd.d/99-net-ssh-tests mode=0755
     - name: add user to rvm group so they can change gem wrappers
       user:

--- a/test/integration/playbook.yml
+++ b/test/integration/playbook.yml
@@ -81,6 +81,11 @@
         - [ 'byebug', 'rake', 'jeweler', 'mocha', 'rbnacl', 'rbnacl-libsodium', 'minitest' ]
       when: "not no_rvm"
     - copy: content='echo "cd /net-ssh ; rake integration-test"' dest=/etc/update-motd.d/99-net-ssh-tests mode=0755
+    - name: add user to rvm group so they can change gem wrappers
+      user:
+        name: "{{myuser}}"
+        groups: rvm
+        append: yes
   handlers:
     - name: restart sshd
       service: name=ssh state=restarted


### PR DESCRIPTION
bunch of fixes to make the integration tests work reliably

- ansible no longer installs gems manually. this ignored the multi-versioned approach entirely and doing it smarter requires an absurd amount of boilerplate code to get the RVM rigging going. instead, we let bundler handle everything
- along this line, I've add a command to the instructions in the readme that forces bundler to be updated to the latest version as otherwise the gemspec might want a newer bundler than is intalled
- before bundling inside vagrant we'll want to drop the Gemfile.lock as otherwise we'd potentially run bundle with incompatible lock files (too new or too old)

:crossed_fingers: praying travis is still happy