### PR TITLE
Raise error when BCryptPbkdf fails

### DIFF
--- a/lib/net/ssh/authentication/ed25519.rb
+++ b/lib/net/ssh/authentication/ed25519.rb
@@ -77,6 +77,7 @@ module Net
               raise "BCryptPbkdf is not implemented for jruby" if RUBY_PLATFORM == "java"
 
               key = BCryptPbkdf::key(password, salt, keylen + ivlen, rounds)
+              raise DecryptError.new("BCyryptPbkdf failed", encrypted_key: true) unless key
             else
               key = '\x00' * (keylen + ivlen)
             end

--- a/test/authentication/test_ed25519.rb
+++ b/test/authentication/test_ed25519.rb
@@ -92,6 +92,12 @@ unless ENV['NET_SSH_NO_ED25519']
         self.assert_equal(pub_key.fingerprint('sha256'), key_fingerprint_sha256_pwd)
       end
 
+      def test_priv_key_no_rounds_should_raise
+        self.assert_raises(Net::SSH::Authentication::ED25519::OpenSSHPrivateKeyLoader::DecryptError) do
+          Net::SSH::Authentication::ED25519::PrivKey.read(private_key_no_rounds, 'pwd')
+        end
+      end
+
       def private_key_pwd
         @pwd_key = <<~EOF
           -----BEGIN OPENSSH PRIVATE KEY-----
@@ -101,6 +107,20 @@ unless ENV['NET_SSH_NO_ED25519']
           46vPiECi6R6OdYGSd7W3fdzUDeyOYCY9ZVIjAzENG+9FsygYzMi6XCuw00OuDFLUp4fL4K
           i/coUIVqouB4TPQAmsCVXiIRVTWQtRG0kWfFaV3qRt/bc22ZCvCT6ZZ1UmtulqqfUhSlKM
           oPcTikV1iWH5Xc+GxRFRRGTN/6HvBf0AKDB1kMXlDhGnBnHGeNH1pk44xG
+          -----END OPENSSH PRIVATE KEY-----
+        EOF
+      end
+
+      def private_key_no_rounds
+        @private_key_no_rounds = <<~EOF
+          -----BEGIN OPENSSH PRIVATE KEY-----
+          b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jYmMAAAAGYmNyeXB0AAAAGAAA
+          ABBxwCvr3V/8pWhC/xvTnGJhAAAAAAAAAAEAAAAzAAAAC3NzaC1lZDI1NTE5
+          AAAAICaHkFaGXqYhUVFcaZ10TPUbkIvmaFXwYRoOS5qE8MciAAAAsNUAhbNQ
+          KwNcOr0eNq3nhtjoyeVyH8hRrpWsiY46vPiECi6R6OdYGSd7W3fdzUDeyOYC
+          Y9ZVIjAzENG+9FsygYzMi6XCuw00OuDFLUp4fL4Ki/coUIVqouB4TPQAmsCV
+          XiIRVTWQtRG0kWfFaV3qRt/bc22ZCvCT6ZZ1UmtulqqfUhSlKMoPcTikV1iW
+          H5Xc+GxRFRRGTN/6HvBf0AKDB1kMXlDhGnBnHGeNH1pk44xG
           -----END OPENSSH PRIVATE KEY-----
         EOF
       end

--- a/test/authentication/test_ed25519.rb
+++ b/test/authentication/test_ed25519.rb
@@ -92,6 +92,12 @@ unless ENV['NET_SSH_NO_ED25519']
         self.assert_equal(pub_key.fingerprint('sha256'), key_fingerprint_sha256_pwd)
       end
 
+      def test_pwd_key_blank
+        self.assert_raises(Net::SSH::Authentication::ED25519::OpenSSHPrivateKeyLoader::DecryptError) do
+          Net::SSH::Authentication::ED25519::PrivKey.read(private_key_no_rounds, '')
+        end
+      end
+
       def test_priv_key_no_rounds_should_raise
         self.assert_raises(Net::SSH::Authentication::ED25519::OpenSSHPrivateKeyLoader::DecryptError) do
           Net::SSH::Authentication::ED25519::PrivKey.read(private_key_no_rounds, 'pwd')


### PR DESCRIPTION
In certain situations, `BCryptPbkdf::key` will return `nil` instead of deriving a key (https://github.com/net-ssh/bcrypt_pbkdf-ruby/blob/6e26b38cc8cfc43212d2fc709e7365cb77063b85/ext/mri/bcrypt_pbkdf.c#L111-L116) but the ED25519 authentication code assumes we'll always get a key, leading to a no method error later on.  This PR detects when we fail to derive a key and raises a `DecryptError`.

The error could possibly be an `ArgumentError` instead, we raise those when the given SSH key contains invalid parameters and we fail to derive a key due to invalid parameters as well.

One test here uses a pathological key that was generated to request zero rounds, the other passes a blank string for the password.  (Our upstream caller defaults a `nil` password to the string `"invalid"`, but allows blank passwords through.)