### PR TITLE
Fix crash when an empty payload is received

### DIFF
--- a/lib/net/ssh/transport/packet_stream.rb
+++ b/lib/net/ssh/transport/packet_stream.rb
@@ -271,7 +271,7 @@ module Net
           server.increment(@packet_length)
           @packet = nil
 
-          return Packet.new(payload)
+          return payload.empty? ? nil : Packet.new(payload)
         end
       end
       # rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
Have fixed a crash whenever a packet with an empty payload is received:

```
unexpected response  (#<Net::SSH::Packet:0x00007f9d9fd83940 @named_elements={}, @content="", @position=0, @type=nil>)
```

The crash occurs when trying to transfer data via SFTP, the remote server is`SSH-2.0-CerberusFTPServer_8.0`. Unfortunately it is a private server and I cannot provide access for debugging. I'm happy to help with debugging if further investigation is needed.