### PR TITLE
Remove Net::SSH::Compat.io_select

### DIFF
--- a/lib/net/ssh/buffered_io.rb
+++ b/lib/net/ssh/buffered_io.rb
@@ -113,7 +113,7 @@ module Net; module SSH
     def wait_for_pending_sends
       send_pending
       while output.length > 0
-        result = Net::SSH::Compat.io_select(nil, [self]) or next
+        result = IO.select(nil, [self]) or next
         next unless result[1].any?
         send_pending
       end

--- a/lib/net/ssh/connection/event_loop.rb
+++ b/lib/net/ssh/connection/event_loop.rb
@@ -64,7 +64,7 @@ module Net; module SSH; module Connection
         sw.each { |wi| owners[wi] = session }
       end
 
-      readers, writers, = Net::SSH::Compat.io_select(r, w, nil, minwait)
+      readers, writers, = IO.select(r, w, nil, minwait)
 
       fired_sessions = {}
 
@@ -105,7 +105,7 @@ module Net; module SSH; module Connection
       raise "Only one session expected" unless @sessions.count == 1
       session = @sessions.first
       sr,sw,actwait = session.ev_do_calculate_rw_wait(wait)
-      readers, writers, = Net::SSH::Compat.io_select(sr, sw, nil, actwait)
+      readers, writers, = IO.select(sr, sw, nil, actwait)
 
       session.ev_do_handle_events(readers,writers)
       session.ev_do_postprocess(!((readers.nil? || readers.empty?) && (writers.nil? || writers.empty?)))

--- a/lib/net/ssh/proxy/command.rb
+++ b/lib/net/ssh/proxy/command.rb
@@ -56,7 +56,7 @@ module Net; module SSH; module Proxy
       }
       begin
         io = IO.popen(command_line, "r+")
-        if result = Net::SSH::Compat.io_select([io], nil, [io], 60)
+        if result = IO.select([io], nil, [io], 60)
           if result.last.any? || io.eof?
             io.close
             raise "command failed"

--- a/lib/net/ssh/ruby_compat.rb
+++ b/lib/net/ssh/ruby_compat.rb
@@ -10,15 +10,3 @@ class String
     end
   end
 end
-
-module Net; module SSH
-  
-  # This class contains miscellaneous patches and workarounds
-  # for different ruby implementations.
-  class Compat
-    def self.io_select(*params)
-      IO.select(*params)
-    end
-  end
-  
-end; end

--- a/lib/net/ssh/transport/packet_stream.rb
+++ b/lib/net/ssh/transport/packet_stream.rb
@@ -72,7 +72,7 @@ module Net; module SSH; module Transport
 
     # Returns true if the IO is available for reading, and false otherwise.
     def available_for_read?
-      result = Net::SSH::Compat.io_select([self], nil, nil, 0)
+      result = IO.select([self], nil, nil, 0)
       result && result.first.any?
     end
 
@@ -105,7 +105,7 @@ module Net; module SSH; module Transport
           return packet if packet
 
           loop do
-            result = Net::SSH::Compat.io_select([self]) or next
+            result = IO.select([self]) or next
             break if result.first.any?
           end
 


### PR DESCRIPTION
Despite the comment, it was not doing anything anymore except invoking the default `IO.select`.