### PR TITLE
Accept pubkey_algorithms option when starting a new connection

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -73,7 +73,7 @@ module Net
       max_win_size send_env set_env use_agent number_of_password_prompts
       append_all_supported_algorithms non_interactive password_prompt
       agent_socket_factory minimum_dh_bits verify_host_key
-      fingerprint_hash check_host_ip
+      fingerprint_hash check_host_ip pubkey_algorithms
     ]
 
     # The standard means of starting a new SSH connection. When used with a
@@ -170,6 +170,11 @@ module Net
     # * :properties => a hash of key/value pairs to add to the new connection's
     #   properties (see Net::SSH::Connection::Session#properties)
     # * :proxy => a proxy instance (see Proxy) to use when connecting
+    # * :pubkey_algorithms => the public key authentication algorithms to use for
+    #   this connection. Valid values are 'rsa-sha2-256-cert-v01@openssh.com',
+    #   'ssh-rsa-cert-v01@openssh.com', 'rsa-sha2-256', 'ssh-rsa'. Currently, this
+    #   option is only used for RSA public key authentication and ignored for other
+    #   types.
     # * :rekey_blocks_limit => the max number of blocks to process before rekeying
     # * :rekey_limit => the max number of bytes to process before rekeying
     # * :rekey_packet_limit => the max number of packets to process before rekeying

--- a/test/start/test_options.rb
+++ b/test/start/test_options.rb
@@ -60,6 +60,13 @@ module NetSSH
       end
     end
 
+    def test_start_should_accept_pubkey_algorithms_option
+      assert_nothing_raised do
+        options = { pubkey_algorithms: %w[ssh-rsa] }
+        Net::SSH.start('localhost', 'testuser', options)
+      end
+    end
+
     def test_start_should_accept_remote_user_option
       assert_nothing_raised do
         options = { remote_user: 'foo' }


### PR DESCRIPTION
a45f54fe1de434605af0b7195dd9a91bccd2cec5 introduced the option to perform RSA client authentication using newer algorithm types, e.g. SHA2.

For me personally, this has broken `net-ssh` with a few servers. We use `net-ssh` in combination with `net-sftp` to communicate with a few obscure SSH implementations that we cannot control. It seems that some of these servers sent a disconnect when trying to authenticate with these newer algorithms, which are tried by default before the old SHA1 algorithm. This might also be the cause of #890, although the servers that we try to communicate with do actually still sent a disconnect packet (resulting in a `Net::SSH::Disconnect` exception), while that does not seem to be the case in #890.

a45f54fe1de434605af0b7195dd9a91bccd2cec5 also introduces the option `pubkey_algorithms` to a `Session` which allows the user of the `Session` to control which algorithms are used for client authentication. However, this option is not available to `Net::SSH#start`, which means that passing in that option results in:
```
ArgumentError: invalid option(s): pubkey_algorithms
```

This PR changes `Net::SSH#start` such that `pubkey_algorithms` is allowed as an option. This allows us to use `sha-rsa` as algorithm for some of the more obscure SSH implementations that we are dealing with, such that we can successfully connect again.