### PR TITLE
Fix StrictHostKeyChecking ssh config parameter translation

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -34,7 +34,7 @@ module Net
     # * ProxyJump => maps to the :proxy option
     # * PubKeyAuthentication => maps to the :auth_methods option
     # * RekeyLimit => :rekey_limit
-    # * StrictHostKeyChecking => :strict_host_key_checking
+    # * StrictHostKeyChecking => :verify_host_key
     # * User => :user
     # * UserKnownHostsFile => :user_known_hosts_file
     # * NumberOfPasswordPrompts => :number_of_password_prompts
@@ -197,6 +197,26 @@ module Net
 
         private
 
+        def translate_verify_host_key(value)
+          case value
+          when false
+            :never
+          when true
+            :always
+          when 'accept-new'
+            :accept_new
+          end
+        end
+
+        def translate_keepalive(hash, value)
+          if value && value.to_i > 0
+            hash[:keepalive] = true
+            hash[:keepalive_interval] = value.to_i
+          else
+            hash[:keepalive] = false
+          end
+        end
+
         TRANSLATE_CONFIG_KEY_RENAME_MAP = {
           bindaddress: :bind_address,
           compression: :compression,
@@ -211,13 +231,14 @@ module Net
           identityfile: :keys,
           fingerprinthash: :fingerprint_hash,
           port: :port,
-          stricthostkeychecking: :strict_host_key_checking,
           user: :user,
           userknownhostsfile: :user_known_hosts_file,
           checkhostip: :check_host_ip
         }.freeze
         def translate_config_key(hash, key, value, settings)
           case key
+          when :stricthostkeychecking
+            hash[:verify_host_key] = translate_verify_host_key(value)
           when :ciphers
             hash[:encryption] = value.split(/,/)
           when :hostbasedauthentication
@@ -235,12 +256,7 @@ module Net
           when :serveralivecountmax
             hash[:keepalive_maxcount] = value.to_i if value
           when :serveraliveinterval
-            if value && value.to_i > 0
-              hash[:keepalive] = true
-              hash[:keepalive_interval] = value.to_i
-            else
-              hash[:keepalive] = false
-            end
+            translate_keepalive(hash, value)
           when :passwordauthentication
             if value
               (hash[:auth_methods] << 'password').uniq!

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -170,7 +170,23 @@ class TestConfig < NetSSHTest
     assert_equal 'MD5',     net_ssh[:fingerprint_hash]
     assert_equal true,      net_ssh[:keepalive]
     assert_equal '/dev/null', net_ssh[:user_known_hosts_file]
-    assert_equal false, net_ssh[:strict_host_key_checking]
+    assert_equal :never, net_ssh[:verify_host_key]
+  end
+
+  def test_translate_should_turn_on_host_key_verification
+    open_ssh = { 'stricthostkeychecking' => true }
+
+    net_ssh = Net::SSH::Config.translate(open_ssh)
+
+    assert_equal :always, net_ssh[:verify_host_key]
+  end
+
+  def test_translate_should_accept_new_host_key
+    open_ssh = { 'stricthostkeychecking' => 'accept-new' }
+
+    net_ssh = Net::SSH::Config.translate(open_ssh)
+
+    assert_equal :accept_new, net_ssh[:verify_host_key]
   end
 
   def test_translate_should_turn_off_authentication_methods
@@ -202,9 +218,7 @@ class TestConfig < NetSSHTest
   end
 
   def test_translate_should_not_disable_keyboard_interactive_when_challange_or_keyboardinterective_is_on
-    open_ssh = {
-      'kbdinteractiveauthentication' => false
-    }
+    open_ssh = { 'kbdinteractiveauthentication' => false }
     net_ssh = Net::SSH::Config.translate(open_ssh)
     assert_equal %w(keyboard-interactive none password publickey), net_ssh[:auth_methods].sort
 


### PR DESCRIPTION
Translate `StrictHostKeyChecking` ssh config parameter to `:verify_host_key` parameter

Fixes: #764