### PR TITLE
Cert based host auth

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,8 @@
+AllCops:
+  Exclude:
+    - 'tryout/**/*'
+  NewCops: enable
+
 inherit_from: .rubocop_todo.yml
 
 Style/DoubleNegation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 AllCops:
   Exclude:
     - 'tryout/**/*'
+    - "vendor/**/.*"
+    - "vendor/**/*"
   NewCops: enable
 
 inherit_from: .rubocop_todo.yml

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+=== 6.3.0 beta1
+
+  * Support cert based host key auth, fix asterisk in known_hosts [#833]
+  * Support kex dh-group14-sha256  [#795]
+
 === 6.2.0 rc1
 
 === 6.2.0 beta1

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem 'byebug', group: %i[development test] if !Gem.win_platform? && RUBY_ENGINE =
 if ENV["CI"]
   gem 'codecov', require: false, group: :test
   gem 'simplecov', require: false, group: :test
-  gem 'x25519', github: 'RubyCrypto/x25519', ref: '60c0f2913460c7b13b516e4e887a5517a2bd9edd'
 end
 
 gem 'webrick', group: %i[development test] if RUBY_VERSION.split(".")[0].to_i >= 3

--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -121,7 +121,7 @@ module Net
     # * :forward_agent => set to true if you want the SSH agent connection to
     #   be forwarded
     # * :known_hosts => a custom object holding known hosts records.
-    #   It must implement #search_for and add in a similiar manner as KnownHosts.
+    #   It must implement #search_for and `add` in a similiar manner as KnownHosts.
     # * :global_known_hosts_file => the location of the global known hosts
     #   file. Set to an array if you want to specify multiple global known
     #   hosts files. Defaults to %w(/etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2).

--- a/lib/net/ssh/known_hosts.rb
+++ b/lib/net/ssh/known_hosts.rb
@@ -3,7 +3,6 @@ require 'openssl'
 require 'base64'
 require 'net/ssh/buffer'
 require 'net/ssh/authentication/ed25519_loader'
-require 'byebug'
 
 module Net
   module SSH

--- a/lib/net/ssh/known_hosts.rb
+++ b/lib/net/ssh/known_hosts.rb
@@ -223,11 +223,11 @@ module Net
       def match(host, pattern)
         if pattern.include?('*') || pattern.include?('?')
           # see man 8 sshd for pattern details
-          pattern_regexp = pattern.split('*').map do |x|
-            x.split('?').map do |y|
+          pattern_regexp = pattern.split('*', -1).map do |x|
+            x.split('?', -1).map do |y|
               Regexp.escape(y)
             end.join('.')
-          end.join('[^.]*')
+          end.join('.*')
 
           host =~ Regexp.new("\\A#{pattern_regexp}\\z")
         else

--- a/lib/net/ssh/known_hosts.rb
+++ b/lib/net/ssh/known_hosts.rb
@@ -10,8 +10,7 @@ module Net
     module HostKeyEntries
       # regular public key entry
       class PubKey < Delegator
-        def initialize(key, comment: nil)
-          super()
+        def initialize(key, comment: nil) # rubocop:disable Lint/MissingSuper
           @key = key
           @comment = comment
         end

--- a/lib/net/ssh/known_hosts.rb
+++ b/lib/net/ssh/known_hosts.rb
@@ -43,6 +43,9 @@ module Net
             ecdsa-sha2-nistp256-cert-v01@openssh.com
             ecdsa-sha2-nistp384-cert-v01@openssh.com
             ecdsa-sha2-nistp521-cert-v01@openssh.com
+            ssh-ed25519-cert-v01@openssh.com
+            ssh-rsa-cert-v01@openssh.com
+            ssh-rsa-cert-v00@openssh.com
           ]
         end
 

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -278,7 +278,7 @@ module Net
             # existing known key for the host has preference.
 
             existing_keys = session.host_keys
-            host_keys = existing_keys.map { |key| key.ssh_type }.uniq
+            host_keys = existing_keys.flat_map { |key| key.respond_to?(:ssh_types) ? key.ssh_types : [key.ssh_type] }.uniq
             algorithms[:host_key].each do |name|
               host_keys << name unless host_keys.include?(name)
             end

--- a/lib/net/ssh/verifiers/always.rb
+++ b/lib/net/ssh/verifiers/always.rb
@@ -23,7 +23,10 @@ module Net
           # blob also match.
           found = host_keys.any? do |key|
             key.ssh_type == arguments[:key].ssh_type &&
-            key.to_blob  == arguments[:key].to_blob
+            (
+              (key.respond_to?(:to_blob) && key.to_blob  == arguments[:key].to_blob) ||
+              (key.respond_to?(:matches?) && key.matches?(arguments[:key].to_blob))
+            )
           end
 
           # If a match was found, return true. Otherwise, raise an exception

--- a/lib/net/ssh/verifiers/always.rb
+++ b/lib/net/ssh/verifiers/always.rb
@@ -21,12 +21,13 @@ module Net
 
           # If we found any matches, check to see that the key type and
           # blob also match.
+
           found = host_keys.any? do |key|
-            key.ssh_type == arguments[:key].ssh_type &&
-            (
-              (key.respond_to?(:to_blob) && key.to_blob  == arguments[:key].to_blob) ||
-              (key.respond_to?(:matches?) && key.matches?(arguments[:key].to_blob))
-            )
+            if key.respond_to?(:matches_key?)
+              key.matches_key?(arguments[:key])
+            else
+              key.ssh_type == arguments[:key].ssh_type && key.to_blob == arguments[:key].to_blob
+            end
           end
 
           # If a match was found, return true. Otherwise, raise an exception

--- a/test/integration/common.rb
+++ b/test/integration/common.rb
@@ -122,7 +122,7 @@ module IntegrationTestHelpers
         yield pid, port
       end
     else
-      with_lines_as_tempfile('') do |path, pidpath|
+      with_lines_as_tempfile(['']) do |path, pidpath|
         pid = spawn('sudo', '/opt/net-ssh-openssh/sbin/sshd', '-D', '-f', path, '-p', port)
         sshpidfile = pidpath
         yield pid, port

--- a/test/integration/common.rb
+++ b/test/integration/common.rb
@@ -97,7 +97,7 @@ module IntegrationTestHelpers
       end
       f.write("\nLogLevel DEBUG3\n") if debug
       f.close
-      puts "CONFIG: #{f.path} PID: #{pidpath}"
+      puts "CONFIG: #{f.path} PID: #{pidpath}" if debug
       yield(f.path, pidpath)
     end
   end

--- a/test/integration/playbook.yml
+++ b/test/integration/playbook.yml
@@ -92,7 +92,10 @@
       lineinfile: dest='/etc/ssh/sshd_config' line='X11Forwarding no' regexp=X11Forwarding
       notify: restart sshd
     - name: sshd allow forward
-      lineinfile: dest='/etc/ssh/sshd_config' line='PasswordAuthentication=yes' regexp=PasswordAuthentication
+      lineinfile: dest='/etc/ssh/sshd_config' line='#PasswordAuthentication no' regexp='#?PasswordAuthentication.+no'
+      notify: restart sshd
+    - name: sshd allow forward
+      lineinfile: dest='/etc/ssh/sshd_config' line='PasswordAuthentication yes' regexp=PasswordAuthentication
       notify: restart sshd
     - name: put NET_SSH_RUN_INTEGRATION_TESTS=YES environment
       lineinfile: dest='/etc/environment' line='NET_SSH_RUN_INTEGRATION_TESTS=YES'

--- a/test/integration/playbook.yml
+++ b/test/integration/playbook.yml
@@ -102,9 +102,12 @@
     - name: change dir in bashrc
       lineinfile: dest="{{homedir}}/.bashrc" owner="{{myuser}}" mode=0644
         regexp='^cd ' line='cd /net-ssh'
-    - name: add host aliases
+    - name: add host aliases1
       lineinfile: dest='/etc/hosts' owner='root' group='root' mode=0644
         regexp='^127\.0\.0\.1\s+gateway.netssh' line='127.0.0.1  gateway.netssh'
+    - name: add host aliases2
+      lineinfile: dest='/etc/hosts' owner='root' group='root' mode=0644
+        regexp='^127\.0\.0\.1\s+one.hosts.netssh' line='127.0.0.1  one.hosts.netssh'
     - name: Update APT Cache
       apt:
         update_cache: yes

--- a/test/integration/test_cert_host_auth.rb
+++ b/test/integration/test_cert_host_auth.rb
@@ -13,10 +13,7 @@ class TestCertHostAuth < NetSSHTest
 
   def setup_ssh_env(&block)
     tmpdir do |dir|
-      @badcert = "#{dir}/badca"
-      sh "rm -rf #{@badcert} #{@badcert}.pub"
-      sh "ssh-keygen -t rsa -N '' -C 'ca@hosts.netssh' -f #{@badcert}"
-
+      # create a cert, and sign the host key
       @cert = "#{dir}/ca"
       sh "rm -rf #{@cert} #{@cert}.pub"
       sh "ssh-keygen -t rsa -N '' -C 'ca@hosts.netssh' -f #{@cert}"
@@ -25,29 +22,29 @@ class TestCertHostAuth < NetSSHTest
         sh "ssh-keygen -s #{@cert} -h -I one.hosts.netssh -n one.hosts.netssh #{dir}/one.hosts.netssh.pub"
         sh "ssh-keygen -L -f one.hosts.netssh-cert.pub"
       end
-      # FileUtils.cp "#{dir}/cloud.jameshfisher.com-cert.pub", "/etc/ssh/ssh_host_ecdsa_key-cert.pub"
-      sh "sudo cp -f #{dir}/one.hosts.netssh-cert.pub /etc/ssh/ssh_host_ecdsa_key-cert.pub"
-      yield(cert_pub: "#{@cert}.pub", badcert_pub: "#{@badcert}.pub")
+      signed_host_key = "/etc/ssh/ssh_host_ecdsa_key-cert.pub"
+      sh "sudo cp -f #{dir}/one.hosts.netssh-cert.pub #{signed_host_key}"
+
+      # we don't use this for signing the cert
+      @badcert = "#{dir}/badca"
+      sh "rm -rf #{@badcert} #{@badcert}.pub"
+      sh "ssh-keygen -t rsa -N '' -C 'ca@hosts.netssh' -f #{@badcert}"
+
+      yield(cert_pub: "#{@cert}.pub", badcert_pub: "#{@badcert}.pub", signed_host_key: signed_host_key)
     end
   end
 
-  def test_smoke
-    config_lines = []
-    config_lines.push("HostCertificate /etc/ssh/ssh_host_ecdsa_key-cert.pub")
-
+  def test_host_should_match_when_host_key_was_signed_by_key
     Tempfile.open('cert_kh') do |f|
       setup_ssh_env do |params|
         data = File.read(params[:cert_pub])
-        puts "Data: #{data}"
         f.write("@cert-authority *.hosts.netssh #{data}")
         f.close
 
-        start_sshd_7_or_later(config: config_lines, debug: true) do |_pid, port|
-          Timeout.timeout(400) do
-            # We have our own sshd, give it a chance to come up before
-            # listening.
+        config_lines = ["HostCertificate #{params[:signed_host_key]}"]
+        start_sshd_7_or_later(config: config_lines) do |_pid, port|
+          Timeout.timeout(100) do
             ret = Net::SSH.start("one.hosts.netssh", "net_ssh_1", password: 'foopwd', port: port, verify_host_key: :always, user_known_hosts_file: [f.path], verbose: :debug) do |ssh|
-              # assert_equal ssh.transport.algorithms.kex, "curve25519-sha256"
               ssh.exec! "echo 'foo'"
             end
             assert_equal "foo\n", ret
@@ -60,26 +57,19 @@ class TestCertHostAuth < NetSSHTest
     end
   end
 
-  def test_failure
-    config_lines = []
-    config_lines.push("HostCertificate /etc/ssh/ssh_host_ecdsa_key-cert.pub")
-
-    Tempfile.open('empty_kh') do |f|
+  def test_with_other_pub_key_host_key_should_not_match
+    Tempfile.open('cert_kh') do |f|
       setup_ssh_env do |params|
         data = File.read(params[:badcert_pub])
-
-        puts "Data: #{data}"
         f.write("@cert-authority *.hosts.netssh #{data}")
         f.close
 
-        start_sshd_7_or_later(config: config_lines, debug: true) do |_pid, port|
-          Timeout.timeout(400) do
-            # sh "ssh net_ssh_1@one.hosts.netssh -p #{port} -o UserKnownHostsFile=#{f.path}"
-
+        config_lines = ["HostCertificate #{params[:signed_host_key]}"]
+        start_sshd_7_or_later(config: config_lines) do |_pid, port|
+          Timeout.timeout(100) do
             sleep 0.2
             assert_raises(Net::SSH::HostKeyMismatch) do
               Net::SSH.start("one.hosts.netssh", "net_ssh_1", password: 'foopwd', port: port, verify_host_key: :always, user_known_hosts_file: [f.path], verbose: :debug) do |ssh|
-                # assert_equal ssh.transport.algorithms.kex, "curve25519-sha256"
                 ssh.exec! "echo 'foo'"
               end
             end

--- a/test/integration/test_cert_host_auth.rb
+++ b/test/integration/test_cert_host_auth.rb
@@ -17,7 +17,7 @@ class TestCertHostAuth < NetSSHTest
       @badcert = "#{dir}/badca"
       sh "rm -rf #{@badcert} #{@badcert}.pub"
       sh "ssh-keygen -t rsa -N '' -C 'ca@hosts.netssh' -f #{@badcert}"
-       
+
       @cert = "#{dir}/ca"
       sh "rm -rf #{@cert} #{@cert}.pub"
       sh "ssh-keygen -t rsa -N '' -C 'ca@hosts.netssh' -f #{@cert}"
@@ -42,7 +42,7 @@ class TestCertHostAuth < NetSSHTest
         puts "Data: #{data}"
         f.write("@cert-authority *.hosts.netssh #{data}")
         f.close
-      
+
         start_sshd_7_or_later(config: config_lines, debug: true) do |_pid, port|
           Timeout.timeout(400) do
             # We have our own sshd, give it a chance to come up before
@@ -64,7 +64,7 @@ class TestCertHostAuth < NetSSHTest
   def test_failure
     config_lines = []
     config_lines.push("HostCertificate /etc/ssh/ssh_host_ecdsa_key-cert.pub")
-    
+
     Tempfile.open('empty_kh') do |f|
       setup_ssh_env do |params|
         data = File.read(params[:badcert_pub])
@@ -72,13 +72,11 @@ class TestCertHostAuth < NetSSHTest
         puts "Data: #{data}"
         f.write("@cert-authority *.hosts.netssh #{data}")
         f.close
-      
+
         start_sshd_7_or_later(config: config_lines, debug: true) do |_pid, port|
           Timeout.timeout(400) do
-            # We have our own sshd, give it a chance to come up before
-            # listening.
-            #sh "ssh net_ssh_1@one.hosts.netssh -p #{port} -o UserKnownHostsFile=#{f.path}"
-            
+            # sh "ssh net_ssh_1@one.hosts.netssh -p #{port} -o UserKnownHostsFile=#{f.path}"
+
             sleep 0.2
             assert_raises(Net::SSH::HostKeyMismatch) do
               Net::SSH.start("one.hosts.netssh", "net_ssh_1", password: 'foopwd', port: port, verify_host_key: :always, user_known_hosts_file: [f.path], verbose: :debug) do |ssh|

--- a/test/integration/test_cert_host_auth.rb
+++ b/test/integration/test_cert_host_auth.rb
@@ -1,7 +1,6 @@
 require_relative 'common'
 require 'fileutils'
 require 'tmpdir'
-require 'byebug'
 require 'net/ssh'
 
 require 'timeout'

--- a/test/integration/test_cert_host_auth.rb
+++ b/test/integration/test_cert_host_auth.rb
@@ -1,0 +1,97 @@
+require_relative 'common'
+require 'fileutils'
+require 'tmpdir'
+require 'byebug'
+require 'net/ssh'
+
+require 'timeout'
+
+# see Vagrantfile,playbook for env.
+# we're running as net_ssh_1 user password foo
+# and usually connecting to net_ssh_2 user password foo2pwd
+class TestCertHostAuth < NetSSHTest
+  include IntegrationTestHelpers
+
+  def setup_ssh_env(&block)
+    tmpdir do |dir|
+      @badcert = "#{dir}/badca"
+      sh "rm -rf #{@badcert} #{@badcert}.pub"
+      sh "ssh-keygen -t rsa -N '' -C 'ca@hosts.netssh' -f #{@badcert}"
+       
+      @cert = "#{dir}/ca"
+      sh "rm -rf #{@cert} #{@cert}.pub"
+      sh "ssh-keygen -t rsa -N '' -C 'ca@hosts.netssh' -f #{@cert}"
+      FileUtils.cp "/etc/ssh/ssh_host_ecdsa_key.pub", "#{dir}/one.hosts.netssh.pub"
+      Dir.chdir(dir) do
+        sh "ssh-keygen -s #{@cert} -h -I one.hosts.netssh -n one.hosts.netssh #{dir}/one.hosts.netssh.pub"
+        sh "ssh-keygen -L -f one.hosts.netssh-cert.pub"
+      end
+      # FileUtils.cp "#{dir}/cloud.jameshfisher.com-cert.pub", "/etc/ssh/ssh_host_ecdsa_key-cert.pub"
+      sh "sudo cp -f #{dir}/one.hosts.netssh-cert.pub /etc/ssh/ssh_host_ecdsa_key-cert.pub"
+      yield(cert_pub: "#{@cert}.pub", badcert_pub: "#{@badcert}.pub")
+    end
+  end
+
+  def test_smoke
+    config_lines = []
+    config_lines.push("HostCertificate /etc/ssh/ssh_host_ecdsa_key-cert.pub")
+
+    Tempfile.open('cert_kh') do |f|
+      setup_ssh_env do |params|
+        data = File.read(params[:cert_pub])
+        puts "Data: #{data}"
+        f.write("@cert-authority *.hosts.netssh #{data}")
+        f.close
+      
+        start_sshd_7_or_later(config: config_lines, debug: true) do |_pid, port|
+          Timeout.timeout(400) do
+            # We have our own sshd, give it a chance to come up before
+            # listening.
+            ret = Net::SSH.start("one.hosts.netssh", "net_ssh_1", password: 'foopwd', port: port, verify_host_key: :always, user_known_hosts_file: [f.path], verbose: :debug) do |ssh|
+              # assert_equal ssh.transport.algorithms.kex, "curve25519-sha256"
+              ssh.exec! "echo 'foo'"
+            end
+            assert_equal "foo\n", ret
+          rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+            sleep 0.25
+            retry
+          end
+        end
+      end
+    end
+  end
+
+  def test_failure
+    config_lines = []
+    config_lines.push("HostCertificate /etc/ssh/ssh_host_ecdsa_key-cert.pub")
+    
+    Tempfile.open('empty_kh') do |f|
+      setup_ssh_env do |params|
+        data = File.read(params[:badcert_pub])
+
+        puts "Data: #{data}"
+        f.write("@cert-authority *.hosts.netssh #{data}")
+        f.close
+      
+        start_sshd_7_or_later(config: config_lines, debug: true) do |_pid, port|
+          Timeout.timeout(400) do
+            # We have our own sshd, give it a chance to come up before
+            # listening.
+            #sh "ssh net_ssh_1@one.hosts.netssh -p #{port} -o UserKnownHostsFile=#{f.path}"
+            
+            sleep 0.2
+            assert_raises(Net::SSH::HostKeyMismatch) do
+              Net::SSH.start("one.hosts.netssh", "net_ssh_1", password: 'foopwd', port: port, verify_host_key: :always, user_known_hosts_file: [f.path], verbose: :debug) do |ssh|
+                # assert_equal ssh.transport.algorithms.kex, "curve25519-sha256"
+                ssh.exec! "echo 'foo'"
+              end
+            end
+          rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+            sleep 0.25
+            retry
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/test_channel.rb
+++ b/test/integration/test_channel.rb
@@ -108,7 +108,7 @@ class TestChannel < NetSSHTest
 
   def test_channel_should_set_environment_variables_on_remote
     setup_ssh_env do
-      start_sshd_7_or_later(config: 'AcceptEnv foo baz') do |_pid, port|
+      start_sshd_7_or_later(config: ['AcceptEnv foo baz']) do |_pid, port|
         Timeout.timeout(20) do
           # We have our own sshd, give it a chance to come up before
           # listening.

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -46,9 +46,10 @@ module Transport
     end
 
     def test_constructor_with_known_hosts_reporting_known_host_key_should_use_that_host_key_type
-      Net::SSH::KnownHosts.expects(:search_for).with("net.ssh.test,127.0.0.1", {
-        user_known_hosts_file: "/dev/null", global_known_hosts_file: "/dev/null"
-      }).returns([stub("key", ssh_type: "ssh-dss")])
+      Net::SSH::KnownHosts.expects(:search_for).with(
+        "net.ssh.test,127.0.0.1",
+        { user_known_hosts_file: "/dev/null", global_known_hosts_file: "/dev/null" }
+      ).returns([stub("key", ssh_type: "ssh-dss")])
       assert_equal %w[ssh-dss] + ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa rsa-sha2-256 rsa-sha2-512], algorithms[:host_key]
     end
 
@@ -441,8 +442,10 @@ module Transport
 
     def transport(transport_options={})
       @transport ||= MockTransport.new(
-        {user_known_hosts_file: '/dev/null',
-        global_known_hosts_file: '/dev/null'}.merge(transport_options)  
+        {
+          user_known_hosts_file: '/dev/null',
+          global_known_hosts_file: '/dev/null'
+        }.merge(transport_options)
       )
     end
   end

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -442,7 +442,7 @@ module Transport
     def transport(transport_options={})
       @transport ||= MockTransport.new(
         {user_known_hosts_file: '/dev/null',
-        global_known_hosts_file: '/dev/null'}.merge(transport_options)
+        global_known_hosts_file: '/dev/null'}.merge(transport_options)  
       )
     end
   end

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -46,7 +46,9 @@ module Transport
     end
 
     def test_constructor_with_known_hosts_reporting_known_host_key_should_use_that_host_key_type
-      Net::SSH::KnownHosts.expects(:search_for).with("net.ssh.test,127.0.0.1", {}).returns([stub("key", ssh_type: "ssh-dss")])
+      Net::SSH::KnownHosts.expects(:search_for).with("net.ssh.test,127.0.0.1", {
+        user_known_hosts_file: "/dev/null", global_known_hosts_file: "/dev/null"
+      }).returns([stub("key", ssh_type: "ssh-dss")])
       assert_equal %w[ssh-dss] + ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa rsa-sha2-256 rsa-sha2-512], algorithms[:host_key]
     end
 
@@ -438,7 +440,10 @@ module Transport
     end
 
     def transport(transport_options={})
-      @transport ||= MockTransport.new(transport_options)
+      @transport ||= MockTransport.new(
+        {user_known_hosts_file: '/dev/null',
+        global_known_hosts_file: '/dev/null'}.merge(transport_options)
+      )
     end
   end
 end


### PR DESCRIPTION
Fixes: #613 

Implements `@cert-authority` marker in KnownHosts file.
1. If we see such marker, matching the connected host, we allow prioritize all cert-algs when negotiating with server.
https://github.com/net-ssh/net-ssh/blob/51dc78feac5dc9df615ca0ef82e707951887411c/lib/net/ssh/known_hosts.rb#L41-L47
2. If server sends a certificate , we verify that it's signed correctly and the signature matches what's in known hosts
https://github.com/net-ssh/net-ssh/blob/51dc78feac5dc9df615ca0ef82e707951887411c/lib/net/ssh/known_hosts.rb#L54-L60

Also changes `*` in `known_host` like in openssh this now includes dots and also a single `*` can be used to match any hosts.


TODO: We don't support `@revoke` yet, also if nonstandard port like `2213` used, the we only match`[hostname]:2213` against patterns in `known_hosts`. Unlike regular opens which matches portless name if host key's is new. 
https://github.com/openssh/openssh-portable/blob/4d2d4d47a18d93f3e0a91a241a6fdb545bbf7dc2/sshconnect.c#L1106-L1118