### PR TITLE
Limit cert.valid_before to max supported by JRuby

### DIFF
--- a/lib/net/ssh/authentication/certificate.rb
+++ b/lib/net/ssh/authentication/certificate.rb
@@ -34,11 +34,11 @@ module Net
           # 0x20c49ba5e353f7 = 0x7fffffffffffffff/1000, the largest value possible for JRuby
           # JRuby Time.at multiplies the arg by 1000, and then stores it in a signed long.
           # 0x20c49ba5e353f7 = 292278994-08-17 01:12:55 -0600
-          if RUBY_PLATFORM == "java"
-            cert.valid_before = Time.at([0x20c49ba5e353f7, buffer.read_int64].min)
-          else
-            cert.valid_before = Time.at(buffer.read_int64)
-          end
+          cert.valid_before = if RUBY_PLATFORM == "java"
+                                Time.at([0x20c49ba5e353f7, buffer.read_int64].min)
+                              else
+                                Time.at(buffer.read_int64)
+                              end
 
           cert.critical_options = read_options(buffer)
           cert.extensions = read_options(buffer)

--- a/lib/net/ssh/authentication/certificate.rb
+++ b/lib/net/ssh/authentication/certificate.rb
@@ -34,7 +34,12 @@ module Net
           # 0x20c49ba5e353f7 = 0x7fffffffffffffff/1000, the largest value possible for JRuby
           # JRuby Time.at multiplies the arg by 1000, and then stores it in a signed long.
           # 0x20c49ba5e353f7 = 292278994-08-17 01:12:55 -0600
-          cert.valid_before = Time.at([0x20c49ba5e353f7, buffer.read_int64].min)
+          if RUBY_PLATFORM == "java"
+            cert.valid_before = Time.at([0x20c49ba5e353f7, buffer.read_int64].min)
+          else
+            cert.valid_before = Time.at(buffer.read_int64)
+          end
+
           cert.critical_options = read_options(buffer)
           cert.extensions = read_options(buffer)
           cert.reserved = buffer.read_string

--- a/lib/net/ssh/authentication/certificate.rb
+++ b/lib/net/ssh/authentication/certificate.rb
@@ -31,7 +31,10 @@ module Net
           cert.key_id = buffer.read_string
           cert.valid_principals = buffer.read_buffer.read_all(&:read_string)
           cert.valid_after = Time.at(buffer.read_int64)
-          cert.valid_before = Time.at(buffer.read_int64)
+          # 0x20c49ba5e353f7 = 0x7fffffffffffffff/1000, the largest value possible for JRuby
+          # JRuby Time.at multiplies the arg by 1000, and then stores it in a signed long.
+          # 0x20c49ba5e353f7 = 292278994-08-17 01:12:55 -0600
+          cert.valid_before = Time.at([0x20c49ba5e353f7, buffer.read_int64].min)
           cert.critical_options = read_options(buffer)
           cert.extensions = read_options(buffer)
           cert.reserved = buffer.read_string

--- a/lib/net/ssh/authentication/certificate.rb
+++ b/lib/net/ssh/authentication/certificate.rb
@@ -31,10 +31,11 @@ module Net
           cert.key_id = buffer.read_string
           cert.valid_principals = buffer.read_buffer.read_all(&:read_string)
           cert.valid_after = Time.at(buffer.read_int64)
-          # 0x20c49ba5e353f7 = 0x7fffffffffffffff/1000, the largest value possible for JRuby
-          # JRuby Time.at multiplies the arg by 1000, and then stores it in a signed long.
-          # 0x20c49ba5e353f7 = 292278994-08-17 01:12:55 -0600
+          
           cert.valid_before = if RUBY_PLATFORM == "java"
+                                # 0x20c49ba5e353f7 = 0x7fffffffffffffff/1000, the largest value possible for JRuby
+                                # JRuby Time.at multiplies the arg by 1000, and then stores it in a signed long.
+                                # 0x20c49ba5e353f7 = 292278994-08-17 01:12:55 -0600
                                 Time.at([0x20c49ba5e353f7, buffer.read_int64].min)
                               else
                                 Time.at(buffer.read_int64)


### PR DESCRIPTION
The OpenSSH certificate format interpets a `valid_before` time of `2^64-1` (max for unsigned long) to mean "forever": https://github.com/openssh/openssh-portable/blob/master/sshkey.c#L3159

Golang also interprets it this way:
https://github.com/golang/crypto/blob/master/ssh/certs.go#L47

I'm running into a `RangeError` issue with net-ssh on JRuby for certificates that have been issued to be valid for 'forever', as JRuby uses a signed long, and also multiplies the passed value by 1000 (as the internal storage uses milliseconds). (https://github.com/jruby/jruby/blob/master/core/src/main/java/org/jruby/RubyTime.java#L1280)

This caps the `cert.valid_before` at `0x20c49ba5e353f7` which is the largest value that can be handled by JRuby and which translates to `292278994-08-17 01:12:55 -0600`, which I believe is close enough to 'forever' to not have any real effect here.
