### PR TITLE
improve CTR speed by not mutating the remaining string in a loop

### DIFF
--- a/lib/net/ssh/transport/ctr.rb
+++ b/lib/net/ssh/transport/ctr.rb
@@ -12,7 +12,7 @@ module Net::SSH::Transport
         @counter_len = orig.block_size
         orig.encrypt
         orig.padding = 0
-        
+
         singleton_class.send(:alias_method, :_update, :update)
         singleton_class.send(:private, :_update)
         singleton_class.send(:undef_method, :update)
@@ -50,11 +50,14 @@ module Net::SSH::Transport
 
           encrypted = ""
 
-          while @remaining.bytesize >= block_size
-            encrypted += xor!(@remaining.slice!(0, block_size),
+          offset = 0
+          while (@remaining.bytesize - offset) >= block_size
+            encrypted += xor!(@remaining.slice(offset, block_size),
                               _update(@counter))
             increment_counter!
+            offset += block_size
           end
+          @remaining = @remaining.slice(offset..-1)
 
           encrypted
         end


### PR DESCRIPTION
#slice! in a loop gets expensive quickly when encrypting larger data blobs
(e.g. when uploading data through net-sftp).
#slice! needs to modify self AND create a new string for the substr,
#slice on the other hand only needs to do the latter.

as we do not need the modified remaining string in the loop we can simply
slice in the loop and then change remaining afterwards to modify the
string permanently.

Closes: #542