### PR TITLE
Let use Etc.getpwuid.name() instead of Etc.getlogin to adapt default …

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+
+  * adapt to ssh's default bahaviors when no username is provided.
+    When Net::SSH.start user is nil and config has no entry
+    we default to Etc.getpwuid.name() instead of Etc.getlogin(). [#749]
+
 === 6.1.0.rc1
 
   * Make sha2-{256,512}-etm@openssh.com MAC default again [#761]

--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -251,7 +251,7 @@ module Net
       transport = Transport::Session.new(host, options)
       auth = Authentication::Session.new(transport, options)
 
-      user = options.fetch(:user, user) || Etc.getlogin
+      user = options.fetch(:user, user) || Etc.getpwuid.name
       if auth.authenticate("ssh-connection", user, options[:password])
         connection = Connection::Session.new(transport, options)
         if block_given?

--- a/test/start/test_user_nil.rb
+++ b/test/start/test_user_nil.rb
@@ -18,7 +18,7 @@ module NetSSH
     end
 
     def test_start_should_use_default_user_when_nil
-      @authentication_session.stubs(:authenticate).with {|_next_service, user, _password| user == Etc.getlogin }.returns(true)
+      @authentication_session.stubs(:authenticate).with {|_next_service, user, _password| user == Etc.getpwuid.name }.returns(true)
       assert_nothing_raised do
         Net::SSH.start('localhost', nil, config: false)
       end


### PR DESCRIPTION
…behavior of ssh.

related issue: #749.

Closes: #749