### PR TITLE
Support including multiple files by a single Include directive

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -303,10 +303,17 @@ module Net; module SSH
           hash
         end
 
-        def included_file_paths(base_dir, config_path)
-          Dir.glob(File.expand_path(config_path, base_dir)).select { |f| File.file?(f) }
+        def included_file_paths(base_dir, config_paths)
+          tokenize_config_value(config_paths).flat_map do |path|
+            Dir.glob(File.expand_path(path, base_dir)).select { |f| File.file?(f) }
+          end
         end
 
+        # Tokenize string into tokens.
+        # A token is a word or a quoted sequence of words, separated by whitespaces.
+        def tokenize_config_value(str)
+          str.scan(/([^"\s]+)?(?:"([^"]+)")?\s*/).map(&:join)
+        end
     end
   end
 

--- a/test/configs/include
+++ b/test/configs/include
@@ -1,4 +1,4 @@
-Include subset1
+Include subset1 "subset ws"
 
 Host xyz
   Include conf.d/*

--- a/test/configs/subset ws
+++ b/test/configs/subset ws
@@ -1,0 +1,1 @@
+Compression yes

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -281,6 +281,7 @@ class TestConfig < NetSSHTest
     assert_equal 'example.com', net_ssh[:host_name]
     assert_equal 'foo', net_ssh[:user]
     assert_equal 2345, net_ssh[:port]
+    assert_equal true, net_ssh[:compression]
     assert net_ssh[:keys_only]
     assert_equal %w(~/.ssh/id.pem), net_ssh[:keys]
   end


### PR DESCRIPTION
ssh_config(5) from OpenSSH says an Include directive may take multiple pathnames. The pathnames are separated by whitespaces and may contain whitespaces when enclosed in double quotes.