### PR TITLE
Fix bundle 2.0 compatibility

### DIFF
--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency("ed25519", "~> 1.2")
   end
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", ">= 1.11"
 
   spec.add_development_dependency "minitest", "~> 5.10"
   spec.add_development_dependency "mocha", ">= 1.2.1"


### PR DESCRIPTION
This PR solve the bundle 2.0 compatibility issue : 

```
$ bundle install
Fetching gem metadata from https://rubygems.org/.............
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.11)

  Current Bundler version:
    bundler (2.0.2)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 1.11)' in any of the relevant sources:
  the local ruby installation
```