### PR TITLE
drop support for ruby lower than 2.2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,12 @@ addon:
     gateway.netssh
 
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
-  - 2.3.0
-  - 2.4.0
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
+  - ruby-head
   - jruby-9.1.6.0
   - rbx-3.69
-  - ruby-head
 env:
   NET_SSH_RUN_INTEGRATION_TESTS=1
 

--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Net::SSH: a pure-Ruby implementation of the SSH2 client protocol. It allows you to write programs that invoke and interact with processes on remote servers, via SSH2.}
   spec.homepage      = "https://github.com/net-ssh/net-ssh"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.2.6")
 
   spec.extra_rdoc_files = [
     "LICENSE.txt",


### PR DESCRIPTION
Drop ruby versions that are not supported by the ruby-core team any longer and does not receive any fixes.