### PR TITLE
Tweak max constant value to work with JRuby 9.1

### DIFF
--- a/lib/net/ssh/authentication/certificate.rb
+++ b/lib/net/ssh/authentication/certificate.rb
@@ -35,8 +35,9 @@ module Net
           cert.valid_before = if RUBY_PLATFORM == "java"
                                 # 0x20c49ba5e353f7 = 0x7fffffffffffffff/1000, the largest value possible for JRuby
                                 # JRuby Time.at multiplies the arg by 1000, and then stores it in a signed long.
-                                # 0x20c49ba5e353f7 = 292278994-08-17 01:12:55 -0600
-                                Time.at([0x20c49ba5e353f7, buffer.read_int64].min)
+                                # 0x20c49ba2d52500 = 292278993-01-01 00:00:00 +0000
+                                # JRuby 9.1 does not accept the year 292278994 because of edge cases (https://github.com/JodaOrg/joda-time/issues/190)
+                                Time.at([0x20c49ba2d52500, buffer.read_int64].min)
                               else
                                 Time.at(buffer.read_int64)
                               end


### PR DESCRIPTION
This PR slightly reduces the max constant so that it is compatible with JRuby 9.1.

JRuby uses JodaTime under the hood. Until JodaTime 2.9 was released, while the year `292278994` was technically able to be stored, JodaTime didn't allow it because of undefined behavior at the edge of the numeric range (because of time zones and other issues). JodaTime 2.9 removed that undefined behavior, and now allows the year `292278994`. Details are available here: https://github.com/JodaOrg/joda-time/issues/190

JodaTime 2.9 was not pulled into JRuby until JRuby 9.2, so by slightly reducing this value, we can gain compatibility with JRuby 9.1.

```
irb(main):001:0> Time.at(0x20c49ba5e353f7)
RangeError: Value 292278994 for year must be in the range [-292275054,292278993]
	from org/jruby/RubyTime.java:1166:in `at'
	from (irb):1:in `<eval>'
	from org/jruby/RubyKernel.java:1000:in `eval'
	from org/jruby/RubyKernel.java:1298:in `loop'
	from org/jruby/RubyKernel.java:1120:in `catch'
	from org/jruby/RubyKernel.java:1120:in `catch'
	from /home/sskousen/.rbenv/versions/jruby-9.1.12.0/bin/irb:13:in `<main>'
irb(main):002:0> Time.at(0x20c49ba2d52500)
=> 292278993-01-01 00:00:00 +0000
irb(main):003:0> 
```