### PR TITLE
Send EOF on closing channels.

### DIFF
--- a/lib/net/ssh/connection/session.rb
+++ b/lib/net/ssh/connection/session.rb
@@ -120,7 +120,12 @@ module Net
         # connection.
         def close
           info { "closing remaining channels (#{channels.length} open)" }
-          channels.each { |id, channel| channel.close }
+
+          channels.each do |id, channel|
+            channel.eof!
+            channel.close
+          end
+
           begin
             loop(0.1) { channels.any? }
           rescue Net::SSH::Disconnect


### PR DESCRIPTION
Sending EOF is the default behaviour of openssh client.
Some servers (SSH-2.0-7.9.0.0_openssh GlobalSCAPE) ignore the CLOSE message, but respond to EOF by closing the channel.
OpenSSH server handles the EOF properly.

Might fix the https://github.com/net-ssh/net-sftp/issues/22 and similar hangs on closing the SFTP connection.