### PR TITLE
Channel: drop debugging statement

### DIFF
--- a/lib/net/ssh/connection/channel.rb
+++ b/lib/net/ssh/connection/channel.rb
@@ -686,7 +686,6 @@ module Net
         #
         #   channel.set_remote_env foo: 'bar', baz: 'whale'
         def set_remote_env(env)
-          env.each { |key, value| puts "E:#{key} V:#{value}" }
           env.each { |key, value| self.env(key, value) }
         end
       end


### PR DESCRIPTION
After upgrading to net-ssh 7.0.0, I get several lines like `E:TERM
V:xterm` printed in the terminal when connecting to hosts. I'm assuming
this slipped by mistake in commit 5e79b6687771 ("Fixed integration
test opensshd kill")