### PR TITLE
Update agent.rb

### DIFF
--- a/lib/net/ssh/authentication/agent.rb
+++ b/lib/net/ssh/authentication/agent.rb
@@ -222,8 +222,13 @@ module Net
         # is returned as a Net::SSH::Buffer).
         def read_packet
           buffer = Net::SSH::Buffer.new(@socket.read(4))
-          buffer.append(@socket.read(buffer.read_long))
-          type = buffer.read_byte
+          begin
+            buffer.append(@socket.read(buffer.read_long))
+          rescue StandardError => e  
+            puts e.message  
+            puts e.backtrace.inspect  
+          end  
+            type = buffer.read_byte
           debug { "received agent packet #{type} len #{buffer.length - 4}" }
           return type, buffer
         end

--- a/lib/net/ssh/authentication/agent.rb
+++ b/lib/net/ssh/authentication/agent.rb
@@ -228,7 +228,7 @@ module Net
             puts e.message  
             puts e.backtrace.inspect  
           end  
-            type = buffer.read_byte
+          type = buffer.read_byte
           debug { "received agent packet #{type} len #{buffer.length - 4}" }
           return type, buffer
         end


### PR DESCRIPTION
Add excetion handle to read_paket because of the following error while using net-ssh 6.1 with test-kitchen 

from /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/authentication/agent.rb:211:in read_packet' /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/buffer.rb:147:in append': can't modify frozen String: "" (FrozenError)