### PR TITLE
fix net/ssh 5+ for jruby

### DIFF
--- a/lib/net/ssh/transport/cipher_factory.rb
+++ b/lib/net/ssh/transport/cipher_factory.rb
@@ -27,9 +27,9 @@ module Net
           "3des-ctr"                    => "des-ede3",
           "blowfish-ctr"                => "bf-ecb",
     
-          "aes256-ctr"                  => "aes-256-ctr",
-          "aes192-ctr"                  => "aes-192-ctr",
-          "aes128-ctr"                  => "aes-128-ctr",
+          "aes256-ctr"                  => ::OpenSSL::Cipher.ciphers.include?("aes-256-ctr") ? "aes-256-ctr" : "aes-256-ecb",
+          "aes192-ctr"                  => ::OpenSSL::Cipher.ciphers.include?("aes-192-ctr") ? "aes-192-ctr" : "aes-192-ecb",
+          "aes128-ctr"                  => ::OpenSSL::Cipher.ciphers.include?("aes-128-ctr") ? "aes-128-ctr" : "aes-128-ecb",
           "cast128-ctr"                 => "cast5-ecb",
     
           "none"                        => "none"


### PR DESCRIPTION
while this doesn't cleanup the specs for jruby yet (a few issues are being fixed in jruby-openssl with `set_key` on pkey); it does allow net/ssh > 5 to work on Jruby as the ctr ciphers are not yet available in jruby-openssl

fixes issue #611 

