### PR TITLE
Pass :password_prompt to KeyFactory.load_private_key

### DIFF
--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -139,7 +139,7 @@ module Net
 
           if info[:key].nil? && info[:from] == :file
             begin
-              info[:key] = KeyFactory.load_private_key(info[:file], options[:passphrase], !options[:non_interactive])
+              info[:key] = KeyFactory.load_private_key(info[:file], options[:passphrase], !options[:non_interactive], options[:password_prompt])
             rescue OpenSSL::OpenSSLError, Exception => e
               raise KeyManagerError, "the given identity is known, but the private key could not be loaded: #{e.class} (#{e.message})"
             end

--- a/test/authentication/test_key_manager.rb
+++ b/test/authentication/test_key_manager.rb
@@ -174,6 +174,12 @@ module Authentication
       end
     end
 
+    def test_sign_passes_password_prompt_to_key_factory
+      manager.known_identities[rsa] = { from: :file, file: "/first" }
+      Net::SSH::KeyFactory.expects(:load_private_key).with('/first', nil, true, prompt).returns(rsa)
+      manager.sign(rsa, "hello, world")
+    end
+
     private
 
     def stub_file_private_key(name, key, options = {})


### PR DESCRIPTION
Fixes #668

At least in the issue example app's simple case.

The example app from issue

#### Before:

```
$ ruby example.rb
Enter passphrase for /Users/kimmo/.ssh/passphrase:
```

#### After:

```
$ ruby example.rb
just asking..
just asking..
just asking..
```
