### PR TITLE
Add timeout to blocking next_packet IO.select

### DIFF
--- a/lib/net/ssh/test/extensions.rb
+++ b/lib/net/ssh/test/extensions.rb
@@ -156,6 +156,8 @@ module Net
               end
     
               raise "no readers were ready for reading, and none had any incoming packets" if processed == 0 && wait != 0
+
+              [[], [], []]
             end
           end
         end

--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -190,7 +190,7 @@ module Net
           loop do
             return @queue.shift if consume_queue && @queue.any? && algorithms.allow?(@queue.first)
 
-            packet = socket.next_packet(mode)
+            packet = socket.next_packet(mode, options[:timeout])
             return nil if packet.nil?
 
             case packet.type

--- a/test/transport/test_packet_stream.rb
+++ b/test/transport/test_packet_stream.rb
@@ -172,6 +172,11 @@ module Transport
       assert_raises(Net::SSH::Disconnect) { stream.next_packet(:block) }
     end
 
+    def test_next_packet_when_blocking_times_out
+      IO.expects(:select).with([stream], nil, nil, 7).returns(nil)
+      assert_raises(Net::SSH::ConnectionTimeout) { stream.next_packet(:block, 7) }
+    end
+
     def test_next_packet_fails_with_invalid_argument
       assert_raises(ArgumentError) { stream.next_packet("invalid") }
     end

--- a/test/transport/test_session.rb
+++ b/test/transport/test_session.rb
@@ -193,13 +193,19 @@ module Transport
 
     def test_poll_message_should_query_next_packet_using_the_given_blocking_parameter
       session!
-      socket.expects(:next_packet).with(:blocking_parameter).returns(nil)
+      socket.expects(:next_packet).with(:blocking_parameter, nil).returns(nil)
       session.poll_message(:blocking_parameter)
+    end
+
+    def test_poll_message_should_query_next_packet_using_the_timeout_option
+      session!(timeout: 7)
+      socket.expects(:next_packet).with(:nonblock, 7).returns(nil)
+      session.poll_message
     end
 
     def test_poll_message_should_default_to_non_blocking
       session!
-      socket.expects(:next_packet).with(:nonblock).returns(nil)
+      socket.expects(:next_packet).with(:nonblock, nil).returns(nil)
       session.poll_message
     end
 


### PR DESCRIPTION
If the socket isn't closed properly for some reason this select will
block forever.

Fixes #550