### PR TITLE
Re-add fix for JRuby

### DIFF
--- a/lib/net/ssh/transport/cipher_factory.rb
+++ b/lib/net/ssh/transport/cipher_factory.rb
@@ -22,9 +22,9 @@ module Net
           "3des-ctr"                    => "des-ede3",
           "blowfish-ctr"                => "bf-ecb",
 
-          "aes256-ctr"                  => ::OpenSSL::Cipher.ciphers.include?("aes-256-ctr") ? "aes-256-ctr" : "aes-256-cbc",
-          "aes192-ctr"                  => ::OpenSSL::Cipher.ciphers.include?("aes-192-ctr") ? "aes-192-ctr" : "aes-192-cbc",
-          "aes128-ctr"                  => ::OpenSSL::Cipher.ciphers.include?("aes-128-ctr") ? "aes-128-ctr" : "aes-128-cbc",
+          "aes256-ctr"                  => ::OpenSSL::Cipher.ciphers.include?("aes-256-ctr") ? "aes-256-ctr" : "aes-256-ecb",
+          "aes192-ctr"                  => ::OpenSSL::Cipher.ciphers.include?("aes-192-ctr") ? "aes-192-ctr" : "aes-192-ecb",
+          "aes128-ctr"                  => ::OpenSSL::Cipher.ciphers.include?("aes-128-ctr") ? "aes-128-ctr" : "aes-128-ecb",
           'cast128-ctr'                 => 'cast5-ecb',
 
           'none'                        => 'none'

--- a/lib/net/ssh/transport/cipher_factory.rb
+++ b/lib/net/ssh/transport/cipher_factory.rb
@@ -22,9 +22,9 @@ module Net
           "3des-ctr"                    => "des-ede3",
           "blowfish-ctr"                => "bf-ecb",
 
-          'aes256-ctr'                  => 'aes-256-ctr',
-          'aes192-ctr'                  => 'aes-192-ctr',
-          'aes128-ctr'                  => 'aes-128-ctr',
+          "aes256-ctr"                  => ::OpenSSL::Cipher.ciphers.include?("aes-256-ctr") ? "aes-256-ctr" : "aes-256-cbc",
+          "aes192-ctr"                  => ::OpenSSL::Cipher.ciphers.include?("aes-192-ctr") ? "aes-192-ctr" : "aes-192-cbc",
+          "aes128-ctr"                  => ::OpenSSL::Cipher.ciphers.include?("aes-128-ctr") ? "aes-128-ctr" : "aes-128-cbc",
           'cast128-ctr'                 => 'cast5-ecb',
 
           'none'                        => 'none'


### PR DESCRIPTION
This re-adds the changes that were introduced in https://github.com/net-ssh/net-ssh/pull/612 and removed in https://github.com/net-ssh/net-ssh/pull/701.

While OpenSSL since 2012 has support for `aes-ctr`, the latest JRuby (9.2.11.1) still does not support them, which means that net-ssh 6 is broken for anyone using JRuby and has `aes-ctr` enabled on the server:

```
$ rbenv shell jruby-9.2.11.1
$ irb
irb(main):001:0> require 'openssl'
=> true
irb(main):002:0> ::OpenSSL::Cipher.ciphers.include?("aes-256-ctr")
=> false
irb(main):003:0> ::OpenSSL::Cipher.ciphers.include?("aes-192-ctr")
=> false
irb(main):004:0> ::OpenSSL::Cipher.ciphers.include?("aes-128-ctr")
```