### PR TITLE
Fix Loggable to use to_s method instead of name method for self.class

### DIFF
--- a/lib/net/ssh/loggable.rb
+++ b/lib/net/ssh/loggable.rb
@@ -56,7 +56,7 @@ module Net
       # originates. It defaults to the name of class with the object_id
       # appended.
       def facility
-        @facility ||= self.class.name.gsub(/::/, ".").gsub(/([a-z])([A-Z])/, "\\1_\\2").downcase + "[%x]" % object_id
+        @facility ||= self.class.to_s.gsub(/::/, ".").gsub(/([a-z])([A-Z])/, "\\1_\\2").downcase + "[%x]" % object_id
       end
     end
   end


### PR DESCRIPTION
This PR is to replace `self.class.name` with `self.class.to_s` in Loggable module's facility method.

I tried including Net::SSH::Loggable module for an anonymous class in my code, but I got an error:

```
NoMethodError (undefined method `+' for nil:NilClass)
```

The reason was that the name method returns nil for the anonymous class. 
Since Ruby 1.9.1, name method returns nil for anonymous module/class.
On the other hand, to_s method returns the object's ID in String.

```
Class.new.name #=> nil
Class.new.to_s #=> "#<Class:0x00007fa22318efa8>"
```

So, for the safety, I suggest to replace name method with to_s method.

This PR must be no affect for the current Net::SSH library itself.