### PR TITLE
use @prompt from the base class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,9 @@ addon:
     gateway.netssh
 
 rvm:
-  - 2.0
-  - 2.1
   - 2.2
-  - 2.3.0
-  - 2.4.0
-  - jruby-9.1.6.0
+  - 2.3.5
+  - 2.4.2
   - rbx-3.69
   - ruby-head
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,23 @@ rvm:
   - 2.2
   - 2.3.5
   - 2.4.2
-  - rbx-3.69
+  - rbx-3.84
   - ruby-head
 env:
   NET_SSH_RUN_INTEGRATION_TESTS=1
 
 matrix:
   exclude:
-    - rvm: rbx-3.69
+    - rvm: rbx-3.84
     - rvm: jruby-9.1.6.0
   include:
-    - rvm: rbx-3.69
+    - rvm: rbx-3.84
       env: NET_SSH_RUN_INTEGRATION_TESTS=
     - rvm: jruby-9.1.6.0
       env: JRUBY_OPTS='--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -Xcext.enabled=false -J-Xss2m -Xcompile.invokedynamic=false' NET_SSH_RUN_INTEGRATION_TESTS=
   fast_finish: true
   allow_failures:
-    - rvm: rbx-3.69
+    - rvm: rbx-3.84
     - rvm: jruby-9.1.6.0
     - rvm: ruby-head
 

--- a/lib/net/ssh/authentication/methods/keyboard_interactive.rb
+++ b/lib/net/ssh/authentication/methods/keyboard_interactive.rb
@@ -41,7 +41,7 @@ module Net
                 debug { "keyboard-interactive info request" }
 
                 if password.nil? && interactive? && prompter.nil?
-                  prompter = prompt.start(type: 'keyboard-interactive', name: name, instruction: instruction)
+                  prompter = @prompt.start(type: 'keyboard-interactive', name: name, instruction: instruction)
                 end
 
                 _ = message.read_string # lang_tag

--- a/lib/net/ssh/authentication/methods/password.rb
+++ b/lib/net/ssh/authentication/methods/password.rb
@@ -62,7 +62,7 @@ module Net
             prompt_info = {type: 'password', user: username, host: host}
             if @prompt_info != prompt_info
               @prompt_info = prompt_info
-              @prompter = prompt.start(prompt_info)
+              @prompter = @prompt.start(prompt_info)
             end
             echo = false
             @prompter.ask("#{username}@#{host}'s password:", echo)


### PR DESCRIPTION
It looks like when 2b6cd7a5a139ce2c1379546b1e8d09c9013ebbd2 refactored the prompt methods, the @prompt instance variable from the base class does not get referenced correctly.

Noted here https://github.com/rapid7/metasploit-framework/issues/8970#issuecomment-329937858