### PR TITLE
Replace deprecated andrewmcodes/rubocop-linter-action

### DIFF
--- a/.github/workflows/ci-with-docker.yml
+++ b/.github/workflows/ci-with-docker.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build docker images
       run: docker-compose build
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build docker images
       run: docker build -t netssh_openssl3 -f Dockerfile.openssl3 .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         ruby-version: [2.6.6, 2.7.2, 3.0.1, 3.1.1]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby 3.1
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -6,8 +6,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Rubocop Linter Action
-      uses: andrewmcodes/rubocop-linter-action@v3.0.0.rc2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      - name: Set up Ruby 3.1
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
+      - name: Run RuboCop
+        run: bundle exec rubocop


### PR DESCRIPTION
[andrewmcodes/rubocop-linter-action](https://github.com/andrewmcodes-archive/rubocop-linter-action) is deprecated and this PR replaces it.
I also bumped [actions/checkout](https://github.com/actions/checkout) to v3.
