### PR TITLE
Fix SSH::Connection::Session#busy? iterating channel hash

### DIFF
--- a/lib/net/ssh/connection/session.rb
+++ b/lib/net/ssh/connection/session.rb
@@ -155,7 +155,7 @@ module Net
           if include_invisible
             channels.any?
           else
-            channels.any? { |id, ch| !ch[:invisible] }
+            channels.dup.any? { |id, ch| !ch[:invisible] }
           end
         end
     


### PR DESCRIPTION
Maybe I'm using it wrong (I assumed some thread safety) but if I were to loop the SSH connection in a thread and creating new channels in another thread ([my code that breaks](https://github.com/2called-chaos/db_sucker/blob/master/lib/db_sucker/application/dispatch.rb#L121-L139)) I sometimes get:

```
RuntimeError: can't add a new key into hash during iteration
.../net-ssh-4.2.0/lib/net/ssh/connection/session.rb:344:in `open_channel'
```

This PR dups the channel hash in the `SSH::Connection::Session#busy?` method which caused my issue (creating a new channel while busy? is iterating over it by using `any?` with a block and params).

I'm not sure if this creates other problems, e.g. busy returns false with the dupped hash while there was a new one inserted into the real one.

---

This is kinda related to #110 I suppose.

There are a few more places where `channels` are iterated without using the `each_channel` method (which dups the hash) but I'm not sure if there are issue with using dup or #110 just forgot them.

* https://github.com/net-ssh/net-ssh/blob/master/lib/net/ssh/connection/session.rb#L125
* https://github.com/net-ssh/net-ssh/blob/master/lib/net/ssh/connection/session.rb#L563

---

Additional info:

* Why is there no need to dup the other `any?` in the `busy?` method? The reason is the C implementation, it only iterates if there is a block given.
* This is only an issue if you were to use `ssh.loop` without a custom block (or use `busy?(false)` in it), this is why I haven't noticed that earlier since my main application uses a [custom check](https://github.com/2called-chaos/db_sucker/blob/master/lib/db_sucker/application/sklaven_treiber.rb#L170-L174) to see if there are pending channels.