### PR TITLE
chacha20-poly1305 with RbNaCl poly1305

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,12 @@ jobs:
         env:
           NET_SSH_RUN_INTEGRATION_TESTS: 1
           CI: 1
+      - name: Run tests (without rbnacl)
+        run: bundle exec rake test
+        env:
+          BUNDLE_GEMFILE: ./Gemfile.norbnacl
+          NET_SSH_RUN_INTEGRATION_TESTS: 1
+          CI: 1
       - name: Run Tests (without ed25519)
         run: bundle exec rake test
         env:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,8 @@
 
+=== 7.2.0 beta1
+
+  * Support `chacha20-poly1305@opnessh.com` cypher if `RbNaCl` gem is installed [#908]
+
 === 7.1.0
 
   * Accept pubkey_algorithms option when starting a new connection [#891]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,23 @@
+### Development notes
+
+## Building/running ssh server in debug mode
+
+clone the openssh server from `https://github.com/openssh/openssh-portable`
+
+```sh
+brew install openssl
+/usr/local/Cellar/openssl@3/3.1.0/bin/openssl
+
+autoreconf
+./configure --with-ssl-dir=/usr/local/Cellar/openssl@3/3.1.0/ --with-audit=debug --enable-debug CPPFLAGS="-DDEBUG -DPACKET_DEBUG" CFLAGS="-g -O0"
+make
+```
+
+To run server in debug mode:
+```sh
+echo '#' > /tmp/sshd_config
+ssh-keygen -t rsa -f /tmp/ssh_host_rsa_key
+# /Users/boga/Work/OSS/NetSSH/openssh-portable/sshd -p 2222 -D -d -d -d -e -f /tmp/sshd_config
+/Users/boga/Work/OSS/NetSSH/openssh-portable/sshd -p 2222 -D -d -d -d -e -f /tmp/sshd_config -h /tmp/ssh_host_rsa_key
+
+```

--- a/Gemfile.norbnacl
+++ b/Gemfile.norbnacl
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+ENV['NET_SSH_NO_RBNACL'] = 'true'
+# Specify your gem's dependencies in mygem.gemspec
+gemspec
+
+if ENV["CI"] && !Gem.win_platform?
+  gem 'simplecov', require: false, group: :test
+  gem 'codecov', require: false, group: :test
+end
+
+gem 'webrick', group: %i[development test] if RUBY_VERSION.split(".")[0].to_i >= 3

--- a/lib/net/ssh/transport/chacha20_poly1305_cipher.rb
+++ b/lib/net/ssh/transport/chacha20_poly1305_cipher.rb
@@ -8,6 +8,18 @@ module Net
       class ChaCha20Poly1305Cipher
         include Net::SSH::Loggable
 
+        # Implicit HMAC, no need to do anything
+        class ImplicitHMac
+          def etm
+            # TODO: ideally this shouln't be called
+            true
+          end
+
+          def key_length
+            64
+          end
+        end
+
         def initialize(encrypt:, key:)
           @chacha_hdr = OpenSSL::Cipher.new("chacha20")
           key_len = @chacha_hdr.key_len
@@ -86,6 +98,10 @@ module Net
 
         def implicit_mac?
           true
+        end
+
+        def implicit_mac
+          return ImplicitHMac.new
         end
 
         def self.block_size

--- a/lib/net/ssh/transport/chacha20_poly1305_cipher.rb
+++ b/lib/net/ssh/transport/chacha20_poly1305_cipher.rb
@@ -1,0 +1,136 @@
+require 'rbnacl'
+
+module Net
+  module SSH
+    module Transport
+      class ChaCha20Poly1305Cipher
+        def initialize(encrypt:, key:)
+          @chacha_hdr = OpenSSL::Cipher.new("chacha20")
+          key_len = @chacha_hdr.key_len
+          @chacha_main = OpenSSL::Cipher.new("chacha20")
+          @poly = RbNaCl::OneTimeAuths::Poly1305
+          if key.size != key_len * 2
+            error { "chacha20_poly1305: keylength doesn't match" }
+            raise "chacha20_poly1305: keylength doesn't match"
+          end
+          if encrypt
+            @chacha_hdr.encrypt
+            @chacha_main.encrypt
+          else
+            @chacha_hdr.decrypt
+            @chacha_main.decrypt
+          end
+          main_key = key[0...key_len]
+          @chacha_main.key = main_key # k2
+          hdr_key = key[key_len...(2 * key_len)]
+          @chacha_hdr.key = hdr_key # k1
+        end
+
+        def update_cipher_mac(payload, sequence_number)
+          iv_data = [0, 0, 0, sequence_number].pack("NNNN")
+          @chacha_main.iv = iv_data
+          poly_key = @chacha_main.update(([0] * 32).pack('C32'))
+
+          packet_length = payload.size
+          length_data = [packet_length].pack("N")
+          @chacha_hdr.iv = iv_data
+          packet = @chacha_hdr.update(length_data)
+
+          iv_data[0] = 1.chr
+          @chacha_main.iv = iv_data
+          unencrypted_data = payload
+          packet += @chacha_main.update(unencrypted_data)
+
+          packet += @poly.auth(poly_key, packet)
+          return packet
+        end
+
+        def read_length(data, sequence_number)
+          iv_data = [0, 0, 0, sequence_number].pack("NNNN")
+          @chacha_hdr.iv = iv_data
+          length_data = @chacha_hdr.update(data).unpack("N").first
+        end
+
+        def read_and_mac(data, mac, sequence_number)
+          iv_data = [0, 0, 0, sequence_number].pack("NNNN")
+          @chacha_main.iv = iv_data
+          poly_key = @chacha_main.update(([0] * 32).pack('C32'))
+
+          iv_data[0] = 1.chr
+          @chacha_main.iv = iv_data
+          unencrypted_data = @chacha_main.update(data[4..-1])
+          begin
+            ok = @poly.verify(poly_key, mac, data[0..-1])
+            raise Net::SSH::Exception, "corrupted hmac detected #{name}" unless ok
+          rescue RbNaCl::BadAuthenticatorError => e
+            raise Net::SSH::Exception, "corrupted hmac detected #{name}"
+          end
+          return unencrypted_data
+        end
+
+        def mac_length
+          16
+        end
+
+        def self.key_length
+          64
+        end
+
+        def block_size
+          8
+        end
+
+        def name
+          "chacha20-poly1305@openssh.com"
+        end
+
+        class << self
+          # A default block size of 8 is required by the SSH2 protocol.
+          def block_size
+            8
+          end
+
+          # Returns an arbitrary integer.
+          def iv_len
+            4
+          end
+
+          # Does nothing. Returns self.
+          def encrypt
+            self
+          end
+
+          # Does nothing. Returns self.
+          def decrypt
+            self
+          end
+
+          # Passes its single argument through unchanged.
+          def update(text)
+            text
+          end
+
+          # Returns the empty string.
+          def final
+            ""
+          end
+
+          # The name of this cipher, which is "chacha20-poly1305@openssh.com".
+          def name
+            "chacha20-poly1305@openssh.com"
+          end
+
+          # Does nothing. Returns nil.
+          def iv=(v)
+            nil
+          end
+
+          # Does nothing. Returns self.
+          def reset
+            self
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/net/ssh/transport/chacha20_poly1305_cipher_loader.rb
+++ b/lib/net/ssh/transport/chacha20_poly1305_cipher_loader.rb
@@ -1,0 +1,17 @@
+module Net
+  module SSH
+    module Transport
+      # Loads chacha20 poly1305 support which requires optinal dependency rbnacl
+      module ChaCha20Poly1305CipherLoader
+        begin
+          require 'net/ssh/transport/chacha20_poly1305_cipher'
+          LOADED = true
+          ERROR = nil
+        rescue LoadError => e
+          ERROR = e
+          LOADED = false
+        end
+      end
+    end
+  end
+end

--- a/lib/net/ssh/transport/cipher_factory.rb
+++ b/lib/net/ssh/transport/cipher_factory.rb
@@ -2,7 +2,7 @@ require 'openssl'
 require 'net/ssh/transport/ctr.rb'
 require 'net/ssh/transport/key_expander'
 require 'net/ssh/transport/identity_cipher'
-require 'net/ssh/transport/chacha20_poly1305_cipher'
+require 'net/ssh/transport/chacha20_poly1305_cipher_loader'
 
 module Net
   module SSH
@@ -30,9 +30,15 @@ module Net
           'none' => 'none'
         }
 
-        SSH_TO_CLASS = {
-          'chacha20-poly1305@openssh.com' => Net::SSH::Transport::ChaCha20Poly1305Cipher
-        }
+        SSH_TO_CLASS =
+          if Net::SSH::Transport::ChaCha20Poly1305CipherLoader::LOADED
+            {
+              'chacha20-poly1305@openssh.com' => Net::SSH::Transport::ChaCha20Poly1305Cipher
+            }
+          else
+            {
+            }
+          end
 
         # Returns true if the underlying OpenSSL library supports the given cipher,
         # and false otherwise.

--- a/lib/net/ssh/transport/cipher_factory.rb
+++ b/lib/net/ssh/transport/cipher_factory.rb
@@ -3,6 +3,7 @@ require 'net/ssh/transport/ctr.rb'
 require 'net/ssh/transport/key_expander'
 require 'net/ssh/transport/identity_cipher'
 require 'net/ssh/transport/chacha20_poly1305_cipher_loader'
+require 'net/ssh/transport/openssl_cipher_extensions'
 
 module Net
   module SSH
@@ -67,6 +68,7 @@ module Net
 
           cipher.padding = 0
 
+          cipher.extend(Net::SSH::Transport::OpenSSLCipherExtensions)
           if name =~ /-ctr(@openssh.org)?$/
             if ossl_name !~ /-ctr/
               cipher.extend(Net::SSH::Transport::CTR)

--- a/lib/net/ssh/transport/identity_cipher.rb
+++ b/lib/net/ssh/transport/identity_cipher.rb
@@ -11,6 +11,10 @@ module Net
             8
           end
 
+          def key_length
+            0
+          end
+
           # Returns an arbitrary integer.
           def iv_len
             4

--- a/lib/net/ssh/transport/identity_cipher.rb
+++ b/lib/net/ssh/transport/identity_cipher.rb
@@ -54,6 +54,10 @@ module Net
           def reset
             self
           end
+
+          def implicit_mac?
+            false
+          end
         end
       end
     end

--- a/lib/net/ssh/transport/openssl_cipher_extensions.rb
+++ b/lib/net/ssh/transport/openssl_cipher_extensions.rb
@@ -1,5 +1,6 @@
 module Net::SSH::Transport
-  module OpenSSLCipherExtensions 
+  # we add those mehtods to OpenSSL::Chipher instances
+  module OpenSSLCipherExtensions
     def implicit_mac?
       false
     end

--- a/lib/net/ssh/transport/openssl_cipher_extensions.rb
+++ b/lib/net/ssh/transport/openssl_cipher_extensions.rb
@@ -1,0 +1,7 @@
+module Net::SSH::Transport
+  module OpenSSLCipherExtensions 
+    def implicit_mac?
+      false
+    end
+  end
+end

--- a/lib/net/ssh/version.rb
+++ b/lib/net/ssh/version.rb
@@ -49,14 +49,14 @@ module Net
       MAJOR = 7
 
       # The minor component of this version of the Net::SSH library
-      MINOR = 1
+      MINOR = 2
 
       # The tiny component of this version of the Net::SSH library
       TINY  = 0
 
       # The prerelease component of this version of the Net::SSH library
       # nil allowed
-      PRE   = nil
+      PRE   = "beta1"
 
       # The current version of the Net::SSH library as a Version instance
       CURRENT = new(*[MAJOR, MINOR, TINY, PRE].compact)

--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -36,6 +36,8 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency('x25519') unless RUBY_PLATFORM == 'java'
   end
 
+  spec.add_development_dependency('rbnacl', '~> 7.1') unless ENV['NET_SSH_NO_RBNACL']
+
   spec.add_development_dependency "bundler", ">= 1.17"
   spec.add_development_dependency "minitest", "~> 5.10"
   spec.add_development_dependency "mocha", "~> 1.11.2"

--- a/test/integration/common.rb
+++ b/test/integration/common.rb
@@ -127,15 +127,18 @@ module IntegrationTestHelpers
   def start_sshd_7_or_later(port = '2200', config: nil, debug: false)
     pid = nil
     sshpidfile = nil
+    sshlogpath = nil
     if config
       with_lines_as_tempfile(config, debug: debug) do |path, pidpath|
         puts "DEBUG - SSH LOG: #{path}-log.txt config: #{path}" if debug
         raise "A leftover sshd is already running" if port_open?(port)
 
         extra_params = []
-        extra_params = ['-E', "#{path}-log.txt"] if debug
+        sshlogpath = "#{path}-log.txt"
+        extra_params = ['-E', sshlogpath]
         pid = spawn('sudo', '/opt/net-ssh-openssh/sbin/sshd', '-D', '-f', path, '-p', port, *extra_params)
         sshpidfile = pidpath
+
         yield pid, port
       end
     else
@@ -150,6 +153,10 @@ module IntegrationTestHelpers
     # properly, so we just have to hope that -15 (TERM) will manage to bring
     # down sshd.
     if sshpidfile
+      if !File.exist?(sshpidfile) && !sshlogpath.nil?
+        loglines = `sudo tail -n 10 #{sshlogpath}`.split("\n")
+        puts "ERROR: sshpidfile #{sshpidfile} does not exist\n\nSSH server logs:\n#{loglines.join("\n")}"
+      end
       sshpid = File.read(sshpidfile).strip
       system('sudo', 'kill', '-15', sshpid.to_s)
       begin

--- a/test/integration/test_chacha20_poly1305_cipher.rb
+++ b/test/integration/test_chacha20_poly1305_cipher.rb
@@ -30,7 +30,7 @@ class TestChacha20Poly1305Cipher < NetSSHTest
           # We have our own sshd, give it a chance to come up before
           # listening.
           ret = Net::SSH.start("localhost", "net_ssh_1", encryption: "chacha20-poly1305@openssh.com", password: 'foopwd', port: port, user_known_hosts_file: [f.path], verbose: :debug) do |ssh|
-            #assert_equal ssh.transport.algorithms.kex, "curve25519-sha256"
+            # assert_equal ssh.transport.algorithms.kex, "curve25519-sha256"
             ssh.exec! "echo 'foo'"
           end
           assert_equal "foo\n", ret

--- a/test/integration/test_chacha20_poly1305_cipher.rb
+++ b/test/integration/test_chacha20_poly1305_cipher.rb
@@ -1,0 +1,45 @@
+require_relative 'common'
+require 'fileutils'
+require 'tmpdir'
+
+require 'net/ssh'
+
+require 'timeout'
+
+# see Vagrantfile,playbook for env.
+# we're running as net_ssh_1 user password foo
+# and usually connecting to net_ssh_2 user password foo2pwd
+class TestChacha20Poly1305Cipher < NetSSHTest
+  include IntegrationTestHelpers
+
+  def test_with_only_chacha20_cipher
+    config_lines = File.read('/etc/ssh/sshd_config').split("\n")
+    config_lines = config_lines.map do |line|
+      if line =~ /^Ciphers/
+        "##{line}"
+      else
+        line
+      end
+    end
+    config_lines.push("Ciphers chacha20-poly1305@openssh.com")
+
+    Tempfile.open('empty_kh') do |f|
+      f.close
+      start_sshd_7_or_later(config: config_lines, debug: true) do |_pid, port|
+        Timeout.timeout(4) do
+          # We have our own sshd, give it a chance to come up before
+          # listening.
+          ret = Net::SSH.start("localhost", "net_ssh_1", encryption: "chacha20-poly1305@openssh.com", password: 'foopwd', port: port, user_known_hosts_file: [f.path], verbose: :debug) do |ssh|
+            byebug
+            #assert_equal ssh.transport.algorithms.kex, "curve25519-sha256"
+            ssh.exec! "echo 'foo'"
+          end
+          assert_equal "foo\n", ret
+        rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+          sleep 0.25
+          retry
+        end
+      end
+    end
+  end
+end

--- a/test/integration/test_chacha20_poly1305_cipher.rb
+++ b/test/integration/test_chacha20_poly1305_cipher.rb
@@ -30,7 +30,6 @@ class TestChacha20Poly1305Cipher < NetSSHTest
           # We have our own sshd, give it a chance to come up before
           # listening.
           ret = Net::SSH.start("localhost", "net_ssh_1", encryption: "chacha20-poly1305@openssh.com", password: 'foopwd', port: port, user_known_hosts_file: [f.path], verbose: :debug) do |ssh|
-            byebug
             #assert_equal ssh.transport.algorithms.kex, "curve25519-sha256"
             ssh.exec! "echo 'foo'"
           end

--- a/test/integration/test_chacha20_poly1305_cipher.rb
+++ b/test/integration/test_chacha20_poly1305_cipher.rb
@@ -6,37 +6,39 @@ require 'net/ssh'
 
 require 'timeout'
 
-# see Vagrantfile,playbook for env.
-# we're running as net_ssh_1 user password foo
-# and usually connecting to net_ssh_2 user password foo2pwd
-class TestChacha20Poly1305Cipher < NetSSHTest
-  include IntegrationTestHelpers
+unless ENV['NET_SSH_NO_RBNACL']
+  # see Vagrantfile,playbook for env.
+  # we're running as net_ssh_1 user password foo
+  # and usually connecting to net_ssh_2 user password foo2pwd
+  class TestChacha20Poly1305Cipher < NetSSHTest
+    include IntegrationTestHelpers
 
-  def test_with_only_chacha20_cipher
-    config_lines = File.read('/etc/ssh/sshd_config').split("\n")
-    config_lines = config_lines.map do |line|
-      if line =~ /^Ciphers/
-        "##{line}"
-      else
-        line
+    def test_with_only_chacha20_cipher
+      config_lines = File.read('/etc/ssh/sshd_config').split("\n")
+      config_lines = config_lines.map do |line|
+        if line =~ /^Ciphers/
+          "##{line}"
+        else
+          line
+        end
       end
-    end
-    config_lines.push("Ciphers chacha20-poly1305@openssh.com")
+      config_lines.push("Ciphers chacha20-poly1305@openssh.com")
 
-    Tempfile.open('empty_kh') do |f|
-      f.close
-      start_sshd_7_or_later(config: config_lines, debug: true) do |_pid, port|
-        Timeout.timeout(4) do
-          # We have our own sshd, give it a chance to come up before
-          # listening.
-          ret = Net::SSH.start("localhost", "net_ssh_1", encryption: "chacha20-poly1305@openssh.com", password: 'foopwd', port: port, user_known_hosts_file: [f.path], verbose: :debug) do |ssh|
-            # assert_equal ssh.transport.algorithms.kex, "curve25519-sha256"
-            ssh.exec! "echo 'foo'"
+      Tempfile.open('empty_kh') do |f|
+        f.close
+        start_sshd_7_or_later(config: config_lines, debug: true) do |_pid, port|
+          Timeout.timeout(4) do
+            # We have our own sshd, give it a chance to come up before
+            # listening.
+            ret = Net::SSH.start("localhost", "net_ssh_1", encryption: "chacha20-poly1305@openssh.com", password: 'foopwd', port: port, user_known_hosts_file: [f.path], verbose: :debug) do |ssh|
+              # assert_equal ssh.transport.algorithms.kex, "curve25519-sha256"
+              ssh.exec! "echo 'foo'"
+            end
+            assert_equal "foo\n", ret
+          rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+            sleep 0.25
+            retry
           end
-          assert_equal "foo\n", ret
-        rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
-          sleep 0.25
-          retry
         end
       end
     end

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -19,7 +19,7 @@ module Transport
     def test_constructor_should_build_default_list_of_preferred_algorithms
       assert_equal ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa rsa-sha2-256 rsa-sha2-512], algorithms[:host_key]
       assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1], algorithms[:kex]
-      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr], algorithms[:encryption]
+      assert_equal chacha_poly_cipher + %w[aes256-ctr aes192-ctr aes128-ctr], algorithms[:encryption]
       assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1], algorithms[:hmac]
       assert_equal %w[none zlib@openssh.com zlib], algorithms[:compression]
       assert_equal %w[], algorithms[:language]
@@ -28,7 +28,7 @@ module Transport
     def test_constructor_should_build_complete_list_of_algorithms_with_append_all_supported_algorithms
       assert_equal ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa rsa-sha2-256 rsa-sha2-512 ssh-dss], algorithms(append_all_supported_algorithms: true)[:host_key]
       assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1], algorithms(append_all_supported_algorithms: true)[:kex]
-      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(append_all_supported_algorithms: true)[:encryption]
+      assert_equal chacha_poly_cipher + %w[aes256-ctr aes192-ctr aes128-ctr aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(append_all_supported_algorithms: true)[:encryption]
       assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 hmac-md5-96 none], algorithms(append_all_supported_algorithms: true)[:hmac]
       assert_equal %w[none zlib@openssh.com zlib], algorithms(append_all_supported_algorithms: true)[:compression]
       assert_equal %w[], algorithms[:language]
@@ -91,6 +91,22 @@ module Transport
       end
     end
 
+    def chacha_poly_cipher
+      if Net::SSH::Transport::ChaCha20Poly1305CipherLoader::LOADED
+        %w[chacha20-poly1305@openssh.com]
+      else
+        []
+      end
+    end
+
+    def chacha_poly_cipher_str
+      if chacha_poly_cipher.empty?
+        ""
+      else
+        "#{chacha_poly_cipher.join(',')},"
+      end
+    end
+
     def test_constructor_with_preferred_kex_should_put_preferred_kex_first
       assert_equal %w[diffie-hellman-group1-sha1] + x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1],
                    algorithms(kex: "diffie-hellman-group1-sha1", append_all_supported_algorithms: true)[:kex]
@@ -112,27 +128,27 @@ module Transport
     end
 
     def test_constructor_with_preferred_encryption_should_put_preferred_encryption_first
-      assert_equal %w[aes256-cbc aes256-ctr aes192-ctr aes128-ctr aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(encryption: "aes256-cbc", append_all_supported_algorithms: true)[:encryption]
+      assert_equal %w[aes256-cbc] + chacha_poly_cipher + %w[aes256-ctr aes192-ctr aes128-ctr aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(encryption: "aes256-cbc", append_all_supported_algorithms: true)[:encryption]
     end
 
     def test_constructor_with_multiple_preferred_encryption_should_put_all_preferred_encryption_first
-      assert_equal %w[aes256-cbc 3des-cbc idea-cbc aes256-ctr aes192-ctr aes128-ctr aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr none], algorithms(encryption: %w[aes256-cbc 3des-cbc idea-cbc], append_all_supported_algorithms: true)[:encryption]
+      assert_equal %w[aes256-cbc 3des-cbc idea-cbc] + chacha_poly_cipher + %w[aes256-ctr aes192-ctr aes128-ctr aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr none], algorithms(encryption: %w[aes256-cbc 3des-cbc idea-cbc], append_all_supported_algorithms: true)[:encryption]
     end
 
     def test_constructor_with_unrecognized_encryption_should_keep_whats_supported
-      assert_equal %w[aes256-cbc aes256-ctr aes192-ctr aes128-ctr aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(encryption: %w[bogus aes256-cbc], append_all_supported_algorithms: true)[:encryption]
+      assert_equal %w[aes256-cbc] + chacha_poly_cipher + %w[aes256-ctr aes192-ctr aes128-ctr aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(encryption: %w[bogus aes256-cbc], append_all_supported_algorithms: true)[:encryption]
     end
 
     def test_constructor_with_preferred_encryption_supports_additions
       # There's nothing we can really append to the set since the default algos
       # are frozen so this is really just testing that it doesn't do anything
       # unexpected.
-      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none],
+      assert_equal chacha_poly_cipher + %w[aes256-ctr aes192-ctr aes128-ctr aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none],
                    algorithms(encryption: %w[+3des-cbc])[:encryption]
     end
 
     def test_constructor_with_preferred_encryption_supports_removals_with_wildcard
-      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr cast128-ctr],
+      assert_equal chacha_poly_cipher + %w[aes256-ctr aes192-ctr aes128-ctr cast128-ctr],
                    algorithms(encryption: %w[-rijndael-cbc@lysator.liu.se -blowfish-* -3des-* -*-cbc -none])[:encryption]
     end
 
@@ -429,8 +445,8 @@ module Transport
       assert_equal 16, buffer.read(16).length
       assert_equal options[:kex] || (x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1]).join(','), buffer.read_string
       assert_equal options[:host_key] || (ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa rsa-sha2-256 rsa-sha2-512]).join(','), buffer.read_string
-      assert_equal options[:encryption_client] || 'aes256-ctr,aes192-ctr,aes128-ctr', buffer.read_string
-      assert_equal options[:encryption_server] || 'aes256-ctr,aes192-ctr,aes128-ctr', buffer.read_string
+      assert_equal options[:encryption_client] || "#{chacha_poly_cipher_str}aes256-ctr,aes192-ctr,aes128-ctr", buffer.read_string
+      assert_equal options[:encryption_server] || "#{chacha_poly_cipher_str}aes256-ctr,aes192-ctr,aes128-ctr", buffer.read_string
       assert_equal options[:hmac_client] || 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1', buffer.read_string
       assert_equal options[:hmac_server] || 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1', buffer.read_string
       assert_equal options[:compression_client] || 'none,zlib@openssh.com,zlib', buffer.read_string

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -358,12 +358,14 @@ module Transport
 
     def install_mock_algorithm_lookups(options = {})
       params = { shared: shared_secret.to_ssh, hash: session_id, digester: hashing_algorithm }
+      key = expanded_key("C", params)
       Net::SSH::Transport::CipherFactory.expects(:get)
-                                        .with(options[:client_cipher] || "aes256-ctr", params.merge(iv: key("A"), key: key("C"), encrypt: true))
+                                        .with(options[:client_cipher] || "aes256-ctr", params.merge(iv: key("A"), key: key, encrypt: true))
                                         .returns(:client_cipher)
 
+      key = expanded_key("D", params)
       Net::SSH::Transport::CipherFactory.expects(:get)
-                                        .with(options[:server_cipher] || "aes256-ctr", params.merge(iv: key("B"), key: key("D"), decrypt: true))
+                                        .with(options[:server_cipher] || "aes256-ctr", params.merge(iv: key("B"), key: key, decrypt: true))
                                         .returns(:server_cipher)
 
       Net::SSH::Transport::HMAC.expects(:get).with(options[:client_hmac] || "hmac-sha2-256", key("E"), params).returns(:client_hmac)
@@ -380,6 +382,22 @@ module Transport
 
     def hashing_algorithm
       OpenSSL::Digest::SHA1
+    end
+
+    def expand_key(key, need_size, digester, secret, hash)
+      result = key
+      while result.size < need_size
+        new_part = digester.digest(secret + hash + result)
+        result += new_part
+      end
+      return result
+    end
+
+    def expanded_key(salt, params)
+      secret   = params[:shared]
+      hash     = params[:hash]
+      digester = params[:digester]
+      expand_key(key(salt), 32, digester, secret, hash)
     end
 
     def key(salt)

--- a/test/transport/test_cipher_factory.rb
+++ b/test/transport/test_cipher_factory.rb
@@ -248,18 +248,19 @@ module Transport
 
     CHACHA20POLY1305 = ["73cbe4dd0d6495d2048bb1ba5f01f055f6271efaa5e56b9de3586bd116ededab481dc7833d5b6aaa7f7827d49c82185a02f62262d9efae8e6973a4e98251dcbbf2beebfc29c40a75192604729b6f7d412add8fe1a730e4b21c8aa1c73786090bd46bb66121c888b3e628c3f5a9a6a0738f8fcc2a611ef97bd0a665eb565ba0247d"].pack('H*')
 
-    OPTIONS_CHACHAPOLY = { iv: "ABC",
-      key: "abcd"*16,
+    OPTIONS_CHACHAPOLY = {
+      iv: "ABC",
+      key: "abcd" * 16,
       digester: OpenSSL::Digest::MD5,
       shared: "1234567890123456780",
-      hash: '!@#$%#$^%$&^&%#$@$' }
+      hash: '!@#$%#$^%$&^&%#$@$'
+    }
 
     def encrypt_cha_cha_poly(type)
       cipher = factory.get(type, OPTIONS_CHACHAPOLY.merge(encrypt: true))
-      padding = TEXT.length % cipher.block_size
       sequence_number = 1
       result = cipher.update_cipher_mac(TEXT.dup[0...64], sequence_number)
-      result << cipher.update_cipher_mac(TEXT.dup[64...], sequence_number+1)
+      result << cipher.update_cipher_mac(TEXT.dup[64...], sequence_number + 1)
       result
     end
 
@@ -269,14 +270,14 @@ module Transport
       sequence_number = 1
       pos = 0
       2.times do
-        encrypted_len = data[pos...pos+4]
+        encrypted_len = data[pos...pos + 4]
         len = cipher.read_length(encrypted_len, sequence_number)
-        encrypted_data = data[pos+4...pos+4+len]
-        mac_data = data[pos+4+len...pos+(4+len+cipher.mac_length)]
-        result <<  cipher.read_and_mac(encrypted_len+encrypted_data, mac_data.dup, sequence_number)
+        encrypted_data = data[pos + 4...pos + 4 + len]
+        mac_data = data[pos + 4 + len...pos + (4 + len + cipher.mac_length)]
+        result <<  cipher.read_and_mac(encrypted_len + encrypted_data, mac_data.dup, sequence_number)
 
         sequence_number += 1
-        pos = pos+(4+len+cipher.mac_length)
+        pos += 4 + len + cipher.mac_length
       end
       return result.strip
     end
@@ -293,7 +294,6 @@ module Transport
 
       assert_equal TEXT, decrypt_chacha_poly("chacha20-poly1305@openssh.com", CHACHA20POLY1305)
     end
-
 
     private
 

--- a/test/transport/test_packet_stream.rb
+++ b/test/transport/test_packet_stream.rb
@@ -3,6 +3,7 @@
 require_relative '../common'
 require 'timeout'
 require 'net/ssh/transport/packet_stream'
+require 'byebug'
 
 module Transport
   class TestPacketStream < NetSSHTest # rubocop:disable Metrics/ClassLength
@@ -203,6 +204,12 @@ module Transport
     end
 
     PACKETS = {
+      'chacha20-poly1305@openssh.com' => {
+        'implicit' => {
+          false => ["5aa01d1e3eff7c277d19f111a384b229fec8652db616d9350d6ef9f51f2011637b60d406673fffad5a647eba"].pack('H*'),
+          :standard => ["5aa01d263f83e1451c7d981526aa8e03b3ec44857a5dde471d76ba92fd92c9a77911c43ca96a13e37a5b1a346508016793f4a57a"].pack('H*')
+        }
+      },
       "3des-cbc" => {
         "hmac-md5" => {
           false => "\003\352\031\261k\243\200\204\301\203]!\a\306\217\201\a[^\304\317\322\264\265~\361\017\n\205\272, \000\032w\312\t\306\374\271\345p\215\224\373\363\v\261",
@@ -1051,8 +1058,9 @@ module Transport
       PACKETS[key].merge!(val)
     end
 
-    ciphers = Net::SSH::Transport::CipherFactory::SSH_TO_OSSL.keys
-    hmacs = Net::SSH::Transport::HMAC::MAP.keys
+    ciphers = Net::SSH::Transport::CipherFactory::SSH_TO_OSSL.keys + Net::SSH::Transport::CipherFactory::SSH_TO_CLASS.keys
+    hmacs = Net::SSH::Transport::HMAC::MAP.keys + ["implicit"]
+    implicit_ciphers = ["chacha20-poly1305@openssh.com"]
 
     ciphers.each do |cipher_name|
       unless Net::SSH::Transport::CipherFactory.supported?(cipher_name) && PACKETS.key?(cipher_name)
@@ -1069,13 +1077,22 @@ module Transport
 
       hmacs.each do |hmac_name|
         [false, :standard].each do |compress|
+          next if (hmac_name != "implicit" && implicit_ciphers.include?(cipher_name)) ||
+                  (hmac_name == "implicit" && !implicit_ciphers.include?(cipher_name))
+
           cipher_method_name = cipher_name.gsub(/\W/, "_")
           hmac_method_name   = hmac_name.gsub(/\W/, "_")
 
           define_method("test_next_packet_with_#{cipher_method_name}_and_#{hmac_method_name}_and_#{compress}_compression") do
             opts = { shared: "123", hash: "^&*", digester: OpenSSL::Digest::SHA1 }
-            cipher = Net::SSH::Transport::CipherFactory.get(cipher_name, opts.merge(key: "ABC", decrypt: true, iv: "abc"))
-            hmac = Net::SSH::Transport::HMAC.get(hmac_name, "{}|", opts)
+            key = "ABC"
+            cipher = Net::SSH::Transport::CipherFactory.get(cipher_name, opts.merge(key: key, decrypt: true, iv: "abc"))
+            hmac =
+              if cipher.implicit_mac?
+                cipher.implicit_mac
+              else
+                Net::SSH::Transport::HMAC.get(hmac_name, "{}|", opts)
+              end
 
             stream.server.set cipher: cipher, hmac: hmac, compression: compress
             stream.stubs(:recv).returns(PACKETS[cipher_name][hmac_name][compress])
@@ -1091,8 +1108,14 @@ module Transport
 
           define_method("test_enqueue_packet_with_#{cipher_method_name}_and_#{hmac_method_name}_and_#{compress}_compression") do
             opts = { shared: "123", digester: OpenSSL::Digest::SHA1, hash: "^&*" }
-            cipher = Net::SSH::Transport::CipherFactory.get(cipher_name, opts.merge(key: "ABC", iv: "abc", encrypt: true))
-            hmac = Net::SSH::Transport::HMAC.get(hmac_name, "{}|", opts)
+            key = "ABC"
+            cipher = Net::SSH::Transport::CipherFactory.get(cipher_name, opts.merge(key: key, iv: "abc", encrypt: true))
+            hmac =
+              if cipher.implicit_mac?
+                cipher.implicit_mac
+              else
+                Net::SSH::Transport::HMAC.get(hmac_name, "{}|", opts)
+              end
 
             srand(100)
             stream.client.set cipher: cipher, hmac: hmac, compression: compress

--- a/test/transport/test_packet_stream.rb
+++ b/test/transport/test_packet_stream.rb
@@ -3,7 +3,6 @@
 require_relative '../common'
 require 'timeout'
 require 'net/ssh/transport/packet_stream'
-require 'byebug'
 
 module Transport
   class TestPacketStream < NetSSHTest # rubocop:disable Metrics/ClassLength


### PR DESCRIPTION
Fixes: #477 

Implementation of `chacha20-poly1305` chipher.

Since openssl has no separate poly implementation it useless RbNaCl for chacha20 and poly1305 implementation. So this feature is only enabled if you have rbnacl gem installed in your system.


TODO:
- [x] uses poly1305 from rbnacl. We can treat that as an optional dependency and only add chacha20-poly1305 if that's installed
- [x] tests
- [x] refactor internals since chach20-poly1305 has mac embedded I've added a bunch of == "chacha20-poly1305" that needs to be simplified
