### PR TITLE
Handle banner prompt within authentication step using keyboard-interactive

### DIFF
--- a/lib/net/ssh/version.rb
+++ b/lib/net/ssh/version.rb
@@ -49,7 +49,7 @@ module Net
       MAJOR = 6
 
       # The minor component of this version of the Net::SSH library
-      MINOR = 3
+      MINOR = 2
 
       # The tiny component of this version of the Net::SSH library
       TINY  = 0


### PR DESCRIPTION
We use Oxidized and have an issue due by a customer login banner requirement that prompts for agreement before the password prompt. Net-ssh doesn't currently implement this.

The banner prompt is relatively standard now and uses ssh message types 60 and 61 under keyboard-interactive. I have amended the keyboard-interactive authentication code to check the prompt, and if it is not asking for the password, give a 'yes' response or respond with the correct password.