### PR TITLE
Load keycert directly from string

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -66,7 +66,7 @@ module Net
       auth_methods bind_address compression compression_level config
       encryption forward_agent hmac host_key identity_agent remote_user
       keepalive keepalive_interval keepalive_maxcount kex keys key_data
-      keycerts languages logger paranoid password port proxy
+      keycerts keycert_data languages logger paranoid password port proxy
       rekey_blocks_limit rekey_limit rekey_packet_limit timeout verbose
       known_hosts global_known_hosts_file user_known_hosts_file host_key_alias
       host_name user properties passphrase keys_only max_pkt_size
@@ -146,6 +146,8 @@ module Net
     #   and hostbased authentication
     # * :keycerts => an array of file names of key certificates to use
     #    with publickey authentication
+    # * :keycert_data => an array of strings, which each element of the array
+    #   being a key certificate to use with publickey authentication
     # * :key_data => an array of strings, with each element of the array being
     #   a raw private key in PEM format.
     # * :keys_only => set to +true+ to use only private keys from +keys+ and

--- a/lib/net/ssh/authentication/session.rb
+++ b/lib/net/ssh/authentication/session.rb
@@ -63,6 +63,7 @@ module Net
           key_manager = KeyManager.new(logger, options)
           keys.each { |key| key_manager.add(key) } unless keys.empty?
           keycerts.each { |keycert| key_manager.add_keycert(keycert) } unless keycerts.empty?
+          keycert_data.each { |data| key_manager.add_keycert_data(data) } unless keycert_data.empty?
           key_data.each { |key2| key_manager.add_key_data(key2) } unless key_data.empty?
           default_keys.each { |key| key_manager.add(key) } unless options.key?(:keys) || options.key?(:key_data)
 
@@ -152,6 +153,12 @@ module Net
         # attempting any key-based authentication mechanism.
         def keycerts
           Array(options[:keycerts])
+        end
+
+        # Returns an array of the keycert data that should be used when
+        # attempting any key-based authentication mechanism.
+        def keycert_data
+          Array(options[:keycert_data])
         end
 
         # Returns an array of the key data that should be used when

--- a/test/authentication/test_key_manager.rb
+++ b/test/authentication/test_key_manager.rb
@@ -12,6 +12,10 @@ module Authentication
       assert manager.keycert_files.empty?
     end
 
+    def test_keycert_data_are_empty_by_default
+      assert manager.keycert_data.empty?
+    end
+
     def test_assume_agent_is_available_by_default
       assert manager.use_agent?
     end
@@ -34,6 +38,15 @@ module Authentication
       assert_equal 3, manager.keycert_files.length
       final_files = manager.keycert_files.map { |item| item.split('/').last }
       assert_equal %w[first second third], final_files
+    end
+
+    def test_add_ensures_keycert_data_list_is_unique
+      manager.add_keycert_data "first"
+      manager.add_keycert_data "second"
+      manager.add_keycert_data "third"
+      manager.add_keycert_data "second"
+      assert_equal 3, manager.keycert_data.length
+      assert_equal %w[first second third], manager.keycert_data
     end
 
     def test_use_agent_should_be_set_to_false_if_agent_could_not_be_found
@@ -80,6 +93,20 @@ module Authentication
       assert_equal 1, identities.length
       assert_equal rsa_cert.to_blob, identities.first.to_blob
       assert_equal({ from: :file, file: first }, manager.known_identities[rsa_cert])
+    end
+
+    def test_each_identity_should_use_cert_data
+      manager.stubs(:agent).returns(nil)
+
+      manager.add_key_data(rsa.to_pem)
+      manager.add_keycert_data("ssh-rsa-cert-v01@openssh.com #{Base64.encode64(rsa_cert.to_blob)}")
+
+      identities = []
+      manager.each_identity { |identity| identities << identity }
+
+      assert_equal 2, identities.length
+      assert_equal rsa.to_blob, identities[0].to_blob
+      assert_equal rsa_cert.to_blob, identities[1].to_blob
     end
 
     def test_each_identity_should_load_from_explicit_cert_file_given_matching_key_is_loaded


### PR DESCRIPTION
My application uses short-lived SSH credentials generated on the fly. The user SSH key and a certificate are stored in the DB. Currently to establish the connection I need to use the following code:

```ruby
Tempfile.create do |f|
  f << user.ssh_certificate
  f.flush
  puts Net::SSH.start("my.host", "username", 
                      key_data: [user.ssh_key], keycerts: [f.path], 
                      keys_only: true) { |ssh| ssh.exec!("hostname") }
end
```

This PR adds the missing element - the possibility to pass the key certificate as a string. As a result, the code above can be simplified to:

```ruby
Net::SSH.start("my.host", "username", 
               key_data: [user.ssh_key], keycert_data: [user.ssh_certificate], 
               keys_only: true) { |ssh| ssh.exec!("hostname") }
```