### PR TITLE
known_hosts.rb: Added missing require delegate

### DIFF
--- a/lib/net/ssh/known_hosts.rb
+++ b/lib/net/ssh/known_hosts.rb
@@ -1,6 +1,7 @@
 require 'strscan'
 require 'openssl'
 require 'base64'
+require 'delegate'
 require 'net/ssh/buffer'
 require 'net/ssh/authentication/ed25519_loader'
 


### PR DESCRIPTION
File known_hosts.rb misses:
```
require 'delegate'
```
This causes following exception on f34:
```
/home/zzambers/.gem/ruby/gems/net-ssh-6.3.0.beta1/lib/net/ssh/known_hosts.rb:11:in `<module:HostKeyEntries>': uninitialized constant Net::SSH::HostKeyEntries::Delegator (NameError)
	from /home/zzambers/.gem/ruby/gems/net-ssh-6.3.0.beta1/lib/net/ssh/known_hosts.rb:9:in `<module:SSH>'
	from /home/zzambers/.gem/ruby/gems/net-ssh-6.3.0.beta1/lib/net/ssh/known_hosts.rb:8:in `<module:Net>'
	from /home/zzambers/.gem/ruby/gems/net-ssh-6.3.0.beta1/lib/net/ssh/known_hosts.rb:7:in `<top (required)>'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /home/zzambers/.gem/ruby/gems/net-ssh-6.3.0.beta1/lib/net/ssh/transport/algorithms.rb:2:in `<top (required)>'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /home/zzambers/.gem/ruby/gems/net-ssh-6.3.0.beta1/lib/net/ssh/transport/session.rb:6:in `<top (required)>'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /home/zzambers/.gem/ruby/gems/net-ssh-6.3.0.beta1/lib/net/ssh.rb:12:in `<top (required)>'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:160:in `require'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:160:in `rescue in require'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:149:in `require'
	from test-net-ssh.rb:1:in `<main>'
<internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- net/ssh (LoadError)
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from test-net-ssh.rb:1:in `<main>'
```

test-net-ssh.rb (reproducer) is just:
```
require "net/ssh"
```

Ruby version:
```
ruby --version
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux]
```

Ruby packages:
```
ruby-3.0.2-149.fc34.x86_64
ruby-libs-3.0.2-149.fc34.x86_64
```

Interestingly, this problem does not show up on older version of ruby (like 2.5.9 used on rhel-8).