### PR TITLE
Remove base64 runtime dependency

### DIFF
--- a/lib/net/ssh/authentication/ed25519.rb
+++ b/lib/net/ssh/authentication/ed25519.rb
@@ -46,7 +46,7 @@ module Net
             raise ArgumentError.new("Expected #{MEND} at end of private key") unless datafull.end_with?(MEND)
 
             datab64 = datafull[MBEGIN.size...-MEND.size]
-            data = Base64.decode64(datab64)
+            data = datab64.unpack1("m")
             raise ArgumentError.new("Expected #{MAGIC} at start of decoded private key") unless data.start_with?(MAGIC)
 
             buffer = Net::SSH::Buffer.new(data[MAGIC.size + 1..-1])
@@ -134,7 +134,7 @@ module Net
 
           def to_pem
             # TODO this is not pem
-            ssh_type + Base64.encode64(@verify_key.to_bytes)
+            ssh_type + [@verify_key.to_bytes].pack("m")
           end
         end
 

--- a/lib/net/ssh/authentication/pub_key_fingerprint.rb
+++ b/lib/net/ssh/authentication/pub_key_fingerprint.rb
@@ -32,7 +32,7 @@ module Net
           when 'MD5'
             OpenSSL::Digest.hexdigest(algorithm, blob).scan(/../).join(":")
           when 'SHA256'
-            "SHA256:#{Base64.encode64(OpenSSL::Digest.digest(algorithm, blob)).chomp.gsub(/=+\z/, '')}"
+            "SHA256:#{[OpenSSL::Digest.digest(algorithm, blob)].pack('m').chomp.gsub(/=+\z/, '')}"
           else
             raise OpenSSL::Digest::DigestError, "unsupported ssh key digest #{algorithm}"
           end

--- a/lib/net/ssh/known_hosts.rb
+++ b/lib/net/ssh/known_hosts.rb
@@ -241,11 +241,11 @@ module Net
       def known_host_hash?(hostlist, entries)
         if hostlist.size == 1 && hostlist.first =~ /\A\|1(\|.+){2}\z/
           chunks = hostlist.first.split(/\|/)
-          salt = Base64.decode64(chunks[2])
+          salt = chunks[2].unpack1("m")
           digest = OpenSSL::Digest.new('sha1')
           entries.each do |entry|
             hmac = OpenSSL::HMAC.digest(digest, salt, entry)
-            return true if Base64.encode64(hmac).chomp == chunks[3]
+            return true if [hmac].pack("m").chomp == chunks[3]
           end
         end
         false

--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency('rbnacl', '~> 7.1') unless ENV['NET_SSH_NO_RBNACL']
 
+  spec.add_development_dependency "base64"
   spec.add_development_dependency "bundler", ">= 1.17"
   spec.add_development_dependency "minitest", "~> 5.19"
   spec.add_development_dependency "mocha", "~> 2.1.0"


### PR DESCRIPTION
Starting in Ruby 3.3.0, `require "base64"` triggers a warning:

> base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.

Rather than introduce a new dependency, this commit removes the base64 requirement in favor of using `String#pack` and `String#unpack1` directly. (The base64 gem is just a thin wrapper around these methods.)

I left base64 as a development dependency so that the existing tests could continue to use `Base64`, to confirm there are no regressions due to my changes.

The approach in this PR is similar to that used in several other gems, including:

- https://github.com/lostisland/faraday/pull/1541
- https://github.com/rack/rack/pull/2110
- https://github.com/rubocop/rubocop/pull/12313
- https://github.com/patsplat/plist/pull/63