### PR TITLE
Add support for diffie-hellman-group14-sha256

### DIFF
--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -41,6 +41,7 @@ module Net
                   ecdh-sha2-nistp384
                   ecdh-sha2-nistp256
                   diffie-hellman-group-exchange-sha256
+                  diffie-hellman-group14-sha256
                   diffie-hellman-group14-sha1],
 
           encryption: %w[aes256-ctr aes192-ctr aes128-ctr],

--- a/lib/net/ssh/transport/kex.rb
+++ b/lib/net/ssh/transport/kex.rb
@@ -1,5 +1,6 @@
 require 'net/ssh/transport/kex/diffie_hellman_group1_sha1'
 require 'net/ssh/transport/kex/diffie_hellman_group14_sha1'
+require 'net/ssh/transport/kex/diffie_hellman_group14_sha256'
 require 'net/ssh/transport/kex/diffie_hellman_group_exchange_sha1'
 require 'net/ssh/transport/kex/diffie_hellman_group_exchange_sha256'
 require 'net/ssh/transport/kex/ecdh_sha2_nistp256'
@@ -14,6 +15,7 @@ module Net::SSH::Transport
     MAP = {
       'diffie-hellman-group1-sha1'           => DiffieHellmanGroup1SHA1,
       'diffie-hellman-group14-sha1'          => DiffieHellmanGroup14SHA1,
+      'diffie-hellman-group14-sha256'        => DiffieHellmanGroup14SHA256,
       'diffie-hellman-group-exchange-sha1'   => DiffieHellmanGroupExchangeSHA1,
       'diffie-hellman-group-exchange-sha256' => DiffieHellmanGroupExchangeSHA256,
       'ecdh-sha2-nistp256'                   => EcdhSHA2NistP256,

--- a/lib/net/ssh/transport/kex/diffie_hellman_group14_sha256.rb
+++ b/lib/net/ssh/transport/kex/diffie_hellman_group14_sha256.rb
@@ -1,0 +1,11 @@
+require 'net/ssh/transport/kex/diffie_hellman_group14_sha1'
+
+module Net::SSH::Transport::Kex
+  # A key-exchange service implementing the "diffie-hellman-group14-sha256"
+  # key-exchange algorithm.
+  class DiffieHellmanGroup14SHA256 < DiffieHellmanGroup14SHA1
+    def digester
+      OpenSSL::Digest::SHA256
+    end
+  end
+end

--- a/test/transport/kex/test_diffie_hellman_group14_sha256.rb
+++ b/test/transport/kex/test_diffie_hellman_group14_sha256.rb
@@ -1,0 +1,17 @@
+require 'common'
+require 'transport/kex/test_diffie_hellman_group14_sha1'
+
+module Transport
+  module Kex
+
+    class TestDiffieHellmanGroup14SHA256 < TestDiffieHellmanGroup14SHA1
+      def subject
+        Net::SSH::Transport::Kex::DiffieHellmanGroup14SHA256
+      end
+
+      def digest_type
+        OpenSSL::Digest::SHA256
+      end
+    end
+  end
+end

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -19,7 +19,7 @@ module Transport
 
     def test_constructor_should_build_default_list_of_preferred_algorithms
       assert_equal ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa rsa-sha2-256 rsa-sha2-512], algorithms[:host_key]
-      assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha1], algorithms[:kex]
+      assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1], algorithms[:kex]
       assert_equal %w[aes256-ctr aes192-ctr aes128-ctr], algorithms[:encryption]
       assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1], algorithms[:hmac]
       assert_equal %w[none zlib@openssh.com zlib], algorithms[:compression]
@@ -28,7 +28,7 @@ module Transport
 
     def test_constructor_should_build_complete_list_of_algorithms_with_append_all_supported_algorithms
       assert_equal ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa rsa-sha2-256 rsa-sha2-512 ssh-dss], algorithms(append_all_supported_algorithms: true)[:host_key]
-      assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1], algorithms(append_all_supported_algorithms: true)[:kex]
+      assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1], algorithms(append_all_supported_algorithms: true)[:kex]
       assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(append_all_supported_algorithms: true)[:encryption]
       assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 hmac-md5-96 none], algorithms(append_all_supported_algorithms: true)[:hmac]
       assert_equal %w[none zlib@openssh.com zlib], algorithms(append_all_supported_algorithms: true)[:compression]
@@ -90,22 +90,22 @@ module Transport
     end
 
     def test_constructor_with_preferred_kex_should_put_preferred_kex_first
-      assert_equal %w[diffie-hellman-group1-sha1] + x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1],
+      assert_equal %w[diffie-hellman-group1-sha1] + x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1],
                    algorithms(kex: "diffie-hellman-group1-sha1", append_all_supported_algorithms: true)[:kex]
     end
 
     def test_constructor_with_unrecognized_kex_should_not_raise_exception
-      assert_equal %w[diffie-hellman-group1-sha1] + x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1],
+      assert_equal %w[diffie-hellman-group1-sha1] + x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1],
                    algorithms(kex: %w[bogus diffie-hellman-group1-sha1], append_all_supported_algorithms: true)[:kex]
     end
 
     def test_constructor_with_preferred_kex_supports_additions
-      assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1],
+      assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1],
                    algorithms(kex: %w[+diffie-hellman-group1-sha1])[:kex]
     end
 
     def test_constructor_with_preferred_kex_supports_removals_with_wildcard
-      assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256],
+      assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256],
                    algorithms(kex: %w[-diffie-hellman-group*-sha1 -diffie-hellman-group-exchange-sha1])[:kex]
     end
 
@@ -390,7 +390,7 @@ module Transport
     def kexinit(options={})
       @kexinit ||= P(:byte, KEXINIT,
         :long, rand(0xFFFFFFFF), :long, rand(0xFFFFFFFF), :long, rand(0xFFFFFFFF), :long, rand(0xFFFFFFFF),
-        :string, options[:kex] || "diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1",
+        :string, options[:kex] || "diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1",
         :string, options[:host_key] || "ssh-rsa,ssh-dss",
         :string, options[:encryption_client] || "aes256-ctr,aes128-cbc,3des-cbc,blowfish-cbc,cast128-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se,idea-cbc",
         :string, options[:encryption_server] || "aes256-ctr,aes128-cbc,3des-cbc,blowfish-cbc,cast128-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se,idea-cbc",
@@ -406,7 +406,7 @@ module Transport
     def assert_kexinit(buffer, options={})
       assert_equal KEXINIT, buffer.type
       assert_equal 16, buffer.read(16).length
-      assert_equal options[:kex] || (x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha1]).join(','), buffer.read_string
+      assert_equal options[:kex] || (x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1]).join(','), buffer.read_string
       assert_equal options[:host_key] || (ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa rsa-sha2-256 rsa-sha2-512]).join(','), buffer.read_string
       assert_equal options[:encryption_client] || 'aes256-ctr,aes192-ctr,aes128-ctr', buffer.read_string
       assert_equal options[:encryption_server] || 'aes256-ctr,aes192-ctr,aes128-ctr', buffer.read_string


### PR DESCRIPTION
This adds support for diffie-hellman-group14-sha256 which fixes #794.

Currently some of the tests are not working, however, that appears to be an issue with the tests themselves.
I have zero ruby experience and I'm not entirely sure where to look for this, however, I have tested this against a live server and it worked just fine.

Tested against `OpenSSH_7.9p1 Debian-10+deb10u2, OpenSSL 1.1.1d  10 Sep 2019` with `KexAlgorithms diffie-hellman-group14-sha256` in `sshd_config` with the following script:
```ruby
gem 'net-ssh', '= 6.2.0.rc1'
require 'net/ssh'

@host = 'myhost'
@user = 'myuser'
Net::SSH.start(@host, @user, kex: ["diffie-hellman-group14-sha256"]) do |ssh|
  puts ssh.exec!('date')
end
```

from sshd log:
```
Jan 15 23:28:38 myhost sshd[24325]: debug1: Client protocol version 2.0; client software version Ruby/Net::SSH_6.2.0.rc1 universal.x86_64-darwin20
Jan 15 23:28:38 myhost sshd[24325]: debug1: no match: Ruby/Net::SSH_6.2.0.rc1 universal.x86_64-darwin20
Jan 15 23:28:38 myhost sshd[24325]: debug1: Local version string SSH-2.0-OpenSSH_7.9p1 Debian-10+deb10u2
Jan 15 23:28:38 myhost sshd[24325]: debug1: permanently_set_uid: 107/65534 [preauth]
Jan 15 23:28:38 myhost sshd[24325]: debug1: list_hostkey_types: ssh-ed25519 [preauth]
Jan 15 23:28:38 myhost sshd[24325]: debug1: SSH2_MSG_KEXINIT sent [preauth]
Jan 15 23:28:39 myhost sshd[24325]: debug1: SSH2_MSG_KEXINIT received [preauth]
Jan 15 23:28:39 myhost sshd[24325]: debug1: kex: algorithm: diffie-hellman-group14-sha256 [preauth]
Jan 15 23:28:39 myhost sshd[24325]: debug1: kex: host key algorithm: ssh-ed25519 [preauth]
Jan 15 23:28:39 myhost sshd[24325]: debug1: kex: client->server cipher: aes256-ctr MAC: hmac-sha2-512-etm@openssh.com compression: none [preauth]
Jan 15 23:28:39 myhost sshd[24325]: debug1: kex: server->client cipher: aes256-ctr MAC: hmac-sha2-512-etm@openssh.com compression: none [preauth]
Jan 15 23:28:39 myhost sshd[24325]: debug1: expecting SSH2_MSG_KEXDH_INIT [preauth]
Jan 15 23:28:39 myhost sshd[24325]: debug1: rekey after 4294967296 blocks [preauth]
Jan 15 23:28:39 myhost sshd[24325]: debug1: SSH2_MSG_NEWKEYS sent [preauth]
Jan 15 23:28:39 myhost sshd[24325]: debug1: expecting SSH2_MSG_NEWKEYS [preauth]
Jan 15 23:28:39 myhost sshd[24325]: debug1: SSH2_MSG_NEWKEYS received [preauth]
Jan 15 23:28:39 myhost sshd[24325]: debug1: rekey after 4294967296 blocks [preauth]
Jan 15 23:28:39 myhost sshd[24325]: debug1: KEX done [preauth]
```

test results:

```
Mocha deprecation warning at /Users/myuser/dev/net-ssh/test/common.rb:14:in `require': Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'.
Skipping packet stream test for idea-cbc
Run options: --seed 51163

# Running:

.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................EE...E..........................................................................................................................................................................................

Finished in 5.025282s, 300.6796 runs/s, 1017.0574 assertions/s.

  1) Error:
Transport::Kex::TestDiffieHellmanGroup14SHA256#test_exchange_keys_should_return_expected_results_when_successful:
Net::SSH::Exception: could not verify server signature
    /Users/myuser/dev/net-ssh/lib/net/ssh/transport/kex/abstract.rb:108:in `verify_signature'
    /Users/myuser/dev/net-ssh/lib/net/ssh/transport/kex/abstract.rb:50:in `exchange_keys'
    /Users/myuser/dev/net-ssh/test/transport/kex/test_diffie_hellman_group1_sha1.rb:100:in `exchange!'
    /Users/myuser/dev/net-ssh/test/transport/kex/test_diffie_hellman_group1_sha1.rb:21:in `test_exchange_keys_should_return_expected_results_when_successful'

  2) Error:
Transport::Kex::TestDiffieHellmanGroup14SHA256#test_exchange_keys_can_use_md5_fingerprints:
Net::SSH::Exception: could not verify server signature
    /Users/myuser/dev/net-ssh/lib/net/ssh/transport/kex/abstract.rb:108:in `verify_signature'
    /Users/myuser/dev/net-ssh/lib/net/ssh/transport/kex/abstract.rb:50:in `exchange_keys'
    /Users/myuser/dev/net-ssh/test/transport/kex/test_diffie_hellman_group1_sha1.rb:100:in `exchange!'
    /Users/myuser/dev/net-ssh/test/transport/kex/test_diffie_hellman_group1_sha1.rb:83:in `block in test_exchange_keys_can_use_md5_fingerprints'
    /Users/myuser/dev/net-ssh/test/common.rb:51:in `assert_nothing_raised'
    /Users/myuser/dev/net-ssh/test/transport/kex/test_diffie_hellman_group1_sha1.rb:83:in `test_exchange_keys_can_use_md5_fingerprints'

  3) Error:
Transport::Kex::TestDiffieHellmanGroup14SHA256#test_exchange_keys_should_pass_expected_parameters_to_host_key_verifier:
Net::SSH::Exception: could not verify server signature
    /Users/myuser/dev/net-ssh/lib/net/ssh/transport/kex/abstract.rb:108:in `verify_signature'
    /Users/myuser/dev/net-ssh/lib/net/ssh/transport/kex/abstract.rb:50:in `exchange_keys'
    /Users/myuser/dev/net-ssh/test/transport/kex/test_diffie_hellman_group1_sha1.rb:100:in `exchange!'
    /Users/myuser/dev/net-ssh/test/transport/kex/test_diffie_hellman_group1_sha1.rb:63:in `block in test_exchange_keys_should_pass_expected_parameters_to_host_key_verifier'
    /Users/myuser/dev/net-ssh/test/common.rb:51:in `assert_nothing_raised'
    /Users/myuser/dev/net-ssh/test/transport/kex/test_diffie_hellman_group1_sha1.rb:63:in `test_exchange_keys_should_pass_expected_parameters_to_host_key_verifier'

1511 runs, 5111 assertions, 0 failures, 3 errors, 0 skips
rake aborted!
Command failed with status (1)
/Users/myuser/.gem/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
/Library/Ruby/Gems/2.6.0/gems/bundler-1.17.2/exe/bundle:30:in `block in <top (required)>'
/Library/Ruby/Gems/2.6.0/gems/bundler-1.17.2/exe/bundle:22:in `<top (required)>'
/usr/bin/bundle:23:in `load'
/usr/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```