### PR TITLE
Add none support to ProxyJump

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -153,8 +153,10 @@ module Net
 
             # ProxyCommand and ProxyJump override each other so they need to be tracked togeather
             %w[proxyjump proxycommand].each do |proxy_key|
-              if (proxy_value = settings.delete(proxy_key))
-                settings['proxy'] ||= [proxy_key, proxy_value]
+              unless proxy_key == 'proxyjump' and proxy_value == 'none'
+                if (proxy_value = settings.delete(proxy_key))
+                  settings['proxy'] ||= [proxy_key, proxy_value]
+                end
               end
             end
           end

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -154,6 +154,7 @@ module Net
             # ProxyCommand and ProxyJump override each other so they need to be tracked togeather
             %w[proxyjump proxycommand].each do |proxy_key|
               if (proxy_value = settings.delete(proxy_key))
+                # When ProxyJump is set to none explicity disable the jumphost
                 unless proxy_key == 'proxyjump' and proxy_value == 'none'
                   settings['proxy'] ||= [proxy_key, proxy_value]
                 end

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -155,7 +155,6 @@ module Net
             %w[proxyjump proxycommand].each do |proxy_key|
               if (proxy_value = settings.delete(proxy_key))
                 settings['proxy'] ||= [proxy_key, proxy_value]
-                # When ProxyJump is set to none explicity remove the proxy settings
                 if proxy_key == 'proxyjump' and proxy_value == 'none'
                   settings.delete('proxy')
                 end

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -154,9 +154,10 @@ module Net
             # ProxyCommand and ProxyJump override each other so they need to be tracked togeather
             %w[proxyjump proxycommand].each do |proxy_key|
               if (proxy_value = settings.delete(proxy_key))
-                # When ProxyJump is set to none explicity disable the jumphost
-                unless proxy_key == 'proxyjump' and proxy_value == 'none'
-                  settings['proxy'] ||= [proxy_key, proxy_value]
+                settings['proxy'] ||= [proxy_key, proxy_value]
+                # When ProxyJump is set to none explicity remove the proxy settings
+                if proxy_key == 'proxyjump' and proxy_value == 'none'
+                  settings.delete('proxy')
                 end
               end
             end

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -153,8 +153,8 @@ module Net
 
             # ProxyCommand and ProxyJump override each other so they need to be tracked togeather
             %w[proxyjump proxycommand].each do |proxy_key|
-              unless proxy_key == 'proxyjump' and proxy_value == 'none'
-                if (proxy_value = settings.delete(proxy_key))
+              if (proxy_value = settings.delete(proxy_key))
+                unless proxy_key == 'proxyjump' and proxy_value == 'none'
                   settings['proxy'] ||= [proxy_key, proxy_value]
                 end
               end

--- a/lib/net/ssh/proxy/jump.rb
+++ b/lib/net/ssh/proxy/jump.rb
@@ -43,9 +43,10 @@ module Net
           template << " -p #{uri.port}"    if uri.port
           template << " -J #{extra_jumps}" if extra_jumps
           template << " -F #{config}" if config != true && config
-          template << " -W %h:%p "
-          template << uri.host
-
+          unless uri.host == 'none'
+            template << " -W %h:%p "
+            template << uri.host
+          end
           @command_line_template = template
         end
       end

--- a/lib/net/ssh/proxy/jump.rb
+++ b/lib/net/ssh/proxy/jump.rb
@@ -43,6 +43,7 @@ module Net
           template << " -p #{uri.port}"    if uri.port
           template << " -J #{extra_jumps}" if extra_jumps
           template << " -F #{config}" if config != true && config
+          # When ProxyJump is set to none explicity disable the jumphost
           unless uri.host == 'none'
             template << " -W %h:%p "
             template << uri.host

--- a/test/test_proxy_jump.rb
+++ b/test/test_proxy_jump.rb
@@ -10,7 +10,7 @@ class TestProxyJump < NetSSHTest
   def test_proxy_none
      proxy = Net::SSH::Proxy::Jump.new("none")
      proxy.build_proxy_command_equivalent
-     assert_equal "ssh jumphost", proxy.command_line_template
+     assert_equal "ssh", proxy.command_line_template
   end
 
   def test_host

--- a/test/test_proxy_jump.rb
+++ b/test/test_proxy_jump.rb
@@ -7,6 +7,12 @@ class TestProxyJump < NetSSHTest
     assert proxy.is_a?(Net::SSH::Proxy::Command)
   end
 
+  def test_proxy_none
+     proxy = Net::SSH::Proxy::Jump.new("none")
+     proxy.build_proxy_command_equivalent
+     assert_equal "ssh jumphost", proxy.command_line_template
+  end
+
   def test_host
     proxy = Net::SSH::Proxy::Jump.new("jumphost")
     proxy.build_proxy_command_equivalent


### PR DESCRIPTION
As per OpenSSH man docs

```
ProxyJump
             Specifies one or more jump proxies as either
             [user@]host[:port] or an ssh URI.  Multiple proxies may be
             separated by comma characters and will be visited
             sequentially.  Setting this option will cause ssh(1) to
             connect to the target host by first making a ssh(1)
             connection to the specified ProxyJump host and then
             establishing a TCP forwarding to the ultimate target from
             there.  Setting the host to none disables this option
             entirely.
```

This along with the tests should obey the above