### PR TITLE
Raise specified error when key-files are not readable

### DIFF
--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -261,6 +261,8 @@ module Net
                 identity[:load_from] = :privkey_file
               end
               identity.merge(privkey_file: file)
+            else
+              raise "not readable file: #{file}"
             end
           end.compact
         end


### PR DESCRIPTION
It is useful to raise specified error  when key-files are not readable. (Easy to deconstruct the problem.)

I'm not sure it is the best way to improve.