### PR TITLE
Check for timeouts while reading headers during server version negotiation

### DIFF
--- a/lib/net/ssh/transport/server_version.rb
+++ b/lib/net/ssh/transport/server_version.rb
@@ -56,11 +56,10 @@ module Net
               rescue EOFError
                 raise Net::SSH::Disconnect, "connection closed by remote host"
               rescue IO::WaitReadable
-                timed_out = IO.select([socket], nil, nil, timeout).nil?
-                if timed_out
-                  raise Net::SSH::ConnectionTimeout, "timeout during server version negotiating"
-                else
+                if IO.select([socket], nil, nil, timeout)
                   retry
+                else
+                  raise Net::SSH::ConnectionTimeout, "timeout during server version negotiating"
                 end
               end
               @version << b

--- a/lib/net/ssh/transport/server_version.rb
+++ b/lib/net/ssh/transport/server_version.rb
@@ -45,9 +45,9 @@ module Net
           socket.write "#{PROTO_VERSION}\r\n"
           socket.flush
 
-          raise Net::SSH::ConnectionTimeout, "timeout during server version negotiating" if timeout && !IO.select([socket], nil, nil, timeout)
-
           loop do
+            raise Net::SSH::ConnectionTimeout, "timeout during server version negotiating" if timeout && !IO.select([socket], nil, nil, timeout)
+
             @version = String.new
             loop do
               begin

--- a/test/transport/test_server_version.rb
+++ b/test/transport/test_server_version.rb
@@ -53,9 +53,9 @@ module Transport
       recv_times += 1 if data[-1] != "\n"
 
       if raise_eot
-        socket.expects(:readpartial).with(1).times(recv_times + 1).returns(*data).then.raises(EOFError, 'end of file reached')
+        socket.expects(:read_nonblock).with(1).times(recv_times + 1).returns(*data).then.raises(EOFError, 'end of file reached')
       else
-        socket.expects(:readpartial).with(1).times(recv_times).returns(*data).then.returns(nil)
+        socket.expects(:read_nonblock).with(1).times(recv_times).returns(*data).then.returns(nil)
       end
 
       socket


### PR DESCRIPTION
Currently, if we connect to a non-SSH server, we'll potentially block forever waiting to receive an SSH version string.  We'll read whatever data the server sends into `@header` but that data could be anything, e.g., the banner message from an FTP server.  If the server never sends a line that starts with `SSH-`, we'll wait around until the server breaks the connection.

This PR moves the `IO::select` timeout inside of the reading loop, so that we check for an IO timeout after each newline from the server.  We could still hang if the server never sends a final newline, but calling `IO.select` after reading each byte felt excessive.  Alternatively, we could use a combination of `IO#read_nonblock` and `IO::select` to implement a version of `IO#readpartial` with timeouts.

This might also merit a separate `read_timeout` option, since this implementation doesn't enforce a hard limit on the time it takes to connect.  (E.g. if the timeout is 10 and the server sleeps for 8 seconds between sending each line, we'll wind up taking far longer than 10 seconds to connect, or eventually timeout if the server never sends an `SSH-` line.)

I haven't attempted to add a test yet, because I wasn't sure if this is a good direction to go.  I'm happy to write a test for this implementation, though.  Just let me know.