### PR TITLE
Support windows new lines when loading private keys

### DIFF
--- a/lib/net/ssh/authentication/ed25519.rb
+++ b/lib/net/ssh/authentication/ed25519.rb
@@ -41,7 +41,7 @@ module Net
           end
 
           def self.read(datafull, password)
-            datafull = datafull.strip
+            datafull = datafull.strip.encode(universal_newline: true)
             raise ArgumentError.new("Expected #{MBEGIN} at start of private key") unless datafull.start_with?(MBEGIN)
             raise ArgumentError.new("Expected #{MEND} at end of private key") unless datafull.end_with?(MEND)
 

--- a/test/authentication/test_ed25519.rb
+++ b/test/authentication/test_ed25519.rb
@@ -45,6 +45,23 @@ unless ENV['NET_SSH_NO_ED25519']
         self.assert_equal(pub_key.fingerprint('sha256'), key_fingerprint_sha256_no_pwd)
       end
 
+      def test_no_pwd_key_with_windows_newlines
+        pub = Net::SSH::Buffer.new(Base64.decode64(public_key_no_pwd.split(' ')[1]))
+        _type = pub.read_string
+        pub_data = pub.read_string
+        priv = private_key_no_pwd_with_windows_newlines
+
+        pub_key = Net::SSH::Authentication::ED25519::PubKey.new(pub_data)
+        priv_key = Net::SSH::Authentication::ED25519::PrivKey.read(priv, nil)
+
+        shared_secret = "Hello"
+        signed = priv_key.ssh_do_sign(shared_secret)
+        self.assert_equal(true, pub_key.ssh_do_verify(signed, shared_secret))
+        self.assert_equal(priv_key.public_key.fingerprint, pub_key.fingerprint)
+        self.assert_equal(pub_key.fingerprint, key_fingerprint_md5_no_pwd)
+        self.assert_equal(pub_key.fingerprint('sha256'), key_fingerprint_sha256_no_pwd)
+      end
+
       def test_pwd_key
         if defined?(JRUBY_VERSION)
           puts "Skipping password protected ED25519 for JRuby"
@@ -169,6 +186,23 @@ unless ENV['NET_SSH_NO_ED25519']
 
 
         EOF
+      end
+
+      def private_key_no_pwd_with_windows_newlines
+        @anonymous_key = <<~EOF
+          -----BEGIN OPENSSH PRIVATE KEY-----
+          b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+          QyNTUxOQAAACAwdjQYeBiTz1DdZFzzLvG+t913L+eVqCgtzpAYxQG8yQAAAKjlHzLo5R8y
+          6AAAAAtzc2gtZWQyNTUxOQAAACAwdjQYeBiTz1DdZFzzLvG+t913L+eVqCgtzpAYxQG8yQ
+          AAAEBPrD+n4901Y+NYJ2sry+EWRdltGFhMISvp91TywJ//mTB2NBh4GJPPUN1kXPMu8b63
+          3Xcv55WoKC3OkBjFAbzJAAAAIHZhZ3JhbnRAdmFncmFudC11YnVudHUtdHJ1c3R5LTY0AQ
+          IDBAU=
+          -----END OPENSSH PRIVATE KEY-----
+
+
+        EOF
+
+        @anonymous_key.encode(crlf_newline: true)
       end
 
       def public_key_no_pwd


### PR DESCRIPTION
This always converts the new lines to be \n

This fixes https://github.com/net-ssh/net-ssh/issues/921