### PR TITLE
Add debugging information for algorithm of pubkey in use

### DIFF
--- a/lib/net/ssh/authentication/methods/publickey.rb
+++ b/lib/net/ssh/authentication/methods/publickey.rb
@@ -44,7 +44,7 @@ module Net
           end
 
           def authenticate_with_alg(identity, next_service, username, alg, sig_alg = nil)
-            debug { "trying publickey (#{identity.fingerprint})" }
+            debug { "trying publickey (#{identity.fingerprint}) ALG: #{alg}" }
             send_request(identity, username, next_service, alg)
 
             message = session.next_message

--- a/lib/net/ssh/authentication/methods/publickey.rb
+++ b/lib/net/ssh/authentication/methods/publickey.rb
@@ -44,7 +44,7 @@ module Net
           end
 
           def authenticate_with_alg(identity, next_service, username, alg, sig_alg = nil)
-            debug { "trying publickey (#{identity.fingerprint}) ALG: #{alg}" }
+            debug { "trying publickey (#{identity.fingerprint}) alg #{alg}" }
             send_request(identity, username, next_service, alg)
 
             message = session.next_message


### PR DESCRIPTION
Before this change it was not possible to distinguish between two public key authentications of the same key with different algorithms.

Which makes it difficult to see one attempt was failing with `USERAUTH_FAILURE`.

Similar things mentioned in https://github.com/net-ssh/net-ssh/issues/886