### PR TITLE
Add changelog_uri to metadata to easily link from rubygems.org

### DIFF
--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/net-ssh/net-ssh"
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3")
-  spec.metadata      = {
+  spec.metadata = {
     "changelog_uri" => "https://github.com/net-ssh/net-ssh/blob/master/CHANGES.txt"
   }
 

--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -17,6 +17,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/net-ssh/net-ssh"
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3")
+  spec.metadata      = {
+    "changelog_uri" => "https://github.com/net-ssh/net-ssh/blob/master/CHANGES.txt"
+  }
 
   spec.extra_rdoc_files = [
     "LICENSE.txt",


### PR DESCRIPTION
Reference: https://guides.rubygems.org/specification-reference/#metadata