### PR TITLE
OpenSSL 3.0 support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -95,6 +95,12 @@ Rake::TestTask.new do |t|
   t.test_files = test_files
 end
 
+# We need to enable the OpenSSL 3.0 legacy providers for our test suite
+require 'openssl'
+if OpenSSL::OPENSSL_LIBRARY_VERSION.start_with? "OpenSSL 3" then
+  ENV['OPENSSL_CONF'] = 'test/openssl3.conf'
+end
+
 desc "Run tests of Net::SSH:Test"
 Rake::TestTask.new do |t|
   t.name = "test_test"

--- a/lib/net/ssh/buffer.rb
+++ b/lib/net/ssh/buffer.rb
@@ -315,15 +315,15 @@ module Net
             key.pub_key = read_bignum
           end
         when /^ssh-rsa$/
-          key = OpenSSL::PKey::RSA.new
-          if key.respond_to?(:set_key)
-            e = read_bignum
-            n = read_bignum
-            key.set_key(n, e, nil)
-          else
-            key.e = read_bignum
-            key.n = read_bignum
-          end
+          e = read_bignum
+          n = read_bignum
+
+          asn1 = OpenSSL::ASN1::Sequence([
+            OpenSSL::ASN1::Integer(n),
+            OpenSSL::ASN1::Integer(e)
+          ])
+
+          key = OpenSSL::PKey::RSA.new(asn1.to_der)
         when /^ssh-ed25519$/
           Net::SSH::Authentication::ED25519Loader.raiseUnlessLoaded("unsupported key type `#{type}'")
           key = Net::SSH::Authentication::ED25519::PubKey.read_keyblob(self)

--- a/lib/net/ssh/transport/kex/ecdh_sha2_nistp256.rb
+++ b/lib/net/ssh/transport/kex/ecdh_sha2_nistp256.rb
@@ -18,7 +18,7 @@ module Net
           private
 
           def generate_key # :nodoc:
-            OpenSSL::PKey::EC.new(curve_name).generate_key
+            OpenSSL::PKey::EC.generate(curve_name)
           end
 
           # compute shared secret from server's public key and client's private key

--- a/test/authentication/test_agent.rb
+++ b/test/authentication/test_agent.rb
@@ -292,7 +292,7 @@ module Authentication
     end
 
     def test_add_ecdsa_identity
-      ecdsa = OpenSSL::PKey::EC.new("prime256v1").generate_key
+      ecdsa = OpenSSL::PKey::EC.generate("prime256v1")
       socket.expect do |s, type, buffer|
         assert_equal SSH2_AGENT_ADD_IDENTITY, type
         assert_equal buffer.read_string, "ecdsa-sha2-nistp256"
@@ -309,7 +309,7 @@ module Authentication
     end
 
     def test_add_ecdsa_cert_identity
-      cert = make_cert(OpenSSL::PKey::EC.new("prime256v1").generate_key)
+      cert = make_cert(OpenSSL::PKey::EC.generate("prime256v1"))
       socket.expect do |s, type, buffer|
         assert_equal SSH2_AGENT_ADD_IDENTITY, type
         assert_equal buffer.read_string, "ecdsa-sha2-nistp256-cert-v01@openssh.com"

--- a/test/authentication/test_key_manager.rb
+++ b/test/authentication/test_key_manager.rb
@@ -330,15 +330,15 @@ module Authentication
     end
 
     def ecdsa_sha2_nistp256
-      @ecdsa_sha2_nistp256 ||= OpenSSL::PKey::EC.new('prime256v1').generate_key
+      @ecdsa_sha2_nistp256 ||= OpenSSL::PKey::EC.generate('prime256v1')
     end
 
     def ecdsa_sha2_nistp384
-      @ecdsa_sha2_nistp384 ||= OpenSSL::PKey::EC.new('secp384r1').generate_key
+      @ecdsa_sha2_nistp384 ||= OpenSSL::PKey::EC.generate('secp384r1')
     end
 
     def ecdsa_sha2_nistp521
-      @ecdsa_sha2_nistp521 ||= OpenSSL::PKey::EC.new('secp521r1').generate_key
+      @ecdsa_sha2_nistp521 ||= OpenSSL::PKey::EC.generate('secp521r1')
     end
 
     def rsa_pk

--- a/test/openssl3.conf
+++ b/test/openssl3.conf
@@ -1,0 +1,25 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+ssl_conf = ssl_sect
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+CipherString = DEFAULT@SECLEVEL=0
+# system_default = system_default_sect
+# 
+# [system_default_sect]
+# Options = UnsafeLegacyRenegotiation

--- a/test/test_buffer.rb
+++ b/test/test_buffer.rb
@@ -457,7 +457,7 @@ class TestBuffer < NetSSHTest
   end
 
   def random_ecdsa_sha2_nistp256
-    k = OpenSSL::PKey::EC.new('prime256v1').generate_key
+    k = OpenSSL::PKey::EC.generate('prime256v1')
     buffer = Net::SSH::Buffer.from(:string, 'nistp256',
                                    :string, k.public_key.to_bn.to_s(2))
     key = yield(buffer)
@@ -466,7 +466,7 @@ class TestBuffer < NetSSHTest
   end
 
   def random_ecdsa_sha2_nistp384
-    k = OpenSSL::PKey::EC.new('secp384r1').generate_key
+    k = OpenSSL::PKey::EC.generate('secp384r1')
     buffer = Net::SSH::Buffer.from(:string, 'nistp384',
                                    :string, k.public_key.to_bn.to_s(2))
     key = yield(buffer)
@@ -475,7 +475,7 @@ class TestBuffer < NetSSHTest
   end
 
   def random_ecdsa_sha2_nistp521
-    k = OpenSSL::PKey::EC.new('secp521r1').generate_key
+    k = OpenSSL::PKey::EC.generate('secp521r1')
     buffer = Net::SSH::Buffer.from(:string, 'nistp521',
                                    :string, k.public_key.to_bn.to_s(2))
     key = yield(buffer)

--- a/test/test_buffer.rb
+++ b/test/test_buffer.rb
@@ -319,16 +319,24 @@ class TestBuffer < NetSSHTest
   def test_write_dss_key_should_write_argument_to_end_of_buffer
     buffer = new("start")
 
-    key = OpenSSL::PKey::DSA.new
-    if key.respond_to?(:set_pqg)
-      key.set_pqg(0xffeeddccbbaa9988, 0x7766554433221100, 0xffddbb9977553311)
-      key.set_key(0xeeccaa8866442200, nil)
-    else
-      key.p = 0xffeeddccbbaa9988
-      key.q = 0x7766554433221100
-      key.g = 0xffddbb9977553311
-      key.pub_key = 0xeeccaa8866442200
-    end
+    p = 0xffeeddccbbaa9988
+    q = 0x7766554433221100
+    g = 0xffddbb9977553311
+    pub_key = 0xeeccaa8866442200
+
+    asn1 = OpenSSL::ASN1::Sequence.new([
+      OpenSSL::ASN1::Sequence.new([
+        OpenSSL::ASN1::ObjectId.new('DSA'),
+        OpenSSL::ASN1::Sequence.new([
+          OpenSSL::ASN1::Integer.new(p),
+          OpenSSL::ASN1::Integer.new(q),
+          OpenSSL::ASN1::Integer.new(g)
+        ]),
+      ]),
+      OpenSSL::ASN1::BitString.new(OpenSSL::ASN1::Integer.new(pub_key).to_der)
+    ])
+
+    key = OpenSSL::PKey::DSA.new(asn1.to_der)
 
     buffer.write_key(key)
     assert_equal "start\0\0\0\7ssh-dss\0\0\0\011\0\xff\xee\xdd\xcc\xbb\xaa\x99\x88\0\0\0\010\x77\x66\x55\x44\x33\x22\x11\x00\0\0\0\011\0\xff\xdd\xbb\x99\x77\x55\x33\x11\0\0\0\011\0\xee\xcc\xaa\x88\x66\x44\x22\x00", buffer.to_s

--- a/test/test_buffer.rb
+++ b/test/test_buffer.rb
@@ -337,13 +337,15 @@ class TestBuffer < NetSSHTest
   def test_write_rsa_key_should_write_argument_to_end_of_buffer
     buffer = new("start")
 
-    key = OpenSSL::PKey::RSA.new
-    if key.respond_to?(:set_key)
-      key.set_key(0x7766554433221100, 0xffeeddccbbaa9988, nil)
-    else
-      key.e = 0xffeeddccbbaa9988
-      key.n = 0x7766554433221100
-    end
+    n = 0x7766554433221100
+    e = 0xffeeddccbbaa9988
+
+    asn1 = OpenSSL::ASN1::Sequence([
+      OpenSSL::ASN1::Integer(n),
+      OpenSSL::ASN1::Integer(e)
+    ])
+
+    key = OpenSSL::PKey::RSA.new(asn1.to_der)
 
     buffer.write_key(key)
     assert_equal "start\0\0\0\7ssh-rsa\0\0\0\011\0\xff\xee\xdd\xcc\xbb\xaa\x99\x88\0\0\0\010\x77\x66\x55\x44\x33\x22\x11\x00", buffer.to_s

--- a/test/test_known_hosts.rb
+++ b/test/test_known_hosts.rb
@@ -166,13 +166,12 @@ class TestKnownHosts < NetSSHTest
   end
 
   def rsa_key
-    key = OpenSSL::PKey::RSA.new
-    if key.respond_to?(:set_key)
-      key.set_key(0x7766554433221100, 0xffeeddccbbaa9988, nil)
-    else
-      key.e = 0xffeeddccbbaa9988
-      key.n = 0x7766554433221100
-    end
-    key
+    n = 0x7766554433221100
+    e = 0xffeeddccbbaa9988
+    asn1 = OpenSSL::ASN1::Sequence([
+      OpenSSL::ASN1::Integer(n),
+      OpenSSL::ASN1::Integer(e)
+    ])
+    OpenSSL::PKey::RSA.new(asn1.to_der)
   end
 end

--- a/test/transport/kex/test_curve25519_sha256.rb
+++ b/test/transport/kex/test_curve25519_sha256.rb
@@ -111,7 +111,7 @@ unless ENV['NET_SSH_NO_ED25519']
         end
 
         def server_host_key
-          @server_host_key ||= OpenSSL::PKey::EC.new('prime256v1').generate_key
+          @server_host_key ||= OpenSSL::PKey::EC.generate('prime256v1')
         end
 
         def packet_data

--- a/test/transport/kex/test_ecdh_sha2_nistp256.rb
+++ b/test/transport/kex/test_ecdh_sha2_nistp256.rb
@@ -109,11 +109,11 @@ module Transport
       end
 
       def server_key
-        @server_key ||= OpenSSL::PKey::EC.new(ecparam).generate_key
+        @server_key ||= OpenSSL::PKey::EC.generate(ecparam)
       end
 
       def server_host_key
-        @server_host_key ||= OpenSSL::PKey::EC.new('prime256v1').generate_key
+        @server_host_key ||= OpenSSL::PKey::EC.generate('prime256v1')
       end
 
       def packet_data


### PR DESCRIPTION
Here is a patchset implementing OpenSSL 3.0 support. Sadly, this has NOT feature-parity, nor does it solve all test failures, hence the draft status.

The feature that is missing is in the DH implementation, where I was unable to find a way to implement the enforcing of the size of the private key.

The tests that are still failing are, fittingly, also related to DH, as the group14 DH support is pretty much broken. My knowledge of the problem area is way too superficial to claim to understand what's going on, though.

The patchset starts with a commit from @terceiro, and much of the rest builds upon work from @lucaskanashiro, collected in [this Launchpad bug](https://bugs.launchpad.net/ubuntu/+source/ruby-net-ssh/+bug/1964025)

Closes #843 