### PR TITLE
Fix mocha deprecation warning

### DIFF
--- a/test/common.rb
+++ b/test/common.rb
@@ -11,7 +11,7 @@ if ENV["CI"]
 end
 
 require 'minitest'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'net/ssh/buffer'
 require 'net/ssh/config'
 require 'net/ssh/loggable'


### PR DESCRIPTION
Before
```
➜  net-ssh git:(master) bundle exec rake test
Mocha deprecation warning at ./net-ssh/test/common.rb:14:in `require': Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'.
Run options: --seed 33461

# Running:

..............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 4.462769s, 350.9032 runs/s, 1182.8979 assertions/s.

1566 runs, 5279 assertions, 0 failures, 0 errors, 0 skips
```

After:
```
➜  net-ssh git:(master) ✗ bundle exec rake test
Run options: --seed 35717

# Running:

..............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 4.677647s, 334.7837 runs/s, 1128.5589 assertions/s.

1566 runs, 5279 assertions, 0 failures, 0 errors, 0 skips
```