### PR TITLE
Add support for IdentityAgent in ssh_config

### DIFF
--- a/lib/net/ssh/authentication/agent.rb
+++ b/lib/net/ssh/authentication/agent.rb
@@ -62,9 +62,9 @@ module Net
 
         # Instantiates a new agent object, connects to a running SSH agent,
         # negotiates the agent protocol version, and returns the agent object.
-        def self.connect(logger=nil, agent_socket_factory = nil)
+        def self.connect(logger=nil, agent_socket_factory = nil, identity_agent = nil)
           agent = new(logger)
-          agent.connect!(agent_socket_factory)
+          agent.connect!(agent_socket_factory, identity_agent)
           agent.negotiate!
           agent
         end
@@ -79,11 +79,13 @@ module Net
         # given by the attribute writers. If the agent on the other end of the
         # socket reports that it is an SSH2-compatible agent, this will fail
         # (it only supports the ssh-agent distributed by OpenSSH).
-        def connect!(agent_socket_factory = nil)
+        def connect!(agent_socket_factory = nil, identity_agent = nil)
           debug { "connecting to ssh-agent" }
           @socket =
             if agent_socket_factory
               agent_socket_factory.call
+            elsif identity_agent
+              unix_socket_class.open(identity_agent)
             elsif ENV['SSH_AUTH_SOCK'] && unix_socket_class
               unix_socket_class.open(ENV['SSH_AUTH_SOCK'])
             elsif Gem.win_platform? && RUBY_ENGINE != "jruby"

--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -176,7 +176,7 @@ module Net
         # or if the agent is otherwise not available.
         def agent
           return unless use_agent?
-          @agent ||= Agent.connect(logger, options[:agent_socket_factory])
+          @agent ||= Agent.connect(logger, options[:agent_socket_factory], options[:identity_agent])
         rescue AgentNotAvailable
           @use_agent = false
           nil

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -22,6 +22,7 @@ module Net
     # * HostKeyAlias => :host_key_alias
     # * HostName => :host_name
     # * IdentityFile => maps to the :keys option
+    # * IdentityAgent => :identity_agent
     # * IdentitiesOnly => :keys_only
     # * Macs => maps to the :hmac option
     # * PasswordAuthentication => maps to the :auth_methods option password
@@ -194,6 +195,7 @@ module Net
             connecttimeout: :timeout,
             forwardagent: :forward_agent,
             identitiesonly: :keys_only,
+            identityagent: :identity_agent,
             globalknownhostsfile: :global_known_hosts_file,
             hostkeyalias: :host_key_alias,
             identityfile: :keys,


### PR DESCRIPTION
This commit adds support for configuring the IdentityAgent through an SSH config file.