### PR TITLE
Resolve relative paths in the Include directive properly

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -72,9 +72,9 @@ module Net; module SSH
       # ones. Returns a hash containing the OpenSSH options. (See
       # #translate for how to convert the OpenSSH options into Net::SSH
       # options.)
-      def load(path, host, settings={})
+      def load(path, host, settings={}, base_dir = nil)
         file = File.expand_path(path)
-        base_dir = File.dirname(file)
+        base_dir ||= File.dirname(file)
         return settings unless File.readable?(file)
 
         globals = {}
@@ -125,7 +125,7 @@ module Net; module SSH
               (globals[key] ||= []) << value
             when 'include'
               included_file_paths(base_dir, value).each do |file_path|
-                globals = load(file_path, host, globals)
+                globals = load(file_path, host, globals, base_dir)
               end
             else
               globals[key] = value unless settings.key?(key)
@@ -136,7 +136,7 @@ module Net; module SSH
               (settings[key] ||= []) << value
             when 'include'
               included_file_paths(base_dir, value).each do |file_path|
-                settings = load(file_path, host, settings)
+                settings = load(file_path, host, settings, base_dir)
               end
             else
               settings[key] = value unless settings.key?(key)
@@ -304,9 +304,7 @@ module Net; module SSH
         end
 
         def included_file_paths(base_dir, config_path)
-          paths = Dir.glob(File.expand_path(config_path)).select { |f| File.file?(f) }
-          paths += Dir.glob(File.join(base_dir, config_path)).select { |f| File.file?(f) }
-          paths.uniq
+          Dir.glob(File.expand_path(config_path, base_dir)).select { |f| File.file?(f) }
         end
 
     end

--- a/test/configs/conf.d/subdir/subset4
+++ b/test/configs/conf.d/subdir/subset4
@@ -1,0 +1,2 @@
+User foo
+IdentitiesOnly yes

--- a/test/configs/conf.d/subset2
+++ b/test/configs/conf.d/subset2
@@ -1,2 +1,1 @@
-User foo
-IdentitiesOnly yes
+Include conf.d/subdir/*


### PR DESCRIPTION
According to [ssh_config(5)](http://man.openbsd.org/ssh_config#Include), relative paths in the Include directive is relative from the directory of the root file, not from that of the including file.  If `~/.ssh/config` includes `~/.ssh/dir1/file1` which has a line `Include dir2/file2`, ssh tries to include `~/.ssh/dir2/file2`, not `~/.ssh/dir1/dir2/file2`.