### PR TITLE
Ensure functionality in FIPS enabled systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ install:
 
 script:
   - ssh -V
+  - sudo chown -R travis:travis /home/travis/.ssh
+  - chmod -R go-rwx /home/travis/.ssh
   - bundle _1.16_ exec rake test
   - BUNDLE_GEMFILE=./Gemfile.noed25519 bundle _1.16_ exec rake test
   - bundle _1.16_ exec rake test_test

--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -76,6 +76,21 @@ module Net
       :agent_socket_factory, :minimum_dh_bits, :verify_host_key
     ]
 
+    # Provides a fingerprint operation on the passed blob
+    #
+    # Adjusts for FIPS and non-FIPS systems as appropriate
+    def self.fingerprint(blob)
+      unless blob.is_a?(String)
+        raise ArgumentError, "item to fingerprint must be a String"
+      end
+
+      if Net::SSH::FIPS
+        OpenSSL::Digest::SHA256.base64digest(blob)
+      else
+        OpenSSL::Digest::MD5.hexdigest(blob).scan(/../).join(':')
+      end
+    end
+
     # The standard means of starting a new SSH connection. When used with a
     # block, the connection will be closed when the block terminates, otherwise
     # the connection will just be returned. The yielded (or returned) value

--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -5,6 +5,7 @@ ENV['HOME'] ||= ENV['HOMEPATH'] ? "#{ENV['HOMEDRIVE']}#{ENV['HOMEPATH']}" : Dir.
 require 'logger'
 require 'etc'
 
+require 'net/ssh/fips'
 require 'net/ssh/config'
 require 'net/ssh/errors'
 require 'net/ssh/loggable'

--- a/lib/net/ssh/authentication/ed25519.rb
+++ b/lib/net/ssh/authentication/ed25519.rb
@@ -5,6 +5,7 @@ require 'ed25519'
 
 require 'base64'
 
+require 'new/ssh/fips'
 require 'net/ssh/transport/cipher_factory'
 require 'bcrypt_pbkdf' unless RUBY_PLATFORM == "java"
 
@@ -52,7 +53,7 @@ module ED25519
     end
 
     def fingerprint
-      @fingerprint ||= OpenSSL::Digest::MD5.hexdigest(to_blob).scan(/../).join(":")
+      @fingerprint ||= Net::SSH::OPENSSL_DIGEST.hexdigest(to_blob).scan(/../).join(":")
     end
   end
 

--- a/lib/net/ssh/authentication/ed25519.rb
+++ b/lib/net/ssh/authentication/ed25519.rb
@@ -53,7 +53,7 @@ module ED25519
     end
 
     def fingerprint
-      @fingerprint ||= Net::SSH::OPENSSL_DIGEST.hexdigest(to_blob).scan(/../).join(":")
+      @fingerprint ||= Net::SSH.fingerprint(to_blob)
     end
   end
 

--- a/lib/net/ssh/fips.rb
+++ b/lib/net/ssh/fips.rb
@@ -1,0 +1,29 @@
+# Systems that are running in FIPS 140-2 compliant mode cannot use certain
+# cryptographic algorithms. This parameter will be set to `true` when the
+# underlying system is in FIPS 140-2 compliant mode. The rescue mechanism is
+# used for compatibility with legacy Ruby versions.
+#
+# This needs to be before ANY segment that requires cryptography that may be
+# affected by FIPS mode in the underlying system.
+module Net
+  module SSH
+    begin
+      require 'openssl'
+
+      OpenSSL::Digest::MD5.hexdigest('fips')
+
+      FIPS = false
+      OPENSSL_DIGEST = OpenSSL::Digest::MD5
+
+    rescue OpenSSL::Digest::DigestError, Exception
+      # The first exception here is what should be used in the future.
+      # However, not all versions of Ruby throw this error and so we need to
+      # fall back to the most general case.
+
+      FIPS = true
+
+      # Future-proofing for a while at least
+      OPENSSL_DIGEST = OpenSSL::Digest::SHA256
+    end
+  end
+end

--- a/lib/net/ssh/fips.rb
+++ b/lib/net/ssh/fips.rb
@@ -13,17 +13,12 @@ module Net
       OpenSSL::Digest::MD5.hexdigest('fips')
 
       FIPS = false
-      OPENSSL_DIGEST = OpenSSL::Digest::MD5
-
     rescue OpenSSL::Digest::DigestError, Exception
       # The first exception here is what should be used in the future.
       # However, not all versions of Ruby throw this error and so we need to
       # fall back to the most general case.
 
       FIPS = true
-
-      # Future-proofing for a while at least
-      OPENSSL_DIGEST = OpenSSL::Digest::SHA256
     end
   end
 end

--- a/lib/net/ssh/transport/hmac.rb
+++ b/lib/net/ssh/transport/hmac.rb
@@ -1,14 +1,18 @@
+require 'net/ssh/fips'
 require 'net/ssh/transport/key_expander'
-require 'net/ssh/transport/hmac/md5'
-require 'net/ssh/transport/hmac/md5_96'
 require 'net/ssh/transport/hmac/sha1'
 require 'net/ssh/transport/hmac/sha1_96'
 require 'net/ssh/transport/hmac/sha2_256'
 require 'net/ssh/transport/hmac/sha2_256_96'
 require 'net/ssh/transport/hmac/sha2_512'
 require 'net/ssh/transport/hmac/sha2_512_96'
-require 'net/ssh/transport/hmac/ripemd160'
-require 'net/ssh/transport/hmac/none'
+
+unless Net::SSH::FIPS
+  require 'net/ssh/transport/hmac/md5'
+  require 'net/ssh/transport/hmac/md5_96'
+  require 'net/ssh/transport/hmac/ripemd160'
+  require 'net/ssh/transport/hmac/none'
+end
 
 # Implements a simple factory interface for fetching hmac implementations, or
 # for finding the key lengths for hmac implementations.s

--- a/lib/net/ssh/transport/hmac.rb
+++ b/lib/net/ssh/transport/hmac.rb
@@ -6,33 +6,31 @@ require 'net/ssh/transport/hmac/sha2_256'
 require 'net/ssh/transport/hmac/sha2_256_96'
 require 'net/ssh/transport/hmac/sha2_512'
 require 'net/ssh/transport/hmac/sha2_512_96'
+require 'net/ssh/transport/hmac/none'
 
 unless Net::SSH::FIPS
   require 'net/ssh/transport/hmac/md5'
   require 'net/ssh/transport/hmac/md5_96'
   require 'net/ssh/transport/hmac/ripemd160'
-  require 'net/ssh/transport/hmac/none'
 end
 
 # Implements a simple factory interface for fetching hmac implementations, or
 # for finding the key lengths for hmac implementations.s
 module Net::SSH::Transport::HMAC
   # The mapping of SSH hmac algorithms to their implementations
-  MAP = {
-    'hmac-md5'       => MD5,
-    'hmac-md5-96'    => MD5_96,
-    'hmac-sha1'      => SHA1,
-    'hmac-sha1-96'   => SHA1_96,
-    'hmac-ripemd160' => RIPEMD160,
-    'hmac-ripemd160@openssh.com' => RIPEMD160,
-    'none'           => None
-  }
+  MAP = { 'none' => None }
 
-  # add mapping to sha2 hmac algorithms if they're available
-  MAP['hmac-sha2-256']    = SHA2_256    if defined?(::Net::SSH::Transport::HMAC::SHA2_256)
-  MAP['hmac-sha2-256-96'] = SHA2_256_96 if defined?(::Net::SSH::Transport::HMAC::SHA2_256_96)
-  MAP['hmac-sha2-512']    = SHA2_512    if defined?(::Net::SSH::Transport::HMAC::SHA2_512)
-  MAP['hmac-sha2-512-96'] = SHA2_512_96 if defined?(::Net::SSH::Transport::HMAC::SHA2_512_96)
+  # Add mappings if they are available
+  MAP['hmac-md5']                   = MD5         if defined?(::Net::SSH::Transport::HMAC::MD5)
+  MAP['hmac-md5-96']                = MD5_96      if defined?(::Net::SSH::Transport::HMAC::MD5_96)
+  MAP['hmac-ripemd160']             = RIPEMD160   if defined?(::Net::SSH::Transport::HMAC::RIPEMD160)
+  MAP['hmac-ripemd160@openssh.com'] = RIPEMD160   if defined?(::Net::SSH::Transport::HMAC::RIPEMD160)
+  MAP['hmac-sha1']                  = SHA1        if defined?(::Net::SSH::Transport::HMAC::SHA1)
+  MAP['hmac-sha1-96']               = SHA1_96     if defined?(::Net::SSH::Transport::HMAC::SHA1_96)
+  MAP['hmac-sha2-256']              = SHA2_256    if defined?(::Net::SSH::Transport::HMAC::SHA2_256)
+  MAP['hmac-sha2-256-96']           = SHA2_256_96 if defined?(::Net::SSH::Transport::HMAC::SHA2_256_96)
+  MAP['hmac-sha2-512']              = SHA2_512    if defined?(::Net::SSH::Transport::HMAC::SHA2_512)
+  MAP['hmac-sha2-512-96']           = SHA2_512_96 if defined?(::Net::SSH::Transport::HMAC::SHA2_512_96)
 
   # Retrieves a new hmac instance of the given SSH type (+name+). If +key+ is
   # given, the new instance will be initialized with that key.

--- a/lib/net/ssh/transport/kex/diffie_hellman_group1_sha1.rb
+++ b/lib/net/ssh/transport/kex/diffie_hellman_group1_sha1.rb
@@ -1,3 +1,4 @@
+require 'net/ssh/fips'
 require 'net/ssh/buffer'
 require 'net/ssh/errors'
 require 'net/ssh/loggable'
@@ -188,7 +189,7 @@ module Net; module SSH; module Transport; module Kex
 
       def generate_key_fingerprint(key)
         blob = Net::SSH::Buffer.from(:key, key).to_s
-        fingerprint = OpenSSL::Digest::MD5.hexdigest(blob).scan(/../).join(":")
+        fingerprint = Net::SSH::OPENSSL_DIGEST.hexdigest(blob).scan(/../).join(":")
 
         [blob, fingerprint]
       rescue ::Exception => e

--- a/lib/net/ssh/transport/kex/diffie_hellman_group1_sha1.rb
+++ b/lib/net/ssh/transport/kex/diffie_hellman_group1_sha1.rb
@@ -189,7 +189,7 @@ module Net; module SSH; module Transport; module Kex
 
       def generate_key_fingerprint(key)
         blob = Net::SSH::Buffer.from(:key, key).to_s
-        fingerprint = Net::SSH::OPENSSL_DIGEST.hexdigest(blob).scan(/../).join(":")
+        fingerprint = Net::SSH.fingerprint(blob)
 
         [blob, fingerprint]
       rescue ::Exception => e

--- a/lib/net/ssh/transport/openssl.rb
+++ b/lib/net/ssh/transport/openssl.rb
@@ -31,7 +31,7 @@ module OpenSSL
       require 'net/ssh/fips'
 
       def fingerprint
-        @fingerprint ||= Net::SSH::OPENSSL_DIGEST.hexdigest(to_blob).scan(/../).join(":")
+        @fingerprint ||= Net::SSH.fingerprint(to_blob)
       end
     end
 

--- a/lib/net/ssh/transport/openssl.rb
+++ b/lib/net/ssh/transport/openssl.rb
@@ -28,8 +28,10 @@ module OpenSSL
   module PKey
 
     class PKey
+      require 'net/ssh/fips'
+
       def fingerprint
-        @fingerprint ||= OpenSSL::Digest::MD5.hexdigest(to_blob).scan(/../).join(":")
+        @fingerprint ||= Net::SSH::OPENSSL_DIGEST.hexdigest(to_blob).scan(/../).join(":")
       end
     end
 

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -23,7 +23,8 @@ module Transport
       if defined?(OpenSSL::Digest::SHA256)
         assert_equal %w(hmac-sha1 hmac-md5 hmac-sha1-96 hmac-md5-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-sha2-256 hmac-sha2-512 hmac-sha2-256-96 hmac-sha2-512-96 none), algorithms[:hmac]
       else
-        assert_equal %w(hmac-sha1 hmac-md5 hmac-sha1-96 hmac-md5-96 hmac-ripemd160 hmac-ripemd160@openssh.com none umac-128-etm@openssh.com), algorithms[:hmac] end
+        assert_equal %w(hmac-sha1 hmac-md5 hmac-sha1-96 hmac-md5-96 hmac-ripemd160 hmac-ripemd160@openssh.com none umac-128-etm@openssh.com), algorithms[:hmac]
+      end
       assert_equal %w(none zlib@openssh.com zlib), algorithms[:compression]
       assert_equal %w(), algorithms[:language]
     end


### PR DESCRIPTION
FIPS enabled system are restricted in which algorithms may be used.
Without restricting the underlying cryptographic methods used by
net/ssh, applications built around the library may crash in unexpected
ways during use.

This patch detects whether or not non-FIPS algorithms can be used and
adjusts the default settiings accordingly.

Additionally transport/algorithms was updated to print the client and
server algorithms that are in use so that users can easily detect a
server/client algorithm mismatch in the future.

Closes #574