### PR TITLE
Add missing 'logger' in test_session.rb.

### DIFF
--- a/test/transport/test_session.rb
+++ b/test/transport/test_session.rb
@@ -1,6 +1,7 @@
 require_relative '../common'
 require 'net/ssh/transport/session'
 require 'net/ssh/proxy/http'
+require 'logger'
 
 # mocha adds #verify to Object, which throws off the host-key-verifier part of
 # these tests.


### PR DESCRIPTION
Otherwise there is an intermittent test failure depending on which order tests are loaded in. The Debian buildds have managed to hit this multiple times.