### PR TITLE
Remove unused base64 requires to fix Ruby 3.3 warning

### DIFF
--- a/lib/net/ssh/authentication/ed25519.rb
+++ b/lib/net/ssh/authentication/ed25519.rb
@@ -3,8 +3,6 @@ gem 'bcrypt_pbkdf', '~> 1.0' unless RUBY_PLATFORM == "java"
 
 require 'ed25519'
 
-require 'base64'
-
 require 'net/ssh/transport/cipher_factory'
 require 'net/ssh/authentication/pub_key_fingerprint'
 require 'bcrypt_pbkdf' unless RUBY_PLATFORM == "java"

--- a/lib/net/ssh/known_hosts.rb
+++ b/lib/net/ssh/known_hosts.rb
@@ -1,6 +1,5 @@
 require 'strscan'
 require 'openssl'
-require 'base64'
 require 'delegate'
 require 'net/ssh/buffer'
 require 'net/ssh/authentication/ed25519_loader'

--- a/test/authentication/test_key_manager.rb
+++ b/test/authentication/test_key_manager.rb
@@ -1,5 +1,6 @@
 require_relative '../common'
 require 'net/ssh/authentication/key_manager'
+require 'base64'
 
 module Authentication
   class TestKeyManager < NetSSHTest

--- a/test/transport/kex/test_curve25519_sha256.rb
+++ b/test/transport/kex/test_curve25519_sha256.rb
@@ -2,6 +2,7 @@ unless ENV['NET_SSH_NO_ED25519']
   require_relative '../../common'
   require 'transport/kex/test_diffie_hellman_group1_sha1'
   require 'net/ssh/transport/kex/curve25519_sha256_loader'
+  require 'base64'
   require 'ostruct'
 
   module Transport

--- a/test/transport/kex/test_diffie_hellman_group1_sha1.rb
+++ b/test/transport/kex/test_diffie_hellman_group1_sha1.rb
@@ -1,5 +1,6 @@
 require_relative '../../common'
 require 'net/ssh/transport/kex/diffie_hellman_group1_sha1'
+require 'base64'
 require 'ostruct'
 
 module Transport

--- a/test/transport/kex/test_ecdh_sha2_nistp256.rb
+++ b/test/transport/kex/test_ecdh_sha2_nistp256.rb
@@ -1,3 +1,4 @@
+require 'base64'
 require 'openssl'
 require 'ostruct'
 require_relative '../../common'


### PR DESCRIPTION
The previous PR #932 refactored the code to no longer use the Base64 module, but forgot to remove the actual `require "base64"` statements. This follow up commit removes those requires to fix the following warning on Ruby 3.3:

> net/ssh/known_hosts.rb:3: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of net-ssh-7.2.2.rc1 to add base64 into its gemspec.