### PR TITLE
Support `~` in the path to the SSH agent's unix socket

### DIFF
--- a/lib/net/ssh/authentication/agent.rb
+++ b/lib/net/ssh/authentication/agent.rb
@@ -85,9 +85,9 @@ module Net
             if agent_socket_factory
               agent_socket_factory.call
             elsif identity_agent
-              unix_socket_class.open(identity_agent)
+              unix_socket_class.open(File.expand_path(identity_agent))
             elsif ENV['SSH_AUTH_SOCK'] && unix_socket_class
-              unix_socket_class.open(ENV['SSH_AUTH_SOCK'])
+              unix_socket_class.open(File.expand_path(ENV['SSH_AUTH_SOCK']))
             elsif Gem.win_platform? && RUBY_ENGINE != "jruby"
               Pageant::Socket.open
             else

--- a/test/authentication/test_agent.rb
+++ b/test/authentication/test_agent.rb
@@ -50,6 +50,11 @@ module Authentication
       agent(false).connect!
     end
 
+    def test_connect_should_expand_path_to_identity_agent
+      factory.expects(:open).with("#{Dir.home}/path/to/ssh.agent.sock").returns(socket)
+      agent(false).connect! nil, "~/path/to/ssh.agent.sock"
+    end
+
     def test_connect_should_use_agent_socket_factory_instead_of_factory
       assert_equal agent.connect!, socket
       assert_equal agent.connect!(agent_socket_factory), "/foo/bar.sock"


### PR DESCRIPTION
`.ssh/config` supports paths in this style but `UNIXSocket.open` does not expand paths

Notably, environment variables like `$USER` are not supported by `ssh` for the `IdentityAgent` field so

```
Host *
  IdentityAgent "~/Library/Application Support/xyz/agent.sock"
```
works; but
```
Host *
  IdentityAgent "$USER/Library/Application Support/xyz/agent.sock"
```
does not



