### PR TITLE
Fix unexpected IOError

### DIFF
--- a/lib/net/ssh/connection/session.rb
+++ b/lib/net/ssh/connection/session.rb
@@ -177,8 +177,8 @@ module Net
         #   ssh.loop(0.1) { not int_pressed }
         def loop(wait=nil, &block)
           running = block || Proc.new { busy? }
-          loop_forever { break unless process(wait, &running) }
           begin
+            loop_forever { break unless process(wait, &running) }
             process(0)
           rescue IOError => e
             if e.message =~ /closed/

--- a/lib/net/ssh/proxy/http.rb
+++ b/lib/net/ssh/proxy/http.rb
@@ -65,7 +65,11 @@ module Net
     
           return socket if resp[:code] == 200
     
-          socket.close
+          begin
+            socket.close
+          rescue IOError
+            nil
+          end
           raise ConnectError, resp.inspect
         end
     

--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -127,7 +127,11 @@ module Net
         # Cleans up (see PacketStream#cleanup) and closes the underlying socket.
         def close
           socket.cleanup
-          socket.close
+          begin
+            socket.close
+          rescue IOError
+            nil
+          end
         end
 
         # Performs a "hard" shutdown of the connection. In general, this should
@@ -136,7 +140,11 @@ module Net
         # underlying protocol's state).
         def shutdown!
           error { "forcing connection closed" }
-          socket.close
+          begin
+            socket.close
+          rescue IOError
+            nil
+          end
         end
 
         # Returns a new service_request packet for the given service name, ready


### PR DESCRIPTION
Connectiong with a remote Windows system ends up in unexpected
IOErrors, which let the connection fail totally.
The dedicated location, where the IOError happens couldn't be
detected exactly. Though it should be rescued.