### PR TITLE
Fix syntax for Ruby 2.4.5 so we can backport newer host key algorithms

### DIFF
--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -249,35 +249,37 @@ module Net
         # Load prepared identities. Private key decryption errors ignored if ignore_decryption_errors
         def load_identities(identities, ask_passphrase, ignore_decryption_errors)
           identities.map do |identity|
-            case identity[:load_from]
-            when :pubkey_file
-              key = KeyFactory.load_public_key(identity[:pubkey_file])
-              { public_key: key, from: :file, file: identity[:privkey_file] }
-            when :privkey_file
-              private_key = KeyFactory.load_private_key(
-                identity[:privkey_file], options[:passphrase], ask_passphrase, options[:password_prompt]
-              )
-              key = private_key.send(:public_key)
-              { public_key: key, from: :file, file: identity[:privkey_file], key: private_key }
-            when :data
-              private_key = KeyFactory.load_data_private_key(
-                identity[:data], options[:passphrase], ask_passphrase, "<key in memory>", options[:password_prompt]
-              )
-              key = private_key.send(:public_key)
-              { public_key: key, from: :key_data, data: identity[:data], key: private_key }
-            else
-              identity
-            end
-          rescue OpenSSL::PKey::RSAError, OpenSSL::PKey::DSAError, OpenSSL::PKey::ECError, OpenSSL::PKey::PKeyError, ArgumentError => e
-            if ignore_decryption_errors
-              identity
-            else
+            begin
+              case identity[:load_from]
+              when :pubkey_file
+                key = KeyFactory.load_public_key(identity[:pubkey_file])
+                { public_key: key, from: :file, file: identity[:privkey_file] }
+              when :privkey_file
+                private_key = KeyFactory.load_private_key(
+                  identity[:privkey_file], options[:passphrase], ask_passphrase, options[:password_prompt]
+                )
+                key = private_key.send(:public_key)
+                { public_key: key, from: :file, file: identity[:privkey_file], key: private_key }
+              when :data
+                private_key = KeyFactory.load_data_private_key(
+                  identity[:data], options[:passphrase], ask_passphrase, "<key in memory>", options[:password_prompt]
+                )
+                key = private_key.send(:public_key)
+                { public_key: key, from: :key_data, data: identity[:data], key: private_key }
+              else
+                identity
+              end
+            rescue OpenSSL::PKey::RSAError, OpenSSL::PKey::DSAError, OpenSSL::PKey::ECError, OpenSSL::PKey::PKeyError, ArgumentError => e
+              if ignore_decryption_errors
+                identity
+              else
+                process_identity_loading_error(identity, e)
+                nil
+              end
+            rescue Exception => e
               process_identity_loading_error(identity, e)
               nil
             end
-          rescue Exception => e
-            process_identity_loading_error(identity, e)
-            nil
           end.compact
         end
 

--- a/lib/net/ssh/authentication/session.rb
+++ b/lib/net/ssh/authentication/session.rb
@@ -69,21 +69,23 @@ module Net
           attempted = []
 
           @auth_methods.each do |name|
-            next unless @allowed_auth_methods.include?(name)
-
-            attempted << name
-
-            debug { "trying #{name}" }
             begin
-              auth_class = Methods.const_get(name.split(/\W+/).map { |p| p.capitalize }.join)
-              method = auth_class.new(self, key_manager: key_manager, password_prompt: options[:password_prompt])
-            rescue NameError
-              debug {"Mechanism #{name} was requested, but isn't a known type.  Ignoring it."}
-              next
-            end
+              next unless @allowed_auth_methods.include?(name)
 
-            return true if method.authenticate(next_service, username, password)
-          rescue Net::SSH::Authentication::DisallowedMethod
+              attempted << name
+
+              debug { "trying #{name}" }
+              begin
+                auth_class = Methods.const_get(name.split(/\W+/).map { |p| p.capitalize }.join)
+                method = auth_class.new(self, key_manager: key_manager, password_prompt: options[:password_prompt])
+              rescue NameError
+                debug {"Mechanism #{name} was requested, but isn't a known type.  Ignoring it."}
+                next
+              end
+
+              return true if method.authenticate(next_service, username, password)
+            rescue Net::SSH::Authentication::DisallowedMethod
+            end
           end
 
           error { "all authorization methods failed (tried #{attempted.join(', ')})" }

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -185,10 +185,12 @@ module Net
         # Filters default_files down to the files that are expandable.
         def expandable_default_files
           default_files.keep_if do |path|
-            File.expand_path(path)
-            true
-          rescue ArgumentError
-            false
+            begin
+              File.expand_path(path)
+              true
+            rescue ArgumentError
+              false
+            end
           end
         end
 

--- a/lib/net/ssh/known_hosts.rb
+++ b/lib/net/ssh/known_hosts.rb
@@ -143,9 +143,11 @@ module Net
         # add an entry for the given host and key to the first file it is able
         # to.
         def add(host, key, options={})
-          hostfiles(options, :user).each do |file|
-            KnownHosts.new(file).add(host, key)
-            return
+          begin
+            hostfiles(options, :user).each do |file|
+              KnownHosts.new(file).add(host, key)
+              return
+            end
           rescue SystemCallError
             # try the next hostfile
           end

--- a/lib/net/ssh/version.rb
+++ b/lib/net/ssh/version.rb
@@ -52,11 +52,11 @@ module Net
       MINOR = 3
 
       # The tiny component of this version of the Net::SSH library
-      TINY  = 0
+      TINY  = 1
 
       # The prerelease component of this version of the Net::SSH library
       # nil allowed
-      PRE   = "beta1"
+      PRE   = "ruby-2.4.5-backport"
 
       # The current version of the Net::SSH library as a Version instance
       CURRENT = new(*[MAJOR, MINOR, TINY, PRE].compact)

--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -13,11 +13,11 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Net::SSH: a pure-Ruby implementation of the SSH2 client protocol.}
   spec.description   = %q{Net::SSH: a pure-Ruby implementation of the SSH2 client protocol. It allows you to write programs that invoke and interact with processes on remote servers, via SSH2.}
-  spec.homepage      = "https://github.com/net-ssh/net-ssh"
+  spec.homepage      = "https://github.com/everquoteinc/net-ssh"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.5")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.5")
   spec.metadata = {
-    "changelog_uri" => "https://github.com/net-ssh/net-ssh/blob/master/CHANGES.txt"
+    "changelog_uri" => "https://github.com/everquoteinc/net-ssh/blob/master/CHANGES.txt"
   }
 
   spec.extra_rdoc_files = [


### PR DESCRIPTION
Files changed are best viewed with whitespace changes turned off: https://github.com/net-ssh/net-ssh/pull/939/files?w=1