### PR TITLE
Fix uncommon blocking condition in version negotiation

### DIFF
--- a/lib/net/ssh/transport/server_version.rb
+++ b/lib/net/ssh/transport/server_version.rb
@@ -50,15 +50,11 @@ module Net
             @version = ""
             loop do
               begin
-                if timeout
-                  b = socket.read_nonblock(1)
-                else
-                  b = socket.readpartial(1)
-                end
+                b = socket.read_nonblock(1)
                 raise Net::SSH::Disconnect, "connection closed by remote host" if b.nil?
               rescue EOFError
                 raise Net::SSH::Disconnect, "connection closed by remote host"
-              rescue IO::WaitReadable => e
+              rescue IO::WaitReadable
                 timed_out = IO.select([socket], nil, nil, timeout).nil?
                 if timed_out
                   raise Net::SSH::ConnectionTimeout, "timeout during server version negotiating"

--- a/test/transport/test_server_version.rb
+++ b/test/transport/test_server_version.rb
@@ -53,9 +53,9 @@ module Transport
       recv_times += 1 if data[-1] != "\n"
 
       if raise_eot
-        socket.expects(:readpartial).with(1).times(recv_times + 1).returns(*data).then.raises(EOFError, 'end of file reached')
+        socket.expects(:read_nonblock).with(1).times(recv_times + 1).returns(*data).then.raises(EOFError, 'end of file reached')
       else
-        socket.expects(:readpartial).with(1).times(recv_times).returns(*data).then.returns(nil)
+        socket.expects(:read_nonblock).with(1).times(recv_times).returns(*data).then.returns(nil)
       end
 
       socket


### PR DESCRIPTION
We're seeing issues where the version negotiation occasionally blocks indefinitely when communicating with an unstable SFTP server, even when timeout is specified. This attempts to fix the problem.