### PR TITLE
ed25519 pubkey in ssh format, including comment (when present)

### DIFF
--- a/lib/net/ssh/buffer.rb
+++ b/lib/net/ssh/buffer.rb
@@ -295,7 +295,7 @@ module Net
       end
 
       # Read a keyblob of the given type from the buffer, and return it as
-      # a key. Only RSA, DSA, and ECDSA keys are supported.
+      # a key.
       def read_keyblob(type)
         case type
         when /^(.*)-cert-v01@openssh\.com$/

--- a/lib/net/ssh/key_factory.rb
+++ b/lib/net/ssh/key_factory.rb
@@ -83,9 +83,9 @@ module Net
           load_data_public_key(data, filename)
         end
 
-        # Loads a public key. It will correctly determine whether
-        # the file describes an RSA or DSA key, and will load it
-        # appropriately. The new public key is returned.
+        # Loads a public key. It will correctly determine the
+        # key type, and will load it appropriately. The new
+        # public key is returned.
         def load_data_public_key(data, filename = "")
           fields = data.split(/ /)
 
@@ -99,7 +99,11 @@ module Net
 
           blob = blob.unpack("m*").first
           reader = Net::SSH::Buffer.new(blob)
-          reader.read_key or raise OpenSSL::PKey::PKeyError, "not a public key #{filename.inspect}"
+          key = reader.read_key or raise OpenSSL::PKey::PKeyError, "not a public key #{filename.inspect}"
+          comment = fields.shift&.chomp
+          key.comment = comment if comment && key.respond_to?(:comment=)
+
+          key
         end
 
         private

--- a/test/authentication/test_ed25519.rb
+++ b/test/authentication/test_ed25519.rb
@@ -24,6 +24,8 @@ unless ENV['NET_SSH_NO_ED25519']
         signed = priv_key.ssh_do_sign(shared_secret)
         self.assert_equal(true, pub_key.ssh_do_verify(signed, shared_secret))
         self.assert_equal(priv_key.public_key.fingerprint, pub_key.fingerprint)
+        self.assert_equal(priv_key.comment, "vagrant@vagrant-ubuntu-trusty-64")
+        self.assert_equal(priv_key.public_key.comment, "vagrant@vagrant-ubuntu-trusty-64")
         self.assert_equal(pub_key.fingerprint, key_fingerprint_md5_no_pwd)
         self.assert_equal(pub_key.fingerprint('sha256'), key_fingerprint_sha256_no_pwd)
       end
@@ -41,6 +43,8 @@ unless ENV['NET_SSH_NO_ED25519']
         signed = priv_key.ssh_do_sign(shared_secret)
         self.assert_equal(true, pub_key.ssh_do_verify(signed, shared_secret))
         self.assert_equal(priv_key.public_key.fingerprint, pub_key.fingerprint)
+        self.assert_equal(priv_key.comment, "vagrant@vagrant-ubuntu-trusty-64")
+        self.assert_equal(priv_key.public_key.comment, "vagrant@vagrant-ubuntu-trusty-64")
         self.assert_equal(pub_key.fingerprint, key_fingerprint_md5_no_pwd)
         self.assert_equal(pub_key.fingerprint('sha256'), key_fingerprint_sha256_no_pwd)
       end
@@ -62,6 +66,8 @@ unless ENV['NET_SSH_NO_ED25519']
         signed = priv_key.ssh_do_sign(shared_secret)
         self.assert_equal(true, pub_key.ssh_do_verify(signed, shared_secret))
         self.assert_equal(priv_key.public_key.fingerprint, pub_key.fingerprint)
+        self.assert_equal(priv_key.comment, "vagrant@vagrant-ubuntu-trusty-64")
+        self.assert_equal(priv_key.public_key.comment, "vagrant@vagrant-ubuntu-trusty-64")
         self.assert_equal(pub_key.fingerprint, key_fingerprint_md5_pwd)
         self.assert_equal(pub_key.fingerprint('sha256'), key_fingerprint_sha256_pwd)
       end
@@ -88,6 +94,8 @@ unless ENV['NET_SSH_NO_ED25519']
         signed = priv_key.ssh_do_sign(shared_secret)
         self.assert_equal(true, pub_key.ssh_do_verify(signed, shared_secret))
         self.assert_equal(priv_key.public_key.fingerprint, pub_key.fingerprint)
+        self.assert_equal(priv_key.comment, "vagrant@vagrant-ubuntu-trusty-64")
+        self.assert_equal(priv_key.public_key.comment, "vagrant@vagrant-ubuntu-trusty-64")
         self.assert_equal(pub_key.fingerprint, key_fingerprint_md5_pwd)
         self.assert_equal(pub_key.fingerprint('sha256'), key_fingerprint_sha256_pwd)
       end

--- a/test/test_key_factory.rb
+++ b/test/test_key_factory.rb
@@ -195,6 +195,15 @@ class TestKeyFactory < NetSSHTest
     end
   end
 
+  unless ENV['NET_SSH_NO_ED25519']
+    def test_parse_ed25519_public_key_comment
+      raise "No ED25519 set NET_SSH_NO_ED25519 to ignore this test" unless Net::SSH::Authentication::ED25519Loader::LOADED
+
+      File.expects(:read).with(@key_file).returns(ed25519_public_key_no_pwd)
+      assert_equal "vagrant@vagrant-ubuntu-trusty-64", Net::SSH::KeyFactory.load_public_key('/key-file').comment
+    end
+  end
+
   private
 
   def rsa_key_fingerprint_md5
@@ -335,6 +344,10 @@ class TestKeyFactory < NetSSHTest
       WEKt5v3QsUEgVrzkM4K9UbI=
       -----END PRIVATE KEY-----
     EOF
+  end
+
+  def ed25519_public_key_no_pwd
+    'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDB2NBh4GJPPUN1kXPMu8b633Xcv55WoKC3OkBjFAbzJ vagrant@vagrant-ubuntu-trusty-64'
   end
 
   def encrypted(key, password)


### PR DESCRIPTION
Allows getting the public key in ssh-format (including the comment), from an original public key or private key

```
  public_key.to_ssh

  private_key.public_key.to_ssh
```

I was not sure about the method name to_ssh, but it fits the (apparently broken) to_pem method.

I would have liked to also implement to_ssh for the private key, but the format is more complicated and I do not know all the details - I also do not need it right now :-). Let me know if you want both key types to have it.

Also it seems a bit harder to also parse the comment when parsing the public key (as it is not part of the binary blob).

Let me know if you think this needs a test or anything else, will be happy to improve this PR.
Also simplified some outdated comments, hope that's okay.