### PR TITLE
Ruby 3.3.0-preview2: Fix error when reading from a closed stream

### DIFF
--- a/lib/net/ssh/buffered_io.rb
+++ b/lib/net/ssh/buffered_io.rb
@@ -61,7 +61,7 @@ module Net
       # if no data was available to be read.
       def fill(n = 8192)
         input.consume!
-        data = recv(n)
+        data = recv(n) || ""
         debug { "read #{data.length} bytes" }
         input.append(data)
         return data.length


### PR DESCRIPTION
Fixes "TypeError, no implicit conversion of nil into String" when reading from a closed stream. This error is related to a change in the behavior of Socket#recv which was introduced in Ruby 3.3.0.

See https://bugs.ruby-lang.org/issues/19899?issue_count=1&issue_position=1