### PR TITLE
Prefer more modern cryptographic algorithms

### DIFF
--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -26,35 +26,44 @@ module Net
         # Define the default algorithms, in order of preference, supported by
         # Net::SSH.
         ALGORITHMS = {
-          host_key: %w[ssh-rsa ssh-dss
-                       ssh-rsa-cert-v01@openssh.com
-                       ssh-rsa-cert-v00@openssh.com],
-          kex: %w[diffie-hellman-group-exchange-sha1
-                  diffie-hellman-group1-sha1
+          host_key: %w[ssh-rsa-cert-v01@openssh.com
+                       ssh-rsa-cert-v00@openssh.com
+                       ssh-rsa ssh-dss],
+          kex: %w[diffie-hellman-group-exchange-sha256
+                  diffie-hellman-group-exchange-sha1
                   diffie-hellman-group14-sha1
-                  diffie-hellman-group-exchange-sha256],
-          encryption: %w[aes128-cbc 3des-cbc blowfish-cbc cast128-cbc
-                         aes192-cbc aes256-cbc rijndael-cbc@lysator.liu.se
-                         idea-cbc arcfour128 arcfour256 arcfour
-                         aes128-ctr aes192-ctr aes256-ctr
-                         cast128-ctr blowfish-ctr 3des-ctr none],
-    
-          hmac: %w[hmac-sha1 hmac-md5 hmac-sha1-96 hmac-md5-96
+                  diffie-hellman-group1-sha1],
+          encryption: %w[aes256-ctr aes192-ctr aes128-ctr
+                         aes256-cbc aes192-cbc aes128-cbc
+                         rijndael-cbc@lysator.liu.se
+                         blowfish-ctr blowfish-cbc
+                         cast128-ctr cast128-cbc
+                         3des-ctr 3des-cbc
+                         idea-cbc arcfour256 arcfour128 arcfour
+                         none],
+
+          hmac: %w[hmac-sha2-512 hmac-sha2-256
+                   hmac-sha2-512-96 hmac-sha2-256-96
+                   hmac-sha1 hmac-sha1-96
                    hmac-ripemd160 hmac-ripemd160@openssh.com
-                   hmac-sha2-256 hmac-sha2-512 hmac-sha2-256-96
-                   hmac-sha2-512-96 none],
-    
+                   hmac-md5 hmac-md5-96
+                   none],
+
           compression: %w[none zlib@openssh.com zlib],
           language: %w[]
         }
         if defined?(OpenSSL::PKey::EC)
-          ALGORITHMS[:host_key] += %w[ecdsa-sha2-nistp256
-                                      ecdsa-sha2-nistp384
-                                      ecdsa-sha2-nistp521]
-          ALGORITHMS[:host_key] += %w[ssh-ed25519] if Net::SSH::Authentication::ED25519Loader::LOADED
-          ALGORITHMS[:kex] += %w[ecdh-sha2-nistp256
-                                 ecdh-sha2-nistp384
-                                 ecdh-sha2-nistp521]
+          ALGORITHMS[:host_key].unshift(*%w[ecdsa-sha2-nistp521-cert-v01@openssh.com
+                                            ecdsa-sha2-nistp384-cert-v01@openssh.com
+                                            ecdsa-sha2-nistp256-cert-v01@openssh.com
+                                            ecdsa-sha2-nistp521
+                                            ecdsa-sha2-nistp384
+                                            ecdsa-sha2-nistp256])
+          ALGORITHMS[:host_key].unshift(*%w[ssh-ed25519-cert-v01@openssh.com
+                                            ssh-ed25519]) if Net::SSH::Authentication::ED25519Loader::LOADED
+          ALGORITHMS[:kex].unshift(*%w[ecdh-sha2-nistp521
+                                       ecdh-sha2-nistp384
+                                       ecdh-sha2-nistp256])
         end
     
         # The underlying transport layer session that supports this object


### PR DESCRIPTION
This commit modifies Net::SSH to prefer strong encryption for HMAC,
Cipher, Host Key Authentication and Key Exchange operations. It should resolve #627.