### PR TITLE
MRI Ruby will show as ruby on RUBY_ENGINE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in mygem.gemspec
 gemspec
 
-if !Gem.win_platform? && RUBY_ENGINE == "mri"
+if !Gem.win_platform? && RUBY_ENGINE == "ruby"
   gem 'byebug', group: [:development, :test]
 end
 


### PR DESCRIPTION
In the Gemfile the byebug gem will not install as expected because RUBY_ENGINE != "mri"

Assuming [this](https://stackoverflow.com/questions/9894168/what-values-for-ruby-engine-correspond-to-which-ruby-implementations) is accurate and it appears to be in my experiments. 