### PR TITLE
Skip identities that provide invalid key

### DIFF
--- a/lib/net/ssh/authentication/agent.rb
+++ b/lib/net/ssh/authentication/agent.rb
@@ -124,6 +124,10 @@ module Net
             comment_str = body.read_string
             begin
               key = Buffer.new(key_str).read_key
+              if key.nil?
+                error { "ignoring invalid key: #{comment_str}" }
+                next
+              end
               key.extend(Comment)
               key.comment = comment_str
               identities.push key


### PR DESCRIPTION
This PR fixes an issue where an invalid result was provided by the ssh-agent daemon when reading available identities. The root cause of the originating issue was within the gnome-keyring project where it would improperly read in v1 public keys and return invalid results. The result of which would be this error:

```
/gems/2.2.0/gems/net-ssh-5.0.2/lib/net/ssh/authentication/agent.rb:128:in `block in identities': can't modify frozen NilClass (RuntimeError)
```

Since `Buffer#read_key` will return `nil` on certain conditions, this PR validates the result is not `nil` before continuing on. If the result _is_ nil, it logs an error and continues on.