### PR TITLE
Server key signature verification done even if not requested

### DIFF
--- a/lib/net/ssh/transport/kex/diffie_hellman_group1_sha1.rb
+++ b/lib/net/ssh/transport/kex/diffie_hellman_group1_sha1.rb
@@ -206,7 +206,7 @@ module Net
 
             hash = @digester.digest(response.to_s)
 
-            raise Net::SSH::Exception, "could not verify server signature" unless result[:server_key].ssh_do_verify(result[:server_sig], hash)
+            raise Net::SSH::Exception, "could not verify server signature" unless connection.host_key_verifier.verify_signature { result[:server_key].ssh_do_verify(result[:server_sig], hash) }
 
             return hash
           end

--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -274,6 +274,23 @@ module Net
 
         private
 
+        # Compatibility verifier which allows users to keep using
+        # custom verifier code without adding new :verify_signature
+        # method.
+        class CompatibleVerifier
+          def initialize(verifier)
+            @verifier
+          end
+
+          def verify(arguments)
+            @verifier.verify(arguments)
+          end
+
+          def verify_signature(&block)
+            yield
+          end
+        end
+
         # Instantiates a new host-key verification class, based on the value of
         # the parameter.
         #
@@ -285,8 +302,8 @@ module Net
         # - :accept_new (insecure)
         # - :always (secure)
         #
-        # If the argument happens to respond to :verify, it is returned
-        # directly. Otherwise, an exception is raised.
+        # If the argument happens to respond to :verify and :verify_signature,
+        # it is returned directly. Otherwise, an exception is raised.
         #
         # Values false, true, and :very were deprecated in
         # [#595](https://github.com/net-ssh/net-ssh/pull/595)
@@ -314,7 +331,12 @@ module Net
             Net::SSH::Verifiers::Always.new
           else
             if verifier.respond_to?(:verify)
-              verifier
+              if verifier.respond_to?(:verify_signature)
+                verifier
+              else
+                Kernel.warn("Warning: verifier without :verify_signature is deprecated")
+                CompatibleVerifier.new(verifier)
+              end
             else
               raise(
                 ArgumentError,

--- a/lib/net/ssh/verifiers/accept_new.rb
+++ b/lib/net/ssh/verifiers/accept_new.rb
@@ -21,6 +21,13 @@ module Net
             return true
           end
         end
+
+        def verify_signature(&block)
+          yield
+        rescue HostKeyUnknown => err
+          err.remember_host!
+          return true
+        end
       end
 
     end

--- a/lib/net/ssh/verifiers/always.rb
+++ b/lib/net/ssh/verifiers/always.rb
@@ -34,6 +34,10 @@ module Net
           found
         end
 
+        def verify_signature(&block)
+          yield
+        end
+
         private
 
         def process_cache_miss(host_keys, args, exc_class, message)

--- a/lib/net/ssh/verifiers/never.rb
+++ b/lib/net/ssh/verifiers/never.rb
@@ -10,6 +10,10 @@ module Net
         def verify(arguments)
           true
         end
+
+        def verify_signature(&block)
+          true
+        end
       end
 
     end

--- a/test/common.rb
+++ b/test/common.rb
@@ -74,6 +74,10 @@ class MockTransport < Net::SSH::Transport::Session
     def verify(data)
       @block.call(data)
     end
+
+    def verify_signature(&block)
+      yield
+    end
   end
 
   attr_reader :host_key_verifier

--- a/test/transport/test_session.rb
+++ b/test/transport/test_session.rb
@@ -92,8 +92,15 @@ module Transport
     end
 
     def test_verify_host_key_value_responding_to_verify_should_pass_muster
-      object = stub("thingy", verify: true)
+      object = stub("thingy", verify: true, verify_signature: true)
       assert_equal object, session(verify_host_key: object).host_key_verifier
+    end
+
+    def test_deprecated_host_key_verifier
+      Kernel.expects(:warn).with('Warning: verifier without :verify_signature is deprecated')
+
+      object = stub("thingy", verify: true)
+      assert_not_nil session(verify_host_key: object).host_key_verifier
     end
 
     def test_host_as_string_should_return_host_and_ip_when_port_is_default

--- a/test/verifiers/test_always.rb
+++ b/test/verifiers/test_always.rb
@@ -37,4 +37,10 @@ class TestAlways < NetSSHTest
       secure_verifier.verify(session:OpenStruct.new(host_keys:host_keys), key:key_actual)
     }
   end
+
+  def test_verify_signature
+    secure_verifier = Net::SSH::Verifiers::Always.new
+
+    assert(true, secure_verifier.verify_signature { true })
+  end
 end


### PR DESCRIPTION
In my environment I know that server key verification would fail so
I set `verify_host_key` to `:never` I see following error:

```
diffie_hellman_group1_sha1.rb:211:in `verify_signature': could not verify server signature (Net::SSH::Exception)
```

This PR updates the Verifiers to provide key verification as well as key signature so when setting
that this operation should never be run it works fine.