### PR TITLE
Fix the documentation URL in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Net::SSH 6.x
 
-* Docs: http://net-ssh.github.com/net-ssh
+* Docs: http://net-ssh.github.io/net-ssh
 * Issues: https://github.com/net-ssh/net-ssh/issues
 * Codes: https://github.com/net-ssh/net-ssh
 * Email: net-ssh@solutious.com


### PR DESCRIPTION
Using github.com for GitHub pages has been deprecated.