### PR TITLE
Terminate proxy command when session is closing

### DIFF
--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -126,6 +126,7 @@ module Net
         # Cleans up (see PacketStream#cleanup) and closes the underlying socket.
         def close
           socket.cleanup
+          Process.kill('TERM', socket.pid) if options[:proxy].is_a?(Net::SSH::Proxy::Command)
           socket.close
         end
 


### PR DESCRIPTION
Under some circumstances, when using SSH ProxyCommand, the process running the proxy might not terminated on session shutdown. This patch is terminating the proxy process when the session was set up using ProxyCommand.