### PR TITLE
Tell any ProxyCommand process to hang up.

### DIFF
--- a/lib/net/ssh/transport/packet_stream.rb
+++ b/lib/net/ssh/transport/packet_stream.rb
@@ -187,6 +187,7 @@ module Net
         def cleanup
           client.cleanup
           server.cleanup
+          Process.kill('HUP', pid) if pid
         end
 
         # If the IO object requires a rekey operation (as indicated by either its

--- a/test/transport/test_packet_stream.rb
+++ b/test/transport/test_packet_stream.rb
@@ -69,6 +69,7 @@ module Transport
     def test_cleanup_should_delegate_cleanup_to_client_and_server_states
       stream.client.expects(:cleanup)
       stream.server.expects(:cleanup)
+      stream.expects(:pid)
       stream.cleanup
     end
 
@@ -1102,6 +1103,7 @@ module Transport
             assert packet[:always_display]
             assert_equal "debugging", packet[:message]
             assert_equal "", packet[:language]
+            stream.stubs(:pid).returns(nil)
             stream.cleanup
           end
 
@@ -1120,6 +1122,7 @@ module Transport
             stream.client.set cipher: cipher, hmac: hmac, compression: compress
             stream.enqueue_packet(ssh_packet)
             assert_equal PACKETS[cipher_name][hmac_name][compress], stream.write_buffer
+            stream.stubs(:pid).returns(nil)
             stream.cleanup
           end
         end


### PR DESCRIPTION
If there's a pid in the IO, send it a SIGHUP on cleanup. This solves a problem when using EC2 Instance Connect Endpoints, which have peculiar semantics and don't handle shutdown across the tunnel the way a regular socket might, leading to zombie sessions on the server and net-ssh hanging on close.

May resolve other similar issues with unconventional proxy configurations. Found by comparison with OpenSSH, which also sends a HUP, so this is behavioural parity¹.

Obviously a variant on #901, which suggests TERM but that proved unreliable for EICE. This change is in a different place with a different signal and I wanted the specific case on record.

------------

_edit to add_: there is an `at_exit` version of this but I don't believe libraries have any business installing `at_exit` handlers². For folks wanting that, I suggest

```
Net::SSH::Proxy::Command.prepend Module.new {
  def open(*)
    super.tap do |io|
      at_exit { Process.kill('HUP', io.pid) rescue nil }
    end
  end
}
```

in your program, Capfile or what have you, and now the command process will be signaled even if the parent exits unexpectedly.

------------

¹ https://github.com/openssh/openssh-portable/blob/1c0d81357921f8d3bab06841df649edac515ae5b/sshconnect.c#L276

² The clearest reason not to do this by default is how it hurts long-lived process. Foremost is memory leakage, since that `at_exit` handler is a closure binding the io object, so both are now forever on the heap, and this builds up with every connection. It also has a bonus nasty surprise failure mode in long-lived processes when pids get reused. Long-running programs would instead need an approach for tracking pids that fits their circumstances.
