### PR TITLE
Update Net::SSH::Prompt usage documentation

### DIFF
--- a/lib/net/ssh/prompt.rb
+++ b/lib/net/ssh/prompt.rb
@@ -13,8 +13,8 @@ module Net
     #
     #   prompter = options[:password_prompt].start({type:'password'})
     #   while !ok && max_retries < 3
-    #     user = prompter.ask("user: ", {}, true)
-    #     password = prompter.ask("password: ", {}, false)
+    #     user = prompter.ask("user: ", true)
+    #     password = prompter.ask("password: ", false)
     #     ok = send(user, password)
     #     prompter.sucess if ok
     #   end


### PR DESCRIPTION
`Net::SSH::Prompt::Prompter#ask` does not take three arguments, it takes two. Update the [docs](https://net-ssh.github.io/net-ssh/Net/SSH/Prompt.html) to reflect this.