### PR TITLE
Add support for PubkeyAcceptedAlgorithms option

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -170,11 +170,10 @@ module Net
     # * :properties => a hash of key/value pairs to add to the new connection's
     #   properties (see Net::SSH::Connection::Session#properties)
     # * :proxy => a proxy instance (see Proxy) to use when connecting
-    # * :pubkey_algorithms => the public key authentication algorithms to use for
-    #   this connection. Valid values are 'rsa-sha2-256-cert-v01@openssh.com',
-    #   'ssh-rsa-cert-v01@openssh.com', 'rsa-sha2-256', 'ssh-rsa'. Currently, this
-    #   option is only used for RSA public key authentication and ignored for other
-    #   types.
+    # * :pubkey_algorithms => an array of public key authentication algorithms
+    #   to use for this connection. (Example of valid values:
+    #   'rsa-sha2-256-cert-v01@openssh.com', 'ssh-rsa-cert-v01@openssh.com',
+    #   'rsa-sha2-256', 'ssh-rsa' ).
     # * :rekey_blocks_limit => the max number of blocks to process before rekeying
     # * :rekey_limit => the max number of bytes to process before rekeying
     # * :rekey_packet_limit => the max number of packets to process before rekeying

--- a/lib/net/ssh/authentication/methods/abstract.rb
+++ b/lib/net/ssh/authentication/methods/abstract.rb
@@ -20,9 +20,7 @@ module Net
           # this.
           attr_reader :key_manager
 
-          # So far only affects algorithms used for rsa keys, but can be
-          # extended to other keys, e.g after reading of
-          # PubkeyAcceptedAlgorithms option from ssh_config file is implemented.
+          # public key algorithms to be used
           attr_reader :pubkey_algorithms
 
           # Instantiates a new authentication method.
@@ -31,11 +29,7 @@ module Net
             @key_manager = options[:key_manager]
             @options = options
             @prompt = options[:password_prompt]
-            @pubkey_algorithms = options[:pubkey_algorithms] \
-              || %w[rsa-sha2-256-cert-v01@openssh.com
-                    ssh-rsa-cert-v01@openssh.com
-                    rsa-sha2-256
-                    ssh-rsa]
+            @pubkey_algorithms = session.transport.pubkey_algorithms
             self.logger = session.logger
           end
 

--- a/lib/net/ssh/authentication/methods/publickey.rb
+++ b/lib/net/ssh/authentication/methods/publickey.rb
@@ -15,6 +15,8 @@ module Net
           def authenticate(next_service, username, password = nil)
             return false unless key_manager
 
+            debug { "pubkey_algorithms: #{pubkey_algorithms.join(', ')}" }
+
             key_manager.each_identity do |identity|
               return true if authenticate_with(identity, next_service, username)
             end
@@ -123,7 +125,7 @@ module Net
                   end
                 end
               end
-            elsif authenticate_with_alg(identity, next_service, username, type)
+            elsif pubkey_algorithms.include?(type) && authenticate_with_alg(identity, next_service, username, type)
               # success
               return true
             end

--- a/lib/net/ssh/authentication/session.rb
+++ b/lib/net/ssh/authentication/session.rb
@@ -77,8 +77,7 @@ module Net
             begin
               auth_class = Methods.const_get(name.split(/\W+/).map { |p| p.capitalize }.join)
               method = auth_class.new(self,
-                                      key_manager: key_manager, password_prompt: options[:password_prompt],
-                                      pubkey_algorithms: options[:pubkey_algorithms] || nil)
+                                      key_manager: key_manager, password_prompt: options[:password_prompt])
             rescue NameError
               debug {"Mechanism #{name} was requested, but isn't a known type.  Ignoring it."}
               next

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -31,6 +31,7 @@ module Net
     # * PreferredAuthentications => maps to the :auth_methods option
     # * ProxyCommand => maps to the :proxy option
     # * ProxyJump => maps to the :proxy option
+    # * PubkeyAcceptedAlgorithms => maps to :pubkey_algorithms
     # * PubKeyAuthentication => maps to the :auth_methods option
     # * RekeyLimit => :rekey_limit
     # * StrictHostKeyChecking => :verify_host_key
@@ -232,7 +233,7 @@ module Net
           userknownhostsfile: :user_known_hosts_file,
           checkhostip: :check_host_ip
         }.freeze
-        def translate_config_key(hash, key, value, settings)
+        def translate_config_key(hash, key, value, settings) # rubocop:disable Metrics/AbcSize
           case key
           when :stricthostkeychecking
             hash[:verify_host_key] = translate_verify_host_key(value)
@@ -278,6 +279,8 @@ module Net
             if (proxy = setup_proxy(*value))
               hash[:proxy] = proxy
             end
+          when :pubkeyacceptedalgorithms
+            hash[:pubkey_algorithms] = value.split(/,/)
           when :pubkeyauthentication
             if value
               (hash[:auth_methods] << 'publickey').uniq!

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -48,7 +48,21 @@ module Net
 
           hmac: %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com
                    hmac-sha2-512 hmac-sha2-256
-                   hmac-sha1]
+                   hmac-sha1],
+
+          pubkey_algorithms: %w[ssh-ed25519-cert-v01@openssh.com
+                                ssh-ed25519
+                                ecdsa-sha2-nistp521-cert-v01@openssh.com
+                                ecdsa-sha2-nistp384-cert-v01@openssh.com
+                                ecdsa-sha2-nistp256-cert-v01@openssh.com
+                                ecdsa-sha2-nistp521
+                                ecdsa-sha2-nistp384
+                                ecdsa-sha2-nistp256
+                                rsa-sha2-256-cert-v01@openssh.com
+                                ssh-rsa-cert-v01@openssh.com
+                                rsa-sha2-256
+                                ssh-rsa
+                                ssh-dss]
         }.freeze
 
         if Net::SSH::Transport::ChaCha20Poly1305CipherLoader::LOADED
@@ -93,6 +107,8 @@ module Net
                    hmac-ripemd160 hmac-ripemd160@openssh.com
                    hmac-md5 hmac-md5-96
                    none],
+
+          pubkey_algorithms: DEFAULT_ALGORITHMS[:pubkey_algorithms],
 
           compression: %w[none zlib@openssh.com zlib],
           language: %w[]

--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -98,6 +98,10 @@ module Net
           end
         end
 
+        def pubkey_algorithms
+          algorithms[:pubkey_algorithms]
+        end
+
         # Returns the host (and possibly IP address) in a format compatible with
         # SSH known-host files.
         def host_as_string

--- a/test/authentication/test_session.rb
+++ b/test/authentication/test_session.rb
@@ -168,13 +168,11 @@ module Authentication
     private
 
     def session(options = {})
-      session_opts = options.clone
-      session_opts[:pubkey_algorithms] = %w[ssh-rsa]
-      @session ||= Net::SSH::Authentication::Session.new(transport(options), session_opts)
+      @session ||= Net::SSH::Authentication::Session.new(transport(options), options)
     end
 
     def transport(options = {})
-      @transport ||= MockTransport.new(options)
+      @transport ||= MockTransport.new(options.merge(pubkey_algorithms: %w[ssh-rsa]))
     end
 
     def assert_none_request(packet)

--- a/test/common.rb
+++ b/test/common.rb
@@ -137,6 +137,10 @@ class MockTransport < Net::SSH::Transport::Session
     end
   end
 
+  def pubkey_algorithms
+    options[:pubkey_algorithms] || Net::SSH::Transport::Algorithms::ALGORITHMS[:pubkey_algorithms]
+  end
+
   def closed?
     false
   end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -135,6 +135,7 @@ class TestConfig < NetSSHTest
       'certificatefile' => %w(m n o),
       'passwordauthentication' => true,
       'port' => 1234,
+      'pubkeyacceptedalgorithms' => "p,q,r",
       'pubkeyauthentication' => true,
       'rekeylimit' => 1024,
       'sendenv' => "LC_*",
@@ -171,6 +172,7 @@ class TestConfig < NetSSHTest
     assert_equal true,      net_ssh[:keepalive]
     assert_equal '/dev/null', net_ssh[:user_known_hosts_file]
     assert_equal :never, net_ssh[:verify_host_key]
+    assert_equal %w(p q r), net_ssh[:pubkey_algorithms]
   end
 
   def test_translate_should_turn_on_host_key_verification


### PR DESCRIPTION
Support for configuring `pubkey_algorithms` in configuration file using [PubkeyAcceptedAlgorithms](https://man.openbsd.org/ssh_config#PubkeyAcceptedAlgorithms). Also `pubkey_algorithms` is no longer limited to RSA.

Can be useful to workaround cases, where ssh server (wrongly) disconnects on unknown algorithm, without need to modify program code. (See e.g. https://github.com/net-ssh/net-ssh/issues/890 https://github.com/net-ssh/net-ssh/pull/891 https://github.com/net-ssh/net-ssh/issues/920)

Configuration examples:
```
Host host1
  PubkeyAcceptedAlgorithms -rsa-sha2-256

Host host2
  PubkeyAcceptedAlgorithms ssh-rsa,ssh-dss
```