### PR TITLE
fixing to work with windows and wingftpserver connecting with public key

### DIFF
--- a/lib/net/ssh/authentication/methods/publickey.rb
+++ b/lib/net/ssh/authentication/methods/publickey.rb
@@ -82,6 +82,8 @@ module Net
 
             when USERAUTH_FAILURE
               return false
+            when USERAUTH_SUCCESS
+              return true
 
             else
               raise Net::SSH::Exception, "unexpected reply to USERAUTH_REQUEST: #{message.type} (#{message.inspect})"


### PR DESCRIPTION
for some reason when using wingftp server it is returning success that is not handled in the library and it was raising an exception.    


```
trying publickey (<fingerprint removed>)
D, [2018-07-11T11:52:06.075571 #16848] DEBUG -- net.ssh.authentication.methods.publickey[3fc7a4652b8c]: trying publickey (<fingerprint removed>)
D, [2018-07-11T11:52:06.075980 #16848] DEBUG -- socket[3fc7a47d0860]: queueing packet nr 4 type 50 len 604
D, [2018-07-11T11:52:06.076182 #16848] DEBUG -- socket[3fc7a47d0860]: sent 628 bytes
D, [2018-07-11T11:52:06.106931 #16848] DEBUG -- socket[3fc7a47d0860]: read 36 bytes
D, [2018-07-11T11:52:06.107231 #16848] DEBUG -- socket[3fc7a47d0860]: received packet nr 4 type 52 len 12
Net::SSH::Exception: unexpected reply to USERAUTH_REQUEST: 52 (#<Net::SSH::Packet:0x007f89bd168bb0 @named_elements={}, @content="4", @position=1, @type=52>)
  from <path>/vendor/bundle/ruby/2.4.0/gems/net-ssh-5.0.2/lib/net/ssh/authentication/methods/publickey.rb:87:in `authenticate_with'
  from <path>/vendor/bundle/ruby/2.4.0/gems/net-ssh-5.0.2/lib/net/ssh/authentication/methods/publickey.rb:20:in `block in authenticate'
  from <path>/vendor/bundle/ruby/2.4.0/gems/net-ssh-5.0.2/lib/net/ssh/authentication/key_manager.rb:112:in `block in each_identity'
  from <path>/vendor/bundle/ruby/2.4.0/gems/net-ssh-5.0.2/lib/net/ssh/authentication/key_manager.rb:104:in `each'
  from <path>/vendor/bundle/ruby/2.4.0/gems/net-ssh-5.0.2/lib/net/ssh/authentication/key_manager.rb:104:in `each_identity'
  from <path>/vendor/bundle/ruby/2.4.0/gems/net-ssh-5.0.2/lib/net/ssh/authentication/methods/publickey.rb:19:in `authenticate'
  from <path>/vendor/bundle/ruby/2.4.0/gems/net-ssh-5.0.2/lib/net/ssh/authentication/session.rb:85:in `block in authenticate'
  from <path>/vendor/bundle/ruby/2.4.0/gems/net-ssh-5.0.2/lib/net/ssh/authentication/session.rb:71:in `each'
  from <path>/vendor/bundle/ruby/2.4.0/gems/net-ssh-5.0.2/lib/net/ssh/authentication/session.rb:71:in `authenticate
```


when using command line I see the following

`debug1: Remote protocol version 2.0, remote software version WingFTPServer
debug1: no match: WingFTPServer
`