### PR TITLE
Disable codecov

### DIFF
--- a/test/common.rb
+++ b/test/common.rb
@@ -5,8 +5,8 @@ if ENV["CI"]
     require 'simplecov'
     SimpleCov.start
 
-    require 'codecov'
-    SimpleCov.formatter = SimpleCov::Formatter::Codecov
+#    require 'codecov'
+#    SimpleCov.formatter = SimpleCov::Formatter::Codecov
   end
 end
 


### PR DESCRIPTION
https://github.com/net-ssh/net-ssh/runs/3979836727?check_suite_focus=true

```
  _____          _
 / ____|        | |
| |     ___   __| | ___  ___ _____   __
| |    / _ \ / _\`|/ _ \/ __/ _ \ \ / /
| |___| (_) | (_| |  __/ (_| (_) \ V /
 \_____\___/ \__,_|\___|\___\___/ \_/
                               Ruby-0.6.0
x> No CI provider detected.
x> No token specified or token is empty
/home/runner/work/net-ssh/net-ssh/vendor/bundle/ruby/2.7.0/gems/codecov-0.6.0/lib/codecov/uploader.rb:56:in `upload': Could not upload reports to Codecov (StandardError)
	from /home/runner/work/net-ssh/net-ssh/vendor/bundle/ruby/2.7.0/gems/codecov-0.6.0/lib/codecov.rb:15:in `format'
	from /home/runner/work/net-ssh/net-ssh/vendor/bundle/ruby/2.7.0/gems/simplecov-0.21.2/lib/simplecov/result.rb:51:in `format!'
	from /home/runner/work/net-ssh/net-ssh/vendor/bundle/ruby/2.7.0/gems/simplecov-0.21.2/lib/simplecov/configuration.rb:197:in `block in at_exit'
	from /home/runner/work/net-ssh/net-ssh/vendor/bundle/ruby/2.7.0/gems/simplecov-0.21.2/lib/simplecov.rb:189:in `run_exit_tasks!'
	from /home/runner/work/net-ssh/net-ssh/vendor/bundle/ruby/2.7.0/gems/simplecov-0.21.2/lib/simplecov.rb:179:in `at_exit_behavior'
	from /home/runner/work/net-ssh/net-ssh/vendor/bundle/ruby/2.7.0/gems/simplecov-0.21.2/lib/minitest/simplecov_plugin.rb:11:in `block in plugin_simplecov_init'
	from /home/runner/work/net-ssh/net-ssh/vendor/bundle/ruby/2.7.0/gems/minitest-5.14.4/lib/minitest.rb:64:in `reverse_each'
	from /home/runner/work/net-ssh/net-ssh/vendor/bundle/ruby/2.7.0/gems/minitest-5.14.4/lib/minitest.rb:64:in `block (2 levels) in autorun'
==> Gzipping contents
==> Uploading reports
    url:   https://codecov.io
    query: token=secret&flags&package=ruby-0.6.0&branch=master&commit=c63c0e8899f089f3a8cd11f7997a37eee7d1daac
->  Pinging Codecov
https://codecov.io/upload/v4?token=secret&flags&package=ruby-0.6.0&branch=master&commit=c63c0e8899f089f3a8cd11f7997a37eee7d1daac
Could not determine repo and owner
rake aborted!
````