### PR TITLE
Backport host/sig key format fix from v6 beta

### DIFF
--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -197,8 +197,8 @@ module Net
 
         def host_key_format
           case host_key
-          when "ssh-rsa-cert-v01@openssh.com", "ssh-rsa-cert-v00@openssh.com"
-            "ssh-rsa"
+          when /^([a-z0-9-]+)-cert-v\d{2}@openssh.com$/
+            Regexp.last_match[1]
           else
             host_key
           end


### PR DESCRIPTION
This allows net-ssh to be used with ed25519 certificates, for example.

Would be great if this (or with modifications) can be released as a 5.x minor update or 5.2.x patch update for compatibility with net-scp 2.0.