### PR TITLE
Add cached KnownHosts implementation - continued...

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -154,6 +154,7 @@ Lint/HandleExceptions:
   Exclude:
     - 'lib/net/ssh/authentication/session.rb'
     - 'lib/net/ssh/known_hosts.rb'
+    - 'lib/net/ssh/known_hosts/cached.rb'
     - 'lib/net/ssh/transport/openssl.rb'
     - 'test/integration/common.rb'
     - 'test/integration/test_forward.rb'

--- a/lib/net/ssh/known_hosts/cached.rb
+++ b/lib/net/ssh/known_hosts/cached.rb
@@ -13,8 +13,13 @@ module Net
       class Cached
         def initialize(options)
           @user_files = Array(options[:user_known_hosts_file] || %w[~/.ssh/known_hosts ~/.ssh/known_hosts2])
+          @user_files.map! { |file| File.expand_path(file) }
           @global_files = Array(options[:global_known_hosts_file] || %w[/etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2])
+          @global_files.map! { |file| File.expand_path(file) }
           @sha_sums = {}
+          @host_lookups = {}
+          @hmac_lookups = {}
+          @pattern_lookups = {}
         end
 
         def search_for(host, options={})

--- a/lib/net/ssh/known_hosts/cached.rb
+++ b/lib/net/ssh/known_hosts/cached.rb
@@ -1,0 +1,106 @@
+module Net
+  module SSH
+    class KnownHosts
+      class Cached
+        def initialize(options)
+          @user_files = Array(options[:user_known_hosts_file] || %w[~/.ssh/known_hosts ~/.ssh/known_hosts2])
+          @global_files = Array(options[:global_known_hosts_file] || %w[/etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2])
+          build_cache
+        end
+
+        def search_for(host, options={})
+          hostname, host_ip = host.split(',')
+
+          entries = []
+          entries.concat @host_lookups.fetch(hostname, [])
+          entries.concat @pattern_lookups.select { |pattern, _| hostname.match(pattern) }.values.flatten
+          @hmac_lookups.each do |(hmac, salt), entry|
+            digest = OpenSSL::Digest.new('sha1')
+            host_hmac = OpenSSL::HMAC.digest(digest, salt, hostname)
+            entries << entry if Base64.encode64(host_hmac.chomp) == hmac
+          end
+
+          if options[:check_host_ip] && host_ip
+            entries.select! { |entry| entry.hosts.include?(host_ip) }
+          end
+
+          HostKeys.new(entries.map(&:key), host, self, options)
+        end
+
+        def build_cache
+          @host_lookups = {}
+          @hmac_lookups = {}
+          @pattern_lookups = {}
+          (@user_files + @global_files).each do |file|
+            parse_known_hosts(File.expand_path(file))
+          end
+        end
+
+        def parse_known_hosts(source)
+          return unless File.readable?(source)
+
+          File.open(source) do |file|
+            file.each_line do |line|
+              hosts, type, key_content = line.split(' ')
+              next unless hosts || hosts.start_with?('#')
+
+              hostlist = hosts.split(',')
+
+              next unless KnownHosts::SUPPORTED_TYPE.include?(type)
+
+              blob = key_content.unpack("m*").first
+              key = Net::SSH::Buffer.new(blob).read_key
+
+              hostlist.each do |host|
+                entry = Entry.new(hostlist, key)
+                if host.include?('*') || host.include?('?')
+                  regex = regexify_pattern(host)
+                  @pattern_lookups[regex] ||= []
+                  @pattern_lookups[regex] << entry
+                elsif host =~ /\A\|1(\|.+){2}\z/
+                  chunks = host.split('|')
+                  salt = Base64.decode64(chunks[2])
+                  hmac = chunks[3]
+                  cache_key = [hmac, salt]
+                  @hmac_lookups[cache_key] ||= []
+                  @hmac_lookups[cache_key] << entry
+                else
+                  @host_lookups[host] ||= []
+                  @host_lookups[host] << entry
+                end
+              end
+            end
+          end
+        end
+
+        def add(host, key)
+          @host_lookups[host] ||= []
+          @host_lookups[host] << Entry.new([host], key)
+
+          @user_files.each do |file|
+            begin
+              KnownHosts.new(file).add(host, key)
+              return
+            rescue SystemCallError
+            end
+          end
+        end
+
+        def regexify(pattern)
+          # see man 8 sshd for pattern details
+          pattern_regexp = pattern.split('*').map do |x|
+            x.split('?').map do |y|
+              Regexp.escape(y)
+            end.join('.')
+          end.join('[^.]*')
+
+          Regexp.new("\\A#{pattern_regexp}\\z")
+        end
+      end
+
+      Entry = Struct.new(:hosts, :key)
+    end
+  end
+end
+
+

--- a/lib/net/ssh/known_hosts/cached.rb
+++ b/lib/net/ssh/known_hosts/cached.rb
@@ -1,14 +1,21 @@
 module Net
   module SSH
     class KnownHosts
+      # Searches an OpenSSH-style known-host file for a given host, and returns all
+      # matching keys. This is used to implement host-key verification, as well as
+      # to determine what key a user prefers to use for a given host. This is different
+      # From the KnownHosts class in that it builds a cache of parsed known hosts in order
+      # to avoid re-parsing known hosts earch time it is needed.
       class Cached
         def initialize(options)
           @user_files = Array(options[:user_known_hosts_file] || %w[~/.ssh/known_hosts ~/.ssh/known_hosts2])
           @global_files = Array(options[:global_known_hosts_file] || %w[/etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2])
-          build_cache
+          @mtimes = {}
         end
 
         def search_for(host, options={})
+          # Ensure cache is up to date
+          build_cache if cache_invalid?
           hostname, host_ip = host.split(',')
 
           entries = []
@@ -17,12 +24,10 @@ module Net
           @hmac_lookups.each do |(hmac, salt), entry|
             digest = OpenSSL::Digest.new('sha1')
             host_hmac = OpenSSL::HMAC.digest(digest, salt, hostname)
-            entries << entry if Base64.encode64(host_hmac.chomp) == hmac
+            entries.concat(entry) if Base64.encode64(host_hmac).chomp == hmac
           end
 
-          if options[:check_host_ip] && host_ip
-            entries.select! { |entry| entry.hosts.include?(host_ip) }
-          end
+          entries.select! { |entry| entry.hosts.include?(host_ip) } if options[:check_host_ip] && host_ip
 
           HostKeys.new(entries.map(&:key), host, self, options)
         end
@@ -40,9 +45,11 @@ module Net
           return unless File.readable?(source)
 
           File.open(source) do |file|
+            @mtimes[source] = File.mtime(source)
             file.each_line do |line|
               hosts, type, key_content = line.split(' ')
-              next unless hosts || hosts.start_with?('#')
+              # Skip empty line or one that is commented
+              next if hosts.nil? || hosts.start_with?('#')
 
               hostlist = hosts.split(',')
 
@@ -54,7 +61,7 @@ module Net
               hostlist.each do |host|
                 entry = Entry.new(hostlist, key)
                 if host.include?('*') || host.include?('?')
-                  regex = regexify_pattern(host)
+                  regex = regexify(host)
                   @pattern_lookups[regex] ||= []
                   @pattern_lookups[regex] << entry
                 elsif host =~ /\A\|1(\|.+){2}\z/
@@ -73,14 +80,17 @@ module Net
           end
         end
 
-        def add(host, key)
+        def add(host, key, _options = nil)
           @host_lookups[host] ||= []
           @host_lookups[host] << Entry.new([host], key)
 
           @user_files.each do |file|
             begin
+              # If this is the only modification since last read, update @mtimes to preserve cache
+              preserve_cache = File.mtime(file) == @mtimes[file]
               KnownHosts.new(file).add(host, key)
-              return
+              @mtimes[file] = File.mtime(file) if preserve_cache
+              break
             rescue SystemCallError
             end
           end
@@ -96,11 +106,16 @@ module Net
 
           Regexp.new("\\A#{pattern_regexp}\\z")
         end
+
+        def cache_invalid?
+          (@user_files + @global_files).each do |file|
+            return true if File.readable?(file) && @mtimes[file] != File.mtime(file)
+          end
+          false
+        end
       end
 
       Entry = Struct.new(:hosts, :key)
     end
   end
 end
-
-

--- a/test/test_known_hosts_cached.rb.rb
+++ b/test/test_known_hosts_cached.rb.rb
@@ -1,0 +1,207 @@
+require 'common'
+require 'net/ssh/known_hosts/cached'
+
+class TestKnownHostsCached < NetSSHTest
+  def build_opts(user_file, global_file = 'does_not_exist')
+    {
+      user_known_hosts_file: user_file,
+      global_known_hosts_file: global_file
+    }
+  end
+
+  def perform_test(source)
+    # For these tests we only want to read a single file, set that as 
+    # the user_known_hosts_file and pass a non-existant file to 
+    # global_known_hosts_file
+    kh = Net::SSH::KnownHosts::Cached.new(build_opts(source))
+    keys = kh.search_for("github.com")
+    assert_equal(1, keys.count)
+    assert_equal("ssh-rsa", keys.first.ssh_type)
+  end
+
+  def test_key_for_when_all_hosts_are_recognized
+    perform_test(path("known_hosts/github"))
+  end
+
+  def test_key_for_when_an_host_hash_is_recognized
+    perform_test(path("known_hosts/github_hash"))
+  end
+
+  def test_parsing_known_hosts_empty_lines_and_comments
+    perform_test(path("known_hosts/known_hosts_ignore"))
+  end
+
+  def test_missing_then_add
+    Tempfile.open('github') do |f|
+      f.write(File.read(path("known_hosts/github")))
+      kh = Net::SSH::KnownHosts::Cached.new(build_opts(f.path))
+      keys = kh.search_for("github2.com")
+      assert_equal(0, keys.count)
+      assert_equal([], keys.to_a)
+
+      kh.add('github2.com',rsa_key)
+      keys2 = kh.search_for("github2.com")
+      assert_equal([rsa_key.to_blob], keys2.to_a.map(&:to_blob))
+    end
+  end
+
+  def test_search_for
+    options = { user_known_hosts_file: path("known_hosts/github") }
+    kh = Net::SSH::KnownHosts::Cached.new(options)
+    keys = kh.search_for('github.com', options)
+    assert_equal(["ssh-rsa"], keys.map(&:ssh_type))
+  end
+
+  def test_search_for_with_hostname_and_right_ip_with_check_host_ip
+    options = { user_known_hosts_file: path("known_hosts/gitlab"), check_host_ip: true }
+    kh = Net::SSH::KnownHosts::Cached.new(options)
+    keys = kh.search_for('gitlab.com,35.231.145.151', options)
+    assert_equal(1, keys.count)
+  end
+
+  def test_search_for_with_hostname_and_right_ip_without_check_host_ip
+    options = { user_known_hosts_file: path("known_hosts/gitlab"), check_host_ip: false }
+    kh = Net::SSH::KnownHosts::Cached.new(options)
+    keys = kh.search_for('gitlab.com,35.231.145.151', options)
+    assert_equal(1, keys.count)
+  end
+
+  def test_search_for_with_hostname_and_wrong_ip_with_check_host_ip
+    options = { user_known_hosts_file: path("known_hosts/gitlab"), check_host_ip: true }
+    kh = Net::SSH::KnownHosts::Cached.new(options)
+    keys = kh.search_for('gitlab.com,192.0.2.1', options)
+    assert_equal(0, keys.count)
+  end
+
+  def test_search_for_with_hostname_and_wrong_ip_without_check_host_ip
+    options = { user_known_hosts_file: path("known_hosts/gitlab"), check_host_ip: false }
+    kh = Net::SSH::KnownHosts::Cached.new(options)
+    keys = kh.search_for('gitlab.com,192.0.2.2', options)
+    assert_equal(1, keys.count)
+  end
+
+  def test_search_for_with_hostname_only_with_check_host_ip
+    options = { user_known_hosts_file: path("known_hosts/gitlab"), check_host_ip: true }
+    kh = Net::SSH::KnownHosts::Cached.new(options)
+    keys = kh.search_for('gitlab.com', options)
+    assert_equal(1, keys.count)
+  end
+
+  def test_search_for_with_hostname_only_without_check_host_ip
+    options = { user_known_hosts_file: path("known_hosts/gitlab"), check_host_ip: false }
+    kh = Net::SSH::KnownHosts::Cached.new(options)
+    keys = kh.search_for('gitlab.com', options)
+    assert_equal(1, keys.count)
+  end
+
+  def test_search_for_with_ip_only_with_check_host_ip
+    options = { user_known_hosts_file: path("known_hosts/gitlab"), check_host_ip: true }
+    # keys = Net::SSH::KnownHosts.search_for('',options)
+    kh = Net::SSH::KnownHosts::Cached.new(options)
+    keys = kh.search_for('35.231.145.151', options)
+    assert_equal(1, keys.count)
+  end
+
+  def test_search_for_with_ip_only_without_check_host_ip
+    options = { user_known_hosts_file: path("known_hosts/gitlab"), check_host_ip: false }
+    kh = Net::SSH::KnownHosts::Cached.new(options)
+    keys = kh.search_for('35.231.145.151', options)
+    assert_equal(1, keys.count)
+  end
+
+  def test_search_for_with_hostname_matching_pattern
+    options = { user_known_hosts_file: path("known_hosts/misc") }
+    kh = Net::SSH::KnownHosts::Cached.new(options)
+    keys = kh.search_for('subdomain.gitfoo.com', options)
+    assert_equal(1, keys.count)
+  end
+
+  def test_search_for_with_hostname_not_matching_pattern_1
+    options = { user_known_hosts_file: path("known_hosts/misc") }
+    kh = Net::SSH::KnownHosts::Cached.new(options)
+    keys = kh.search_for('gitfoo.com', options)
+    assert_equal(0, keys.count)
+  end
+
+  def test_search_for_with_hostname_not_matching_pattern_2
+    options = { user_known_hosts_file: path("known_hosts/misc") }
+    kh = Net::SSH::KnownHosts::Cached.new(options)
+    keys = kh.search_for('subdomain.gitmisc.com', options)
+    assert_equal(0, keys.count)
+  end
+
+  def test_search_for_with_hostname_not_matching_pattern_3
+    options = { user_known_hosts_file: path("known_hosts/misc") }
+    kh = Net::SSH::KnownHosts::Cached.new(options)
+    keys = kh.search_for('subsubdomain.subdomain.gitfoo.com', options)
+    assert_equal(0, keys.count)
+  end
+
+  def test_search_for_then_add
+    Tempfile.open('github') do |f|
+      f.write(File.read(path("known_hosts/github")))
+      options = { user_known_hosts_file: f.path }
+      kh = Net::SSH::KnownHosts::Cached.new(build_opts(f.path))
+      keys = kh.search_for('github2.com', options)
+      assert_equal(0, keys.count)
+
+      keys.add_host_key(rsa_key)
+
+      assert_equal([rsa_key.to_blob], keys.map(&:to_blob))
+      keys = kh.search_for('github2.com', options)
+      assert_equal([rsa_key.to_blob], keys.map(&:to_blob))
+    end
+  end
+
+  def test_host_entry_added_out_of_process
+    Tempfile.open('github') do |f|
+      options = { user_known_hosts_file: f.path }
+      kh = Net::SSH::KnownHosts::Cached.new(build_opts(f.path))
+      keys = kh.search_for('github.com', options)
+      assert_equal(0, keys.count)
+      f.write(File.read(path("known_hosts/github")))
+      f.close
+      # Ensure mtime is different
+      sleep(1)
+      FileUtils.touch(f)
+      keys = kh.search_for("github.com")
+      assert_equal(1, keys.count)
+      assert_equal("ssh-rsa", keys.first.ssh_type)
+    end
+  end
+
+  def test_host_entry_deleted_out_of_process
+    Tempfile.open('github') do |f|
+      f.write(File.read(path("known_hosts/github")))
+      f.flush
+      options = { user_known_hosts_file: f.path }
+      kh = Net::SSH::KnownHosts::Cached.new(build_opts(f.path))
+      keys = kh.search_for('github.com', options)
+      assert_equal(1, keys.count)
+      assert_equal("ssh-rsa", keys.first.ssh_type)
+      f.rewind
+      f.write('#')
+      f.close
+      # Ensure mtime is different
+      sleep(1)
+      FileUtils.touch(f)
+      keys = kh.search_for("github.com")
+      assert_equal(0, keys.count)
+    end
+  end
+
+  def path(relative_path)
+    File.join(File.dirname(__FILE__), relative_path)
+  end
+
+  def rsa_key
+    key = OpenSSL::PKey::RSA.new
+    if key.respond_to?(:set_key)
+      key.set_key(0x7766554433221100, 0xffeeddccbbaa9988, nil)
+    else
+      key.e = 0xffeeddccbbaa9988
+      key.n = 0x7766554433221100
+    end
+    key
+  end
+end


### PR DESCRIPTION
This PR continues the work that @nicklewis did in https://github.com/net-ssh/net-ssh/pull/686 based on the suggestion from @mfazekas to rebuild cache when file changes occur out of band. There are two approaches for this in the PR. First use file mtime (originally suggested by @mfazekas) and the second to use an md5 hash to determine if a known_hosts file has changed out of band. While writing tests for the original mtime implementation I came across a case where a file write happened so close to the time the file was originally read that comparing mtimes did not detect a change.