### PR TITLE
Fix for current arch linux box using openssl-1.1.0g

### DIFF
--- a/lib/net/ssh/transport/openssl.rb
+++ b/lib/net/ssh/transport/openssl.rb
@@ -109,12 +109,12 @@ module OpenSSL
            OpenSSL::ASN1::Integer(sig_r),
            OpenSSL::ASN1::Integer(sig_s)
         ])
-        return verify(OpenSSL::Digest::DSS1.new, a1sig.to_der, data)
+        return verify(OpenSSL::Digest::SHA1.new, a1sig.to_der, data)
       end
 
       # Signs the given data.
       def ssh_do_sign(data)
-        sig = sign( OpenSSL::Digest::DSS1.new, data)
+        sig = sign( OpenSSL::Digest::SHA1.new, data)
         a1sig = OpenSSL::ASN1.decode( sig )
 
         sig_r = a1sig.value[0].value.to_s(2)


### PR DESCRIPTION
Closes: #503 

relative to net-ssh version 4.2.0 (released as gem)

Please note that I could not test this in the 5.0.0-beta1 version with my scripts using code like

```ruby
def executeRemote(command, builder)                                                                                                                                                            
  Net::SSH.start(builder.hostname,builder.username,
                 :config => true, :compression => true) do |ssh|
 
    stdout_data = ""
    stderr_data = ""
    exit_code   = nil
    exit_signal = nil
 
    ssh.open_channel do |channel|
      channel.exec(command) do |ch, success|
        unless success
          raise "FAILED: couldn't execute command #{command}"
        end
 
        channel.on_data do |ch, data|
          stdout_data += data
          $stdout.write(data) if @debug
        end
 
        channel.on_extended_data do |ch, type, data|
          stderr_data += data
          $stderr.write(data)# if @debug
        end
 
        channel.on_request("exit-status") do |ch, data|
          exit_code = data.read_long
        end
 
        channel.on_request("exit-signal") do |ch, data|
          exit_signal = data.read_long
        end
      end
    end
    ssh.loop
  end
end
```

the error looks like this

```
NameError: uninitialized constant Net::SSH::Transport::SimpleDelegator
/home/ram/.gem/ruby/2.5.0/gems/net-ssh-5.0.0.beta1/lib/net/ssh/transport/ctr.rb:5:in `<module:Transport>'
/home/ram/.gem/ruby/2.5.0/gems/net-ssh-5.0.0.beta1/lib/net/ssh/transport/ctr.rb:3:in `<top (required)>'
/home/ram/.gem/ruby/2.5.0/gems/net-ssh-5.0.0.beta1/lib/net/ssh/transport/cipher_factory.rb:2:in `<top (required)>'
/home/ram/.gem/ruby/2.5.0/gems/net-ssh-5.0.0.beta1/lib/net/ssh/transport/algorithms.rb:4:in `<top (required)>'
/home/ram/.gem/ruby/2.5.0/gems/net-ssh-5.0.0.beta1/lib/net/ssh/transport/session.rb:6:in `<top (required)>'
/home/ram/.gem/ruby/2.5.0/gems/net-ssh-5.0.0.beta1/lib/net/ssh.rb:11:in `<top (required)>'
/home/ram/src/cimd/cdo/Rakefile:2:in `<top (required)>'

Caused by:
LoadError: cannot load such file -- net/ssh
/home/ram/src/cimd/cdo/Rakefile:2:in `<top (required)>'
(See full trace by running task with --trace)
```

the built-in test work except TestED25519#test_no_pwd_key and TestED25519#test_pwd_key