### PR TITLE
Add initial Match support

### DIFF
--- a/test/configs/match
+++ b/test/configs/match
@@ -1,0 +1,15 @@
+Host test.host
+  ForwardAgent yes
+
+Match all
+  Compression yes
+
+Match !all
+  Port 1234
+
+Match unsupported
+  Port 2345
+
+Host *
+  Port 22
+  Compression no

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -286,6 +286,14 @@ class TestConfig < NetSSHTest
     assert_equal %w(~/.ssh/id.pem ~/.ssh/id2.pem ~/.ssh/id3.pem), net_ssh[:keys]
   end
 
+  def test_load_with_match_block
+    config = Net::SSH::Config.load(config(:match), "test.host")
+    net_ssh = Net::SSH::Config.translate(config)
+    assert_equal true, net_ssh[:forward_agent]
+    assert_equal true, net_ssh[:compression]
+    assert_equal 22, net_ssh[:port]
+  end
+
   private
 
     def with_home_env(value,&block)


### PR DESCRIPTION
issue: https://github.com/net-ssh/net-ssh/issues/374

This change makes Net::SSH::Config to recognize `Match` directive in ssh_config.
Only the `all` criteria keyword (and its negation) is supported at this time.

Though only supporting `all` is not very useful, it is important that net-ssh correctly handles block structure of ssh_config.