### PR TITLE
Fixed side-effects caused by passing by reference

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -53,7 +53,7 @@ module Net; module SSH
       end
 
       def default_auth_methods
-        @@default_auth_methods
+        @@default_auth_methods.clone
       end
 
       # Loads the configuration data for the given +host+ from all of the

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -49,7 +49,7 @@ module Net; module SSH
       # Returns an array of locations of OpenSSH configuration files
       # to parse by default.
       def default_files
-        @@default_files
+        @@default_files.clone
       end
 
       def default_auth_methods

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -286,6 +286,25 @@ class TestConfig < NetSSHTest
     assert_equal %w(~/.ssh/id.pem ~/.ssh/id2.pem ~/.ssh/id3.pem), net_ssh[:keys]
   end
 
+
+  def test_default_files_not_mutable
+    original_default_files = Net::SSH::Config.default_files.clone
+
+    default_files = Net::SSH::Config.default_files
+    default_files.push('garbage')
+
+    assert_equal(original_default_files, Net::SSH::Config.default_files)
+  end
+
+  def test_default_auth_methods_not_mutable
+    original_default_auth_methods = Net::SSH::Config.default_auth_methods.clone
+
+    default_auth_methods = Net::SSH::Config.default_auth_methods
+    default_auth_methods.push('garbage')
+
+    assert_equal(original_default_auth_methods, Net::SSH::Config.default_auth_methods)
+  end
+
   private
 
     def with_home_env(value,&block)


### PR DESCRIPTION
The `Net::SSH::Config::default_files` method is supposed to "return an array of locations" to parse by default.

However, it currently returns a **reference** to the actual `@@default_files` class variable, meaning that any API consumers who `Enumerable#shift`, `pop`, or otherwise modify the returned Array are actually **__modifying the state of the `Net::SSH` library as a whole__**, meaning that subsequent uses cannot use the same array contents.

----

I found this because I use `Net::SSH.start` by itself (eg, automagically getting configuration), but ran into problems when I added this block in front, where I'm simply loading the files to find whether a new option `IdentityAgent` is set. (Eg, I'm not otherwise using/`::translate`ing the loaded options: I'm still relying on `#start` to do the right thing)

```ruby
raw_opts = {}
opt_files = Net::SSH::Config.default_files
while (file = opt_files.shift)
  raw_opts = Net::SSH::Config.load(file, some_hostname, raw_opts)
end
identity_agent = raw_opts.fetch("identityagent", nil)

# do the same stuff as usual
Net::SSH.start(hostname, nil, verbose: :info) do |session|
  # ...
end
```

After I added that block, the attempted ssh connection used the wrong username, etc, as if `#start` was no longer loading the config files!

At first I assumed that `Net::SSH::Config.load` had side effects (documented or otherwise) but I couldn't see any evidence of that in the code.

Then I found the "pass by reference" problem in `::default_files`...

I confirmed by suspicion by changing only this in my code:

`opt_files = Net::SSH::Config.default_files` -> `opt_files = Net::SSH::Config.default_files.clone`

Hence the PR. I don't think it makes sense for *anyone* to be able to modify the internal state of Net::SSH...

If you don't agree with my change, please let me know: I'll gladly make a different PR that adjusts the documentation instead, warning people of the side effects :-)