### PR TITLE
Fix ansible/rvm install on python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
 
 install:
   - export JRUBY_OPTS='--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -Xcext.enabled=false -J-Xss2m -Xcompile.invokedynamic=false'
-  - sudo pip install ansible
+  - sudo pip install ansible urllib3 pyOpenSSL ndg-httpsclient pyasn1
   - gem install bundler -v "= 1.16"
   - gem list bundler
   - bundle _1.16_ install


### PR DESCRIPTION
Tiger CI has pthon 2.6 and there were ansible validation issues