### PR TITLE
Support multiple identity files

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -144,7 +144,10 @@ module Net; module SSH
           end
         end
 
-        settings = globals.merge(settings) if globals
+        if globals
+          settings['identityfile'] = [globals['identityfile'], settings['identityfile']].flatten.compact
+          settings = globals.merge(settings)
+        end
 
         return settings
       end

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -145,8 +145,14 @@ module Net; module SSH
         end
 
         if globals
-          settings['identityfile'] = [globals['identityfile'], settings['identityfile']].flatten.compact
-          settings = globals.merge(settings)
+          settings = globals.merge(settings) do |key, oldval, newval|
+            case key
+            when 'identityfile'
+              oldval + newval
+            else
+              newval
+            end
+          end
         end
 
         return settings

--- a/test/configs/conf.d/subset3
+++ b/test/configs/conf.d/subset3
@@ -1,1 +1,2 @@
 HostName example.com
+IdentityFile ~/.ssh/id3.pem

--- a/test/configs/include
+++ b/test/configs/include
@@ -1,4 +1,5 @@
 Include subset1 "subset ws"
+IdentityFile ~/.ssh/id2.pem
 
 Host xyz
   Include conf.d/*

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -283,7 +283,7 @@ class TestConfig < NetSSHTest
     assert_equal 2345, net_ssh[:port]
     assert_equal true, net_ssh[:compression]
     assert net_ssh[:keys_only]
-    assert_equal %w(~/.ssh/id.pem), net_ssh[:keys]
+    assert_equal %w(~/.ssh/id.pem ~/.ssh/id2.pem ~/.ssh/id3.pem), net_ssh[:keys]
   end
 
   private


### PR DESCRIPTION
If configuration files have multiple identity files, Net::SSH should support those.

The [ssh_config manual](http://man.openbsd.org/ssh_config#IdentityFile) states:
> It is possible to have multiple identity files specified in configuration files; all these identities will be tried in sequence. 

We should merge `globals['identityfile']` with `settings['identityfile']` in loading configuration files.