### PR TITLE
Expose StrictHostKeyChecking from SSH config

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -33,6 +33,7 @@ module Net
     # * ProxyJump => maps to the :proxy option
     # * PubKeyAuthentication => maps to the :auth_methods option
     # * RekeyLimit => :rekey_limit
+    # * StrictHostKeyChecking => :strict_host_key_checking
     # * User => :user
     # * UserKnownHostsFile => :user_known_hosts_file
     # * NumberOfPasswordPrompts => :number_of_password_prompts
@@ -202,6 +203,7 @@ module Net
             identityfile: :keys,
             fingerprinthash: :fingerprint_hash,
             port: :port,
+            stricthostkeychecking: :strict_host_key_checking,
             user: :user,
             userknownhostsfile: :user_known_hosts_file,
             checkhostip: :check_host_ip

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -139,7 +139,9 @@ class TestConfig < NetSSHTest
       'numberofpasswordprompts' => '123',
       'serveraliveinterval'     => '2',
       'serveralivecountmax'     => '4',
-      'fingerprinthash'         => 'MD5'
+      'fingerprinthash'         => 'MD5',
+      'userknownhostsfile'      => '/dev/null',
+      'stricthostkeychecking'   => false
     }
 
     net_ssh = Net::SSH::Config.translate(open_ssh)
@@ -161,7 +163,9 @@ class TestConfig < NetSSHTest
     assert_equal 4,         net_ssh[:keepalive_maxcount]
     assert_equal 2,         net_ssh[:keepalive_interval]
     assert_equal 'MD5',     net_ssh[:fingerprint_hash]
-    assert_equal true, net_ssh[:keepalive]
+    assert_equal true,      net_ssh[:keepalive]
+    assert_equal '/dev/null', net_ssh[:user_known_hosts_file]
+    assert_equal false, net_ssh[:strict_host_key_checking]
   end
 
   def test_translate_should_turn_off_authentication_methods


### PR DESCRIPTION
Make this setting available so it can be used when deciding how to configure `verify_host_key` so that users of this library can enable behavior consistent with `ssh`.

Resolves #678.