### PR TITLE
Update forward comment correcting local vs remote port usage.

### DIFF
--- a/lib/net/ssh/service/forward.rb
+++ b/lib/net/ssh/service/forward.rb
@@ -48,9 +48,9 @@ module Net
         # If three arguments are given, it is as if the local bind address is
         # "127.0.0.1", and the rest are applied as above.
         #
-        # To request an ephemeral port on the remote server, provide 0 (zero) for
-        # the port number. In all cases, this method will return the port that
-        # has been assigned.
+        # To request an ephemeral port on the local server, provide 0 (zero) for
+        # the local port number. In all cases, this method will return the port 
+        # that has been assigned.
         #
         #   ssh.forward.local(1234, "www.capify.org", 80)
         #   assigned_port = ssh.forward.local("0.0.0.0", 0, "www.capify.org", 80)


### PR DESCRIPTION
This is a nit, but without modification it incorrectly describes the operation of the use of a zero port number in local forward calls. This comment is on the `local` forwarding method incorrectly describes the use of a zero port number on the remote server when the code and intention is clearly the zero refers to the port number being assigned to an ephemeral port on the local server.  