### PR TITLE
Log details of failure to negotiate algorithms

### DIFF
--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -368,7 +368,13 @@ module Net
         def negotiate(algorithm)
           match = self[algorithm].find { |item| @server_data[algorithm].include?(item) }
 
-          raise Net::SSH::Exception, "could not settle on #{algorithm} algorithm" if match.nil?
+          if match.nil?
+            error_message = "could not settle on #{algorithm} algorithm"
+            error { error_message }
+            error { "Server #{algorithm} preferences: #{@server_data[algorithm].join(',')}" }
+            error { "Client #{algorithm} preferences: #{self[algorithm].join(',')}" }
+            raise Net::SSH::Exception, "#{error_message} - see error log for details"
+          end
 
           return match
         end

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -369,11 +369,9 @@ module Net
           match = self[algorithm].find { |item| @server_data[algorithm].include?(item) }
 
           if match.nil?
-            error_message = "could not settle on #{algorithm} algorithm"
-            error { error_message }
-            error { "Server #{algorithm} preferences: #{@server_data[algorithm].join(',')}" }
-            error { "Client #{algorithm} preferences: #{self[algorithm].join(',')}" }
-            raise Net::SSH::Exception, "#{error_message} - see error log for details"
+            raise Net::SSH::Exception, "could not settle on #{algorithm} algorithm\n"\
+              "Server #{algorithm} preferences: #{@server_data[algorithm].join(',')}\n"\
+              "Client #{algorithm} preferences: #{self[algorithm].join(',')}"
           end
 
           return match


### PR DESCRIPTION
Summary
Failure to negotiate algorithms is a common cause of connection
difficulties. This adds helpful troubleshooting information to the
log (at the 'error' level), plus a suggestion to check the log. The
intent is to clarify the problem and make troubleshooting easier.

Motivation
It seems most Issue reports involving the "could not settle" exception are due to client or server mis-configuration, not problems with this gem.  This will increase people's ability to troubleshoot mis-configurations on their own, and reduce the workload on this gem's maintainers.

Background
Some examples of people reporting being stuck on the Net::SSH "could not settle" exception (and may have been able to troubleshoot on their own with additional details):
- https://github.com/net-ssh/net-ssh/issues/93#issuecomment-16364036
- https://github.com/net-ssh/net-ssh/issues/260#issue-98723033
- https://github.com/net-ssh/net-ssh/issues/314#issue-136991264
- https://github.com/net-ssh/net-ssh/issues/342#issue-144385233
- https://github.com/net-ssh/net-ssh/issues/433#issue-178058586
- https://github.com/net-ssh/net-ssh/issues/592#issue-307777348
- https://github.com/net-ssh/net-ssh/issues/654#issue-398721080

By The Way
Thanks @mfazekas for your excellent work maintaining this gem.  Your replies in some of the Issue reports above were super helpful toward my own troubleshooting when I encountered the "could not settle" exception last week.  Appreciate you.

