### PR TITLE
Fix Net::SSH.start docs

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -192,7 +192,7 @@ module Net
     # * :password_prompt => a custom prompt object with ask method. See Net::SSH::Prompt
     #
     # * :agent_socket_factory => enables the user to pass a lambda/block that will serve as the socket factory
-    #    Net::SSH::start(user,host,agent_socket_factory: ->{ UNIXSocket.open('/foo/bar') })
+    #    Net::SSH.start(host,user,agent_socket_factory: ->{ UNIXSocket.open('/foo/bar') })
     #    example: ->{ UNIXSocket.open('/foo/bar')}
     # * :verify_host_key => either false, true, :very, or :secure specifying how
     #   strict host-key verification should be (in increasing order here).


### PR DESCRIPTION
Fixes the docs for Net::SSH.start's `agent_socket_factory` option.

Currently, the example code provided in the docs is not correct and this PR fixes that. Here is what's wrong with the current version:

* `Net::SSH::start` versus `Net::SSH.start`
* Args out of order for `.start`

Let me know if I need to do anything else to land this fix!

Cheers,
Charles