### PR TITLE
Update vagran and playbook

### DIFF
--- a/test/integration/Vagrantfile
+++ b/test/integration/Vagrantfile
@@ -6,6 +6,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "./playbook.yml"
     ansible.sudo = true
     ansible.verbose = 'vvvv'
+    ansible.compatibility_mode = "2.0"
   end
 
   config.vm.synced_folder "../..", "/net-ssh"

--- a/test/integration/playbook.yml
+++ b/test/integration/playbook.yml
@@ -41,9 +41,10 @@
     - lineinfile: dest=/etc/sudoers.d/net_ssh_1 mode=0440 state=present create=yes
         line='net_ssh_2 ALL=(ALL) NOPASSWD:ALL' regexp=net_ssh_2
     - unarchive:
-        src: https://ftp.spline.de/pub/OpenBSD/OpenSSH/portable/openssh-7.4p1.tar.gz
+        src: https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-7.4p1.tar.gz
         dest: /tmp
         remote_src: True
+        validate_certs: False
     - name: building and installing openssh 7.4 (used in forward test)
       command: sh -c "./configure --prefix=/opt/net-ssh-openssh && make && sudo make install"
       args:


### PR DESCRIPTION
It looks `https://ftp.spline.de/pub/OpenBSD/OpenSSH/portable/openssh-7.4p1.tar.gz` is not working and on my mac i had to turn off `validate_certs` - sounds a python/openssl issue.