### PR TITLE
Use empty config when testing default user

### DIFF
--- a/test/start/test_user_nil.rb
+++ b/test/start/test_user_nil.rb
@@ -20,7 +20,7 @@ module NetSSH
     def test_start_should_use_default_user_when_nil
       @authentication_session.stubs(:authenticate).with() {|_next_service, user, _password| user == Etc.getlogin }.returns(true)
       assert_nothing_raised do
-        Net::SSH.start('localhost')
+        Net::SSH.start('localhost', nil, config: false)
       end
     end
   end


### PR DESCRIPTION
The goal of this test seems to be to confirm that the current user's login is used when ssh-ing.  However, it breaks when `~/.ssh/config` contains `User` directives which override the default login.

e.g.:

```
Host *
  User chris_taylor
```

...will cause the test to fail as follows:

```
  1) Failure:
NetSSH::TestStartUserNil#test_start_should_use_default_user_when_nil [/home/ctaylorr/work/net-ssh/test/start/test_user_nil.rb:22]:
unexpected invocation: #<Mock:authentication_session>.authenticate("ssh-connection", "chris_taylor", nil)
satisfied expectations:
- allowed any number of times, not yet invoked: #<Mock:authentication_session>.authenticate()
- allowed any number of times, invoked once: Net::SSH::Authentication::Session.new(any_parameters)
- allowed any number of times, invoked once: Net::SSH::Transport::Session.new(any_parameters)
- allowed any number of times, not yet invoked: Net::SSH::Connection::Session.new(any_parameters)
```

These changes ensure that a default ssh config is used for the purposes of the test.