### PR TITLE
disable broken rubies, update rubies with security issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,30 +7,28 @@ addon:
     gateway.netssh
 
 rvm:
-  - 2.0
-  - 2.1
   - 2.2
-  - 2.3.0
-  - 2.4.0
-  - jruby-9.1.6.0
-  - rbx-3.69
+  - 2.3.5
+  - 2.4.2
+  - jruby-9.1.13.0
+  - rbx-3.84
   - ruby-head
 env:
   NET_SSH_RUN_INTEGRATION_TESTS=1
 
 matrix:
   exclude:
-    - rvm: rbx-3.69
-    - rvm: jruby-9.1.6.0
+    - rvm: rbx-3.84
+    - rvm: jruby-9.1.13.0
   include:
-    - rvm: rbx-3.69
+    - rvm: rbx-3.84
       env: NET_SSH_RUN_INTEGRATION_TESTS=
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.13.0
       env: JRUBY_OPTS='--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -Xcext.enabled=false -J-Xss2m -Xcompile.invokedynamic=false' NET_SSH_RUN_INTEGRATION_TESTS=
   fast_finish: true
   allow_failures:
-    - rvm: rbx-3.69
-    - rvm: jruby-9.1.6.0
+    - rvm: rbx-3.84
+    - rvm: jruby-9.1.13.0
     - rvm: ruby-head
 
 install:


### PR DESCRIPTION
It looks like Ruby 2.0/2.1 are both broken for Travis CI testing because some upstream gems have stopped supporting these versions. Since these also are not receiving security updates, let's bump all tested Ruby versions to the latest supported releases, and remove the unsupported ones.

## Validation Steps

 - [ ] Check that Travis CI tests are now Green