### PR TITLE
aes(128|256)-gcm support

### DIFF
--- a/lib/net/ssh/transport/aead_aes_gcm.rb
+++ b/lib/net/ssh/transport/aead_aes_gcm.rb
@@ -1,0 +1,60 @@
+require 'openssl'
+require 'delegate'
+
+module Net::SSH::Transport
+  # :nodoc:
+  # Ruby implementation of AEAD Aes-GCM Mode
+  # for Block Ciphers. See RFC5647 for details.
+  # The main purpose is the implementation of the GCM iv increment
+  module AEADAESGCM
+    def self.extended(orig)
+      orig.instance_eval do
+        @iv = { fixed: nil, invocation_counter: nil }
+        orig.padding = 0
+
+        singleton_class.send(:alias_method, :_update, :update)
+        singleton_class.send(:private, :_update)
+        singleton_class.send(:undef_method, :update)
+
+        def self.block_size
+          16
+        end
+
+        def iv_len
+          12
+        end
+
+        def iv=(iv_s)
+          if @iv[:fixed].nil?
+            @iv[:fixed] = iv_s[0...4]
+            @iv[:invocation_counter] = iv_s[4...12]
+          end
+          super(iv_s)
+        end
+
+        def incr_iv
+          return if @iv[:fixed].nil?
+
+          @iv[:invocation_counter] = [(@iv[:invocation_counter].unpack1('B*').to_i(2) + 1)].pack('Q>*')
+          self.iv = "#{@iv[:fixed]}#{@iv[:invocation_counter]}"
+        end
+
+        def padding=(pad)
+          # DO NOTHING (always 0)
+        end
+
+        def reset
+          super
+        end
+
+        def final
+          super
+        end
+
+        def update(data)
+          super(data)
+        end
+      end
+    end
+  end
+end

--- a/lib/net/ssh/transport/cipher_factory.rb
+++ b/lib/net/ssh/transport/cipher_factory.rb
@@ -1,5 +1,6 @@
 require 'openssl'
 require 'net/ssh/transport/ctr.rb'
+require 'net/ssh/transport/aead_aes_gcm'
 require 'net/ssh/transport/key_expander'
 require 'net/ssh/transport/identity_cipher'
 
@@ -25,6 +26,8 @@ module Net
           "aes192-ctr" => ::OpenSSL::Cipher.ciphers.include?("aes-192-ctr") ? "aes-192-ctr" : "aes-192-ecb",
           "aes128-ctr" => ::OpenSSL::Cipher.ciphers.include?("aes-128-ctr") ? "aes-128-ctr" : "aes-128-ecb",
           'cast128-ctr' => 'cast5-ecb',
+          "aes256-gcm@openssh.com" => "aes-256-gcm",
+          "aes128-gcm@openssh.com" => "aes-128-gcm",
 
           'none' => 'none'
         }
@@ -59,6 +62,10 @@ module Net
             else
               cipher = Net::SSH::Transport::OpenSSLAESCTR.new(cipher)
             end
+          end
+
+          if name =~ /-gcm/
+            cipher.extend(Net::SSH::Transport::AEADAESGCM)
           end
           cipher.iv = Net::SSH::Transport::KeyExpander.expand_key(cipher.iv_len, options[:iv], options)
 

--- a/lib/net/ssh/transport/hmac.rb
+++ b/lib/net/ssh/transport/hmac.rb
@@ -1,4 +1,6 @@
 require 'net/ssh/transport/key_expander'
+require 'net/ssh/transport/hmac/aead_aes128_gcm'
+require 'net/ssh/transport/hmac/aead_aes256_gcm'
 require 'net/ssh/transport/hmac/md5'
 require 'net/ssh/transport/hmac/md5_96'
 require 'net/ssh/transport/hmac/sha1'
@@ -29,6 +31,8 @@ module Net::SSH::Transport::HMAC
     'hmac-sha2-512-etm@openssh.com' => SHA2_512_Etm,
     'hmac-ripemd160' => RIPEMD160,
     'hmac-ripemd160@openssh.com' => RIPEMD160,
+    'aes128-gcm@openssh.com' => Aes128gcm,
+    'aes256-gcm@openssh.com' => Aes256gcm,
     'none' => None
   }
 

--- a/lib/net/ssh/transport/hmac/abstract.rb
+++ b/lib/net/ssh/transport/hmac/abstract.rb
@@ -8,6 +8,18 @@ module Net
         # The base class of all OpenSSL-based HMAC algorithm wrappers.
         class Abstract
           class << self
+            def aead(*v)
+              @aead = false if !defined?(@aead)
+              if v.empty?
+                @aead = superclass.aead if @aead.nil? && superclass.respond_to?(:aead)
+                return @aead
+              elsif v.length == 1
+                @aead = v.first
+              else
+                raise ArgumentError, "wrong number of arguments (#{v.length} for 1)"
+              end
+            end
+
             def etm(*v)
               @etm = false if !defined?(@etm)
               if v.empty?
@@ -55,6 +67,10 @@ module Net
                 raise ArgumentError, "wrong number of arguments (#{v.length} for 1)"
               end
             end
+          end
+
+          def aead
+            self.class.aead
           end
 
           def etm

--- a/lib/net/ssh/transport/hmac/aead_aes128_gcm.rb
+++ b/lib/net/ssh/transport/hmac/aead_aes128_gcm.rb
@@ -1,0 +1,11 @@
+require 'net/ssh/transport/hmac/abstract'
+
+module Net::SSH::Transport::HMAC
+  # The SHA-512 Encrypt-Then-Mac HMAC algorithm. This has a mac and
+  # key length of 64, and uses the SHA-512 digest algorithm.
+  class Aes128gcm < Abstract
+    aead         true
+    mac_length   16
+    key_length   16
+  end
+end

--- a/lib/net/ssh/transport/hmac/aead_aes256_gcm.rb
+++ b/lib/net/ssh/transport/hmac/aead_aes256_gcm.rb
@@ -1,0 +1,11 @@
+require 'net/ssh/transport/hmac/abstract'
+
+module Net::SSH::Transport::HMAC
+  # The SHA-512 Encrypt-Then-Mac HMAC algorithm. This has a mac and
+  # key length of 64, and uses the SHA-512 digest algorithm.
+  class Aes256gcm < Abstract
+    aead         true
+    mac_length   16
+    key_length   32
+  end
+end

--- a/test/integration/test_gcm_cipher.rb
+++ b/test/integration/test_gcm_cipher.rb
@@ -1,0 +1,51 @@
+require_relative 'common'
+require 'fileutils'
+require 'tmpdir'
+
+require 'net/ssh'
+
+require 'timeout'
+
+# see Vagrantfile,playbook for env.
+# we're running as net_ssh_1 user password foo
+# and usually connecting to net_ssh_2 user password foo2pwd
+class TestGcmCipher < NetSSHTest
+  include IntegrationTestHelpers
+
+  def run_with_only_cipher(cipher)
+    config_lines = File.read('/etc/ssh/sshd_config').split("\n")
+    config_lines = config_lines.map do |line|
+      if line =~ /^Ciphers/
+        "##{line}"
+      else
+        line
+      end
+    end
+    config_lines.push("Ciphers #{cipher}")
+
+    Tempfile.open('empty_kh') do |f|
+      f.close
+      start_sshd_7_or_later(config: config_lines, debug: true) do |_pid, port|
+        Timeout.timeout(4) do
+          # We have our own sshd, give it a chance to come up before
+          # listening.
+          ret = Net::SSH.start("localhost", "net_ssh_1", encryption: cipher, password: 'foopwd', port: port, user_known_hosts_file: [f.path], verbose: :debug) do |ssh|
+            ssh.exec! "echo 'foo'"
+          end
+          assert_equal "foo\n", ret
+        rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+          sleep 0.25
+          retry
+        end
+      end
+    end
+  end
+
+  def test_aes128_gcm
+    run_with_only_cipher('aes128-gcm@openssh.com')
+  end
+
+  def test_aes256_gcm
+    run_with_only_cipher('aes256-gcm@openssh.com')
+  end
+end

--- a/test/transport/test_aead_aes_gcm.rb
+++ b/test/transport/test_aead_aes_gcm.rb
@@ -1,0 +1,27 @@
+require_relative '../common'
+require 'logger'
+require 'net/ssh/transport/aead_aes_gcm'
+
+module Transport
+  class TestAEADAESGCM < NetSSHTest
+    def gcm_cipher
+      iv = "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"
+      Net::SSH::Transport::CipherFactory.get('aes256-gcm@openssh.com',
+                                             iv: iv,
+                                             key: '1' * 32,
+                                             shared: 'toto',
+                                             hash: 'XYZZYXXYZZYX',
+                                             digester: 'none')
+    end
+
+    def test_iv_increment_when_64_bit_long
+      cipher = gcm_cipher
+      cipher.incr_iv
+      assert_equal cipher.instance_variable_get(:@iv), { fixed: "\xFF\xFF\xFF\xFF", invocation_counter: "\x00\x00\x00\x00\x00\x00\x00\x00" }
+    end
+
+    def test_block_size
+      assert_equal gcm_cipher.block_size, 16
+    end
+  end
+end

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -19,7 +19,7 @@ module Transport
     def test_constructor_should_build_default_list_of_preferred_algorithms
       assert_equal ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa rsa-sha2-256 rsa-sha2-512], algorithms[:host_key]
       assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1], algorithms[:kex]
-      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr], algorithms[:encryption]
+      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com], algorithms[:encryption]
       assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1], algorithms[:hmac]
       assert_equal %w[none zlib@openssh.com zlib], algorithms[:compression]
       assert_equal %w[], algorithms[:language]
@@ -28,7 +28,7 @@ module Transport
     def test_constructor_should_build_complete_list_of_algorithms_with_append_all_supported_algorithms
       assert_equal ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa rsa-sha2-256 rsa-sha2-512 ssh-dss], algorithms(append_all_supported_algorithms: true)[:host_key]
       assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1], algorithms(append_all_supported_algorithms: true)[:kex]
-      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(append_all_supported_algorithms: true)[:encryption]
+      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(append_all_supported_algorithms: true)[:encryption]
       assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 hmac-md5-96 none], algorithms(append_all_supported_algorithms: true)[:hmac]
       assert_equal %w[none zlib@openssh.com zlib], algorithms(append_all_supported_algorithms: true)[:compression]
       assert_equal %w[], algorithms[:language]
@@ -112,27 +112,27 @@ module Transport
     end
 
     def test_constructor_with_preferred_encryption_should_put_preferred_encryption_first
-      assert_equal %w[aes256-cbc aes256-ctr aes192-ctr aes128-ctr aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(encryption: "aes256-cbc", append_all_supported_algorithms: true)[:encryption]
+      assert_equal %w[aes256-cbc aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(encryption: "aes256-cbc", append_all_supported_algorithms: true)[:encryption]
     end
 
     def test_constructor_with_multiple_preferred_encryption_should_put_all_preferred_encryption_first
-      assert_equal %w[aes256-cbc 3des-cbc idea-cbc aes256-ctr aes192-ctr aes128-ctr aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr none], algorithms(encryption: %w[aes256-cbc 3des-cbc idea-cbc], append_all_supported_algorithms: true)[:encryption]
+      assert_equal %w[aes256-cbc 3des-cbc idea-cbc aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr none], algorithms(encryption: %w[aes256-cbc 3des-cbc idea-cbc], append_all_supported_algorithms: true)[:encryption]
     end
 
     def test_constructor_with_unrecognized_encryption_should_keep_whats_supported
-      assert_equal %w[aes256-cbc aes256-ctr aes192-ctr aes128-ctr aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(encryption: %w[bogus aes256-cbc], append_all_supported_algorithms: true)[:encryption]
+      assert_equal %w[aes256-cbc aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(encryption: %w[bogus aes256-cbc], append_all_supported_algorithms: true)[:encryption]
     end
 
     def test_constructor_with_preferred_encryption_supports_additions
       # There's nothing we can really append to the set since the default algos
       # are frozen so this is really just testing that it doesn't do anything
       # unexpected.
-      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none],
+      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none],
                    algorithms(encryption: %w[+3des-cbc])[:encryption]
     end
 
     def test_constructor_with_preferred_encryption_supports_removals_with_wildcard
-      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr cast128-ctr],
+      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com cast128-ctr],
                    algorithms(encryption: %w[-rijndael-cbc@lysator.liu.se -blowfish-* -3des-* -*-cbc -none])[:encryption]
     end
 
@@ -358,13 +358,22 @@ module Transport
 
     def install_mock_algorithm_lookups(options = {})
       params = { shared: shared_secret.to_ssh, hash: session_id, digester: hashing_algorithm }
+
+      klass = Class.new do
+        attr_accessor :name
+
+        def initialize(name)
+          @name = name
+        end
+      end
+
       Net::SSH::Transport::CipherFactory.expects(:get)
                                         .with(options[:client_cipher] || "aes256-ctr", params.merge(iv: key("A"), key: key("C"), encrypt: true))
-                                        .returns(:client_cipher)
+                                        .returns(klass.new(:client_cipher))
 
       Net::SSH::Transport::CipherFactory.expects(:get)
                                         .with(options[:server_cipher] || "aes256-ctr", params.merge(iv: key("B"), key: key("D"), decrypt: true))
-                                        .returns(:server_cipher)
+                                        .returns(klass.new(:server_cipher))
 
       Net::SSH::Transport::HMAC.expects(:get).with(options[:client_hmac] || "hmac-sha2-256", key("E"), params).returns(:client_hmac)
       Net::SSH::Transport::HMAC.expects(:get).with(options[:server_hmac] || "hmac-sha2-256", key("F"), params).returns(:server_hmac)
@@ -411,8 +420,8 @@ module Transport
       assert_equal 16, buffer.read(16).length
       assert_equal options[:kex] || (x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1]).join(','), buffer.read_string
       assert_equal options[:host_key] || (ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa rsa-sha2-256 rsa-sha2-512]).join(','), buffer.read_string
-      assert_equal options[:encryption_client] || 'aes256-ctr,aes192-ctr,aes128-ctr', buffer.read_string
-      assert_equal options[:encryption_server] || 'aes256-ctr,aes192-ctr,aes128-ctr', buffer.read_string
+      assert_equal options[:encryption_client] || 'aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com', buffer.read_string
+      assert_equal options[:encryption_server] || 'aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com', buffer.read_string
       assert_equal options[:hmac_client] || 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1', buffer.read_string
       assert_equal options[:hmac_server] || 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1', buffer.read_string
       assert_equal options[:compression_client] || 'none,zlib@openssh.com,zlib', buffer.read_string
@@ -427,8 +436,8 @@ module Transport
       assert !algorithms.pending?
       assert !transport.client_options[:compression]
       assert !transport.server_options[:compression]
-      assert_equal :client_cipher, transport.client_options[:cipher]
-      assert_equal :server_cipher, transport.server_options[:cipher]
+      assert_equal :client_cipher, transport.client_options[:cipher].name
+      assert_equal :server_cipher, transport.server_options[:cipher].name
       assert_equal :client_hmac, transport.client_options[:hmac]
       assert_equal :server_hmac, transport.server_options[:hmac]
     end

--- a/test/transport/test_cipher_factory.rb
+++ b/test/transport/test_cipher_factory.rb
@@ -238,6 +238,17 @@ module Transport
       assert_equal TEXT, decrypt("aes256-ctr", AES256_CTR)
     end
 
+    AES256_GCM = "\xA0\xDC#-\xB4\x010+\aP\x85 \x0E\xD0!\x8D\xB3\xA9\x8A\x92K\x0F\x82?*\xCA[\f\eJ{\x97\a\xB1Z\f\x93\x16\xEF%\xCA\xAC\xE4\x0E\xF6Y\xA9H\xC2\"zsg\xD3\xF69\xF9\xE3-\xCF\t\x1A\xA6\xA4U\xF5w\x89?k\x04\xE2I\xD9\xC4\x03\xD9\x9D~\xF5\xF9\xDE\x04\xC3\xF8\xCC\x9B\xB8&2\xF8B+e\x92\v"
+    AES256_GCM2 = "\xA2d\xE2v\xB6\xC7\xA6}\xAE\xBC'\xEBe\xE2*l\xC1\xFF\x96\xF0\\:\xA4\xCF\xAD\a\xAFW\x90\x1C4\x7F7E\xF4\xDF \xB5\x1C\xB6K\x18s^\f\x96S#7F\x99\xCAP_\x98\xFC\x13\xF5c-\xF2@6\x9Cg\xE8\xF3Q%\xC6\xF5K\xCE\xD7\xB9\xDF\xC5\x04K\xD1\xF2\xB0M\xF0\x9F(\xD8\x05u\xE8\xBA\xAA\x81\xF0nD"
+
+    def test_aes256_gcm_for_encryption
+      assert_equal AES256_GCM, encrypt("aes256-gcm@openssh.com")
+    end
+
+    def test_aes256_gcm_for_encryption2
+      assert_equal [AES256_GCM, AES256_GCM2], encrypt2("aes256-gcm@openssh.com")
+    end
+
     def test_none_for_encryption
       assert_equal TEXT, encrypt("none").strip
     end
@@ -278,7 +289,8 @@ module Transport
 
       cipher.reset
 
-      cipher.iv = "0123456789123456"
+      cipher.iv = "012345678912"
+
       padding = TEXT2.length % cipher.block_size
       result2 = cipher.update(TEXT2.dup)
       result2 << cipher.update(" " * (cipher.block_size - padding)) if padding > 0


### PR DESCRIPTION
I've added the support for the GCM algorithmes, whoch actually implies the support of AEAD algorithms. 

Used cipher name are :
- aes128-gcm@openssh.com
- aes256-gcm@openssh.com 

Example call:
```ruby
Net::SSH.start(serverIp, username, password: pass, encryption:'aes128-gcm@openssh.com') do |ssh|
  puts ssh.exec!('hostname')
end
```

or


```ruby
Net::SSH.start(serverIp, username, password: pass, encryption:'aes256-gcm@openssh.com') do |ssh|
  puts ssh.exec!('hostname')
end
```

I think the more sensitive point is the implementation of the GCM iv/counter, I really need you to pay a special intention to it during review. 

Close #834 