### PR TITLE
Key manager can load public key as IdentityFile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,8 @@
 .git/
 .gitignore
 
+# Vagrant
+test/integration/.vagrant
+
 docker-compose.yml
 README.md

--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -248,10 +248,14 @@ module Net
         def prepare_identities_from_files
           key_files.map do |file|
             if readable_file?(file)
-              identity = {}
+              identity = {privkey_file: file}
               cert_file = file + "-cert.pub"
               public_key_file = file + ".pub"
-              if readable_file?(cert_file)
+              if file.end_with?(".pub")
+                identity[:load_from] = :pubkey_file
+                identity[:pubkey_file] = file
+                identity.delete(:privkey_file)
+              elsif readable_file?(cert_file)
                 identity[:load_from] = :pubkey_file
                 identity[:pubkey_file] = cert_file
               elsif readable_file?(public_key_file)
@@ -260,7 +264,7 @@ module Net
               else
                 identity[:load_from] = :privkey_file
               end
-              identity.merge(privkey_file: file)
+              identity
             end
           end.compact
         end

--- a/test/authentication/test_key_manager.rb
+++ b/test/authentication/test_key_manager.rb
@@ -96,6 +96,24 @@ module Authentication
       assert_equal({ from: :file, file: first }, manager.known_identities[rsa_cert])
     end
 
+    def test_each_identity_should_load_from_public_key_files
+      manager.stubs(:agent).returns(nil)
+      first = File.expand_path("/first")
+      second = File.expand_path("/second")
+      stub_file_public_key first, rsa
+      stub_file_public_key second, dsa
+
+      identities = []
+      manager.each_identity { |identity| identities << identity }
+
+      assert_equal 2, identities.length
+      assert_equal rsa.to_blob, identities.first.to_blob
+      assert_equal dsa.to_blob, identities.last.to_blob
+
+      assert_equal({ from: :file, file: nil }, manager.known_identities[rsa])
+      assert_equal({ from: :file, file: nil }, manager.known_identities[dsa])
+    end
+
     def test_each_identity_should_use_cert_data
       manager.stubs(:agent).returns(nil)
 
@@ -301,9 +319,7 @@ module Authentication
     end
 
     def stub_file_public_key(name, key)
-      manager.add(name)
-      File.stubs(:file?).with(name).returns(true)
-      File.stubs(:readable?).with(name).returns(true)
+      manager.add(name + ".pub")
       File.stubs(:file?).with(name + ".pub").returns(true)
       File.stubs(:readable?).with(name + ".pub").returns(true)
       File.stubs(:file?).with(name + "-cert.pub").returns(false)


### PR DESCRIPTION
This PR allows setting public keys as `IdentityFile` in SSH config.

> If an SSH client supports setting public keys as `IdentityFile`, you can use that to [match hosts to a specific key in 1Password](https://developer.1password.com/docs/ssh/agent/advanced/#match-key-with-host).

This enables deployments with Capistrano or Kamal using SSH keys stored in 1Password when also pinning the public key to a specific host.

```
Host deploy
  IdentitiesOnly yes
  IdentityFile ~/.ssh/kamal.pub
  IdentityAgent ~/.1password/agent.sock
```