### PR TITLE
Improve processing of ssh_config Match conditions

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -96,7 +96,7 @@ module Net
             next if value.nil?
 
             key.downcase!
-            value = $1 if value =~ /^"(.*)"$/
+            value = unquote(value)
 
             value = case value.strip
                     when /^\d+$/ then value.to_i
@@ -328,12 +328,17 @@ module Net
         end
 
         def eval_match_conditions(condition, host, settings)
-          conditions = condition.split(/\s+/)
+          # Not using `\s` for whitespace matching as canonical
+          # ssh_config parser implementation (OpenSSH) has specific character set.
+          # Ref: https://github.com/openssh/openssh-portable/blob/2581333d564d8697837729b3d07d45738eaf5a54/misc.c#L237-L239
+          conditions = condition.split(/[ \t\r\n]+|(?<!=)=(?!=)/).reject(&:empty?)
           return true if conditions == ["all"]
 
           conditions = conditions.each_slice(2)
-          matching = true
+          condition_matches = []
           conditions.each do |(kind,exprs)|
+            exprs = unquote(exprs)
+
             case kind.downcase
             when "all"
               raise "all cannot be mixed with other conditions"
@@ -348,12 +353,17 @@ module Net
               exprs.split(",").each do |expr|
                 condition_met = condition_met || host =~ pattern2regex(expr)
               end
-              matching = matching && negated ^ condition_met
+              condition_matches << (true && negated ^ condition_met)
               # else
               # warn "net-ssh: Unsupported expr in Match block: #{kind}"
             end
           end
-          matching
+
+          !condition_matches.empty? && condition_matches.all?
+        end
+
+        def unquote(string)
+          string =~ /^"(.*)"$/ ? Regexp.last_match(1) : string
         end
       end
     end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -310,7 +310,7 @@ class TestConfig < NetSSHTest
     net_ssh = Net::SSH::Config.translate(config)
     assert_equal true, net_ssh[:forward_agent]
     assert_equal true, net_ssh[:compression]
-    assert_equal 2345, net_ssh[:port]
+    assert_equal 22, net_ssh[:port]
   end
 
   def test_load_with_match_block_with_host
@@ -357,6 +357,132 @@ class TestConfig < NetSSHTest
       config = Net::SSH::Config.load(f, "bar.baz.com")
       assert_equal 1234, config['port']
       config = Net::SSH::Config.load(f, "foo")
+      assert_equal 1234, config['port']
+    end
+  end
+
+  def test_load_with_match_block_with_multi_space_separated_hosts_condition
+    # Extra tabs are thrown in between, for good measure
+    data = %q{
+      Match host 		 foo,*.baz.com
+        Port 1234
+        Compression no
+    }
+    with_config_from_data data do |f|
+      config = Net::SSH::Config.load(f, "bar2")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "bbaz.com")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "bar.baz.com")
+      assert_equal 1234, config['port']
+      config = Net::SSH::Config.load(f, "foo")
+      assert_equal 1234, config['port']
+    end
+  end
+
+  def test_load_with_match_block_with_quoted_hosts_condition
+    data = %q{
+      Match host "foo,*.baz.com"
+        Port 1234
+        Compression no
+    }
+    with_config_from_data data do |f|
+      config = Net::SSH::Config.load(f, "bar2")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "bbaz.com")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "bar.baz.com")
+      assert_equal 1234, config['port']
+      config = Net::SSH::Config.load(f, "foo")
+      assert_equal 1234, config['port']
+    end
+  end
+
+  def test_load_with_match_block_with_equal_signed_hosts_condition
+    data = %q{
+      Match host=foo,*.baz.com
+        Port 1234
+        Compression no
+    }
+    with_config_from_data data do |f|
+      config = Net::SSH::Config.load(f, "bar2")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "bbaz.com")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "bar.baz.com")
+      assert_equal 1234, config['port']
+      config = Net::SSH::Config.load(f, "foo")
+      assert_equal 1234, config['port']
+    end
+  end
+
+  def test_load_with_match_block_with_quoted_equal_signed_hosts_condition
+    data = %q{
+      Match host="foo,*.baz.com"
+        Port 1234
+        Compression no
+    }
+    with_config_from_data data do |f|
+      config = Net::SSH::Config.load(f, "bar2")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "bbaz.com")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "bar.baz.com")
+      assert_equal 1234, config['port']
+      config = Net::SSH::Config.load(f, "foo")
+      assert_equal 1234, config['port']
+    end
+  end
+
+  def test_load_with_match_block_with_whitespace_separated_equal_signed_hosts_condition
+    data = %q{
+      Match host = foo,*.baz.com
+        Port 1234
+        Compression no
+    }
+    with_config_from_data data do |f|
+      config = Net::SSH::Config.load(f, "bar2")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "bbaz.com")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "bar.baz.com")
+      assert_equal 1234, config['port']
+      config = Net::SSH::Config.load(f, "foo")
+      assert_equal 1234, config['port']
+    end
+  end
+
+  def test_load_with_match_block_with_multi_equal_signed_hosts_condition
+    data = %q{
+      Match host==foo,*.baz.com
+        Port 1234
+        Compression no
+    }
+    with_config_from_data data do |f|
+      config = Net::SSH::Config.load(f, "bar2")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "bbaz.com")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "bar.baz.com")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "foo")
+      assert_nil config['port']
+    end
+  end
+
+  def test_load_with_multiple_hosts_criteria
+    data = %q{
+      Match host *.baz.com host !bar.baz.com
+        Port 1234
+    }
+    with_config_from_data data do |f|
+      config = Net::SSH::Config.load(f, "bar2")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "bbaz.com")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "bar.baz.com")
+      assert_nil config['port']
+      config = Net::SSH::Config.load(f, "meh.baz.com")
       assert_equal 1234, config['port']
     end
   end


### PR DESCRIPTION
Previously wasn't correctly handling quoted and `=` delimited values.
Also, fixes logic that unsupported `Match` conditions result in subsequent declarations to be applied for configuration.

OpenSSH implementation details:
- https://github.com/openssh/openssh-portable/blob/624d19ac2d56fa86a22417c35536caceb3be346f/readconf.c#L599
- https://github.com/openssh/openssh-portable/blob/624d19ac2d56fa86a22417c35536caceb3be346f/misc.c#L284-L285

---

Closes #631