### PR TITLE
Rename :paranoid to :verify_host_key

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+=== Unreleased
+
+ * Deprecate `:paranoid` in favor of `:verify_host_key`
+
 === 4.1.0
 === 4.1.0.rc1
 

--- a/lib/net/ssh/test.rb
+++ b/lib/net/ssh/test.rb
@@ -71,7 +71,10 @@ module Net; module SSH
     # in these tests. It is a fully functional SSH transport session, operating
     # over a mock socket (#socket).
     def transport(options={})
-      @transport ||= Net::SSH::Transport::Session.new(options[:host] || "localhost", options.merge(kex: "test", host_key: "ssh-rsa", paranoid: false, proxy: socket(options)))
+      @transport ||= Net::SSH::Transport::Session.new(
+        options[:host] || "localhost",
+        options.merge(kex: "test", host_key: "ssh-rsa", verify_host_key: false, proxy: socket(options))
+      )
     end
 
     # First asserts that a story has been described (see #story). Then yields,

--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -78,7 +78,7 @@ module Net; module SSH; module Transport
 
       @queue = []
 
-      @host_key_verifier = select_host_key_verifier(options[:paranoid])
+      @host_key_verifier = select_host_key_verifier(options[:verify_host_key])
 
 
       @server_version = ServerVersion.new(socket, logger, options[:timeout])
@@ -281,8 +281,8 @@ module Net; module SSH; module Transport
       # strict Secure verifier is returned. If the argument happens to respond
       # to :verify, it is returned directly. Otherwise, an exception
       # is raised.
-      def select_host_key_verifier(paranoid)
-        case paranoid
+      def select_host_key_verifier(verify_host_key)
+        case verify_host_key
         when true, nil then
           Net::SSH::Verifiers::Lenient.new
         when false then
@@ -292,10 +292,14 @@ module Net; module SSH; module Transport
         when :secure then
           Net::SSH::Verifiers::Secure.new
         else
-          if paranoid.respond_to?(:verify)
-            paranoid
+          if verify_host_key.respond_to?(:verify)
+            verify_host_key
           else
-            raise ArgumentError, "argument to :paranoid is not valid: #{paranoid.inspect}"
+            raise(
+              ArgumentError,
+              "Invalid argument to :verify_host_key (or deprecated " \
+              ":paranoid): #{verify_host_key.inspect}"
+            )
           end
         end
       end

--- a/test/transport/test_session.rb
+++ b/test/transport/test_session.rb
@@ -20,29 +20,29 @@ module Transport
       assert_instance_of Net::SSH::Verifiers::Lenient, session.host_key_verifier
     end
 
-    def test_paranoid_true_uses_lenient_verifier
-      assert_instance_of Net::SSH::Verifiers::Lenient, session(paranoid: true).host_key_verifier
+    def test_verify_host_key_true_uses_lenient_verifier
+      assert_instance_of Net::SSH::Verifiers::Lenient, session(verify_host_key: true).host_key_verifier
     end
 
-    def test_paranoid_very_uses_strict_verifier
-      assert_instance_of Net::SSH::Verifiers::Strict, session(paranoid: :very).host_key_verifier
+    def test_verify_host_key_very_uses_strict_verifier
+      assert_instance_of Net::SSH::Verifiers::Strict, session(verify_host_key: :very).host_key_verifier
     end
 
-    def test_paranoid_secure_uses_secure_verifier
-      assert_instance_of Net::SSH::Verifiers::Secure, session(paranoid: :secure).host_key_verifier
+    def test_verify_host_key_secure_uses_secure_verifier
+      assert_instance_of Net::SSH::Verifiers::Secure, session(verify_host_key: :secure).host_key_verifier
     end
 
-    def test_paranoid_false_uses_null_verifier
-      assert_instance_of Net::SSH::Verifiers::Null, session(paranoid: false).host_key_verifier
+    def test_verify_host_key_false_uses_null_verifier
+      assert_instance_of Net::SSH::Verifiers::Null, session(verify_host_key: false).host_key_verifier
     end
 
-    def test_unknown_paranoid_value_raises_exception_if_value_does_not_respond_to_verify
-      assert_raises(ArgumentError) { session(paranoid: :bogus).host_key_verifier }
+    def test_unknown_verify_host_key_value_raises_exception_if_value_does_not_respond_to_verify
+      assert_raises(ArgumentError) { session(verify_host_key: :bogus).host_key_verifier }
     end
 
-    def test_paranoid_value_responding_to_verify_should_pass_muster
+    def test_verify_host_key_value_responding_to_verify_should_pass_muster
       object = stub("thingy", verify: true)
-      assert_equal object, session(paranoid: object).host_key_verifier
+      assert_equal object, session(verify_host_key: object).host_key_verifier
     end
 
     def test_host_as_string_should_return_host_and_ip_when_port_is_default


### PR DESCRIPTION
The words we choose matter. By using the word "paranoid", we make
fun of people who care about security. Instead, we should encourage
security in our community, or at least use a neutral term.

In this patch, we choose the neutral wording that is used by the SSH
manual page:

> the server must be able to verify the client's host key
> (see the description of /etc/ssh/ssh_known_hosts and
> ~/.ssh/known_hosts, below) for login to be permitted.