### PR TITLE
Add Ruby 3.3.0 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        ruby-version: [2.6.10, 2.7.7, 3.0.6, 3.1.3, 3.2.1, '3.3.0-rc1']
+        ruby-version: [2.6.10, 2.7.7, 3.0.6, 3.1.3, 3.2.1, 3.3.0]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This PR adds Ruby 3.3.0 to CI matrix