### PR TITLE
Refactor Object#=~ as it is deprecated since Ruby 2.6 and unsupported since Ruby 3.2

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -92,7 +92,7 @@ module Net
     #
     #         ch.on_data do |ch, data|
     #           print data
-    #           if data =~ /sudo password: /
+    #           if data.match(/sudo password: /)
     #             ch.send_data("password\n")
     #           end
     #         end

--- a/lib/net/ssh/buffered_io.rb
+++ b/lib/net/ssh/buffered_io.rb
@@ -173,7 +173,7 @@ module Net
           debug { "connection was reset => shallowing exception:#{e}" }
           return 0
         rescue IOError => e
-          if e.message =~ /closed/ then
+          if e.message.match(/closed/) then
             debug { "connection was reset => shallowing exception:#{e}" }
             return 0
           else
@@ -189,7 +189,7 @@ module Net
           debug { "connection was reset => shallowing exception:#{e}" }
           return 0
         rescue IOError => e
-          if e.message =~ /closed/ then
+          if e.message.match(/closed/) then
             debug { "connection was reset => shallowing exception:#{e}" }
             return 0
           else

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -86,9 +86,9 @@ module Net
           block_matched = false
           block_seen = false
           IO.foreach(file) do |line|
-            next if line =~ /^\s*(?:#.*)?$/
+            next if line.match(/^\s*(?:#.*)?$/)
 
-            if line =~ /^\s*(\S+)\s*=(.*)$/
+            if line.match(/^\s*(\S+)\s*=(.*)$/)
               key, value = $1, $2
             else
               key, value = line.strip.split(/\s+/, 2)
@@ -114,12 +114,12 @@ module Net
 
               # Check for negative patterns first. If the host matches, that overrules any other positive match.
               # The host substring code is used to strip out the starting "!" so the regexp will be correct.
-              negative_matched = negative_hosts.any? { |h| host =~ pattern2regex(h[1..-1]) }
+              negative_matched = negative_hosts.any? { |h| host.match(pattern2regex(h[1..-1])) }
 
               if negative_matched
                 block_matched = false
               else
-                block_matched = positive_hosts.any? { |h| host =~ pattern2regex(h) }
+                block_matched = positive_hosts.any? { |h| host.match(pattern2regex(h)) }
               end
 
               block_seen = true
@@ -386,7 +386,7 @@ module Net
               end
               condition_met = false
               exprs.split(",").each do |expr|
-                condition_met = condition_met || host =~ pattern2regex(expr)
+                condition_met = condition_met || host.match(pattern2regex(expr))
               end
               condition_matches << (true && negated ^ condition_met)
               # else
@@ -398,7 +398,9 @@ module Net
         end
 
         def unquote(string)
-          string =~ /^"(.*)"$/ ? Regexp.last_match(1) : string
+          return string if string.nil?
+
+          string.match(/^"(.*)"$/) ? Regexp.last_match(1) : string
         end
       end
     end

--- a/lib/net/ssh/connection/channel.rb
+++ b/lib/net/ssh/connection/channel.rb
@@ -384,7 +384,7 @@ module Net
         #   end
         #
         #   channel.on_process do |ch|
-        #     if channel[:data] =~ /^.*?\n/
+        #     if channel[:data].match(/^.*?\n/)
         #       puts $&
         #       channel[:data] = $'
         #     end
@@ -672,7 +672,7 @@ module Net
           Array(env_variable_patterns).each do |env_variable_pattern|
             matched_variables = ENV.find_all do |env_name, _|
               case env_variable_pattern
-              when Regexp then env_name =~ env_variable_pattern
+              when Regexp then env_name.match(env_variable_pattern)
               when String then env_name == env_variable_pattern
               end
             end

--- a/lib/net/ssh/connection/session.rb
+++ b/lib/net/ssh/connection/session.rb
@@ -180,7 +180,7 @@ module Net
           begin
             process(0)
           rescue IOError => e
-            if e.message =~ /closed/
+            if e.message.match(/closed/)
               debug { "stream was closed after loop => shallowing exception so it will be re-raised in next loop" }
             else
               raise

--- a/lib/net/ssh/known_hosts.rb
+++ b/lib/net/ssh/known_hosts.rb
@@ -229,7 +229,7 @@ module Net
             end.join('.')
           end.join('.*')
 
-          host =~ Regexp.new("\\A#{pattern_regexp}\\z")
+          host.match(Regexp.new("\\A#{pattern_regexp}\\z"))
         else
           host == pattern
         end
@@ -238,7 +238,7 @@ module Net
       # Indicates whether one of the entries matches an hostname that has been
       # stored as a HMAC-SHA1 hash in the known hosts.
       def known_host_hash?(hostlist, entries)
-        if hostlist.size == 1 && hostlist.first =~ /\A\|1(\|.+){2}\z/
+        if hostlist.size == 1 && hostlist.first.match(/\A\|1(\|.+){2}\z/)
           chunks = hostlist.first.split(/\|/)
           salt = chunks[2].unpack1("m")
           digest = OpenSSL::Digest.new('sha1')

--- a/lib/net/ssh/proxy/socks5.rb
+++ b/lib/net/ssh/proxy/socks5.rb
@@ -85,7 +85,7 @@ module Net
 
           packet = [VERSION, CMD_CONNECT, 0].pack("C*")
 
-          if host =~ /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/
+          if host.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/)
             packet << [ATYP_IPV4, $1.to_i, $2.to_i, $3.to_i, $4.to_i].pack("C*")
           else
             packet << [ATYP_DOMAIN, host.length, host].pack("CCA*")

--- a/lib/net/ssh/service/forward.rb
+++ b/lib/net/ssh/service/forward.rb
@@ -67,7 +67,7 @@ module Net
               args.shift
             else
               bind_address = "127.0.0.1"
-              bind_address = args.shift if args.first.is_a?(String) && args.first =~ /\D/
+              bind_address = args.shift if args.first.is_a?(String) && args.first.match(/\D/)
               local_port = args.shift.to_i
               local_port_type = :long
               TCPServer.new(bind_address, local_port)
@@ -331,7 +331,7 @@ module Net
               ch[:socket].send_pending
               ch[:socket].shutdown Socket::SHUT_WR
             rescue IOError => e
-              if e.message =~ /closed/ then
+              if e.message.match(/closed/) then
                 debug { "epipe in on_eof => shallowing exception:#{e}" }
               else
                 raise

--- a/lib/net/ssh/transport/cipher_factory.rb
+++ b/lib/net/ssh/transport/cipher_factory.rb
@@ -77,7 +77,7 @@ module Net
           cipher.padding = 0
 
           cipher.extend(Net::SSH::Transport::OpenSSLCipherExtensions)
-          if name =~ /-ctr(@openssh.org)?$/
+          if name.match(/-ctr(@openssh.org)?$/)
             if ossl_name !~ /-ctr/
               cipher.extend(Net::SSH::Transport::CTR)
             else

--- a/lib/net/ssh/transport/openssl.rb
+++ b/lib/net/ssh/transport/openssl.rb
@@ -191,7 +191,7 @@ module OpenSSL
       alias ssh_signature_type ssh_type
 
       def digester
-        if group.curve_name =~ /^[a-z]+(\d+)\w*\z/
+        if group.curve_name.match(/^[a-z]+(\d+)\w*\z/)
           curve_size = Regexp.last_match(1).to_i
           if curve_size <= 256
             OpenSSL::Digest::SHA256.new

--- a/test/integration/common.rb
+++ b/test/integration/common.rb
@@ -21,7 +21,7 @@ module IntegrationTestHelpers
   end
 
   def sshd_8_or_later?
-    !!(`sshd  -v 2>&1 |grep 'OpenSSH_'` =~ /OpenSSH_8./)
+    !!(`sshd  -v 2>&1 |grep 'OpenSSH_'`.match(/OpenSSH_8./))
   end
 
   def ssh_keygen(file, type = 'rsa', password = '')
@@ -53,7 +53,7 @@ module IntegrationTestHelpers
     puts "/usr/bin/ssh-agent -c" if VERBOSE
     agent_out = `/usr/bin/ssh-agent -c`
     agent_out.split("\n").each do |line|
-      if line =~ /setenv (\S+) (\S+);/
+      if line.match(/setenv (\S+) (\S+);/)
         ENV[$1] = $2
         puts "ENV[#{$1}]=#{$2}" if VERBOSE
       end

--- a/test/integration/test_chacha20_poly1305_cipher.rb
+++ b/test/integration/test_chacha20_poly1305_cipher.rb
@@ -16,7 +16,7 @@ unless ENV['NET_SSH_NO_RBNACL']
     def test_with_only_chacha20_cipher
       config_lines = File.read('/etc/ssh/sshd_config').split("\n")
       config_lines = config_lines.map do |line|
-        if line =~ /^Ciphers/
+        if line.match(/^Ciphers/)
           "##{line}"
         else
           line

--- a/test/integration/test_curve25519sha256.rb
+++ b/test/integration/test_curve25519sha256.rb
@@ -16,7 +16,7 @@ unless ENV['NET_SSH_NO_ED25519']
     def test_with_only_curve_kex
       config_lines = File.read('/etc/ssh/sshd_config').split("\n")
       config_lines = config_lines.map do |line|
-        if line =~ /^KexAlgorithms/
+        if line.match(/^KexAlgorithms/)
           "##{line}"
         else
           line

--- a/test/integration/test_ed25519_pkeys.rb
+++ b/test/integration/test_ed25519_pkeys.rb
@@ -59,7 +59,7 @@ unless ENV['NET_SSH_NO_ED25519']
     def test_with_only_ed25519_host_key
       config_lines = File.read('/etc/ssh/sshd_config').split("\n")
       config_lines = config_lines.map do |line|
-        if (line =~ /^HostKey /) && line !~ /ed25519/
+        if (line.match(/^HostKey /)) && line !~ /ed25519/
           "##{line}"
         else
           line

--- a/test/integration/test_gcm_cipher.rb
+++ b/test/integration/test_gcm_cipher.rb
@@ -17,7 +17,7 @@ class TestGcmCipher < NetSSHTest
   def run_with_only_cipher(cipher)
     config_lines = File.read('/etc/ssh/sshd_config').split("\n")
     config_lines = config_lines.map do |line|
-      if line =~ /^Ciphers/
+      if line.match(/^Ciphers/)
         "##{line}"
       else
         line

--- a/test/integration/test_hmac_etm.rb
+++ b/test/integration/test_hmac_etm.rb
@@ -21,7 +21,7 @@ class TestHMacEtm < NetSSHTest
   def config_with_macs(macs)
     config_lines = File.read('/etc/ssh/sshd_config').split("\n")
     config_lines = config_lines.map do |line|
-      if line =~ /^MACs/
+      if line.match(/^MACs/)
         "##{line}"
       else
         line

--- a/test/start/test_options.rb
+++ b/test/start/test_options.rb
@@ -75,14 +75,14 @@ module NetSSH
     end
 
     def test_constructor_should_reject_options_set_to_nil
-      Kernel.expects(:warn).with { |message| message =~ /remote_user/ }.once
+      Kernel.expects(:warn).with { |message| message.match(/remote_user/) }.once
 
       options = { remote_user: nil }
       Net::SSH.start('localhost', 'testuser', options)
     end
 
     def test_constructor_should_reject_options_set_to_array_of_nil
-      Kernel.expects(:warn).with { |message| message =~ /keys/ }.once
+      Kernel.expects(:warn).with { |message| message.match(/keys/) }.once
 
       ENV.delete('no-such-env-variable')
       Net::SSH.start('localhost', 'testuser', keys: [ENV['no-such-env-variable']])

--- a/test/test_all.rb
+++ b/test/test_all.rb
@@ -5,8 +5,8 @@ Dir.chdir(File.dirname(__FILE__)) do
   test_files -= Dir['integration/test_*.rb'] unless ENV['NET_SSH_RUN_INTEGRATION_TESTS']
   test_files -= Dir['win_integration/test_*.rb'] unless ENV['NET_SSH_RUN_WIN_INTEGRATION_TESTS']
   test_files -= Dir['test/test_*.rb']
-  test_files = test_files.reject { |f| f =~ /^manual/ }
-  test_files = test_files.select { |f| f =~ Regexp.new(ENV['ONLY']) } if ENV['ONLY']
-  test_files = test_files.reject { |f| f =~ Regexp.new(ENV['EXCEPT']) } if ENV['EXCEPT']
+  test_files = test_files.reject { |f| f.match(/^manual/) }
+  test_files = test_files.select { |f| f.match(Regexp.new(ENV['ONLY'])) } if ENV['ONLY']
+  test_files = test_files.reject { |f| f.match(Regexp.new(ENV['EXCEPT'])) } if ENV['EXCEPT']
   test_files.each { |file| require(file) }
 end


### PR DESCRIPTION
As you can read [here](https://rubyreferences.github.io/rubychanges/3.2.html#removals), if we want that net-ssh still work in Ruby >= 3.2, we need to change `=~` by `match` method.

That's a quick PR addressing only that particular breaking change.
`test` Rake task pass, but you might want additional pre-condition that the object calling the method `match`, is not actually a `nil` object, otherwise it will raise an error. Let me know what do you think about it, but I could only see one place where that really was necessary.