### PR TITLE
Fix missing OpenSSL::Pkey::EC::Point#ssh_signature_type

### DIFF
--- a/lib/net/ssh/transport/openssl.rb
+++ b/lib/net/ssh/transport/openssl.rb
@@ -53,9 +53,7 @@ module OpenSSL
         "ssh-rsa"
       end
 
-      def ssh_signature_type
-        ssh_type
-      end
+      alias ssh_signature_type ssh_type
 
       # Converts the key to a blob, according to the SSH2 protocol.
       def to_blob
@@ -92,9 +90,7 @@ module OpenSSL
         "ssh-dss"
       end
 
-      def ssh_signature_type
-        ssh_type
-      end
+      alias ssh_signature_type ssh_type
 
       # Converts the key to a blob, according to the SSH2 protocol.
       def to_blob
@@ -172,9 +168,7 @@ module OpenSSL
         "ecdsa-sha2-#{CurveNameAliasInv[group.curve_name]}"
       end
 
-      def ssh_signature_type
-        ssh_type
-      end
+      alias ssh_signature_type ssh_type
 
       def digester
         if group.curve_name =~ /^[a-z]+(\d+)\w*\z/
@@ -245,9 +239,7 @@ module OpenSSL
           "ecdsa-sha2-#{CurveNameAliasInv[group.curve_name]}"
         end
 
-        def ssh_signature_type
-          ssh_type
-        end
+        alias ssh_signature_type ssh_type
 
         # Converts the key to a blob, according to the SSH2 protocol.
         def to_blob

--- a/lib/net/ssh/transport/openssl.rb
+++ b/lib/net/ssh/transport/openssl.rb
@@ -245,6 +245,10 @@ module OpenSSL
           "ecdsa-sha2-#{CurveNameAliasInv[group.curve_name]}"
         end
 
+        def ssh_signature_type
+          ssh_type
+        end
+
         # Converts the key to a blob, according to the SSH2 protocol.
         def to_blob
           @blob ||= Net::SSH::Buffer.from(:string, ssh_type,


### PR DESCRIPTION
`OpenSSL::Pkey::EC::Point#ssh_signature_type` is missing.  
It should be an alias for the method `OpenSSL::Pkey::EC::Point#ssh_type`.