### PR TITLE
CI: Fix builds by using "docker compose" rather than the removed docker-compose tool

### DIFF
--- a/.github/workflows/ci-with-docker.yml
+++ b/.github/workflows/ci-with-docker.yml
@@ -12,22 +12,22 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Build docker images
-      run: docker-compose build
+      run: docker compose build
 
     - name: Run ruby 2.6
-      run: docker-compose run ruby-2.6
+      run: docker compose run ruby-2.6
 
     - name: Run ruby 2.7
-      run: docker-compose run ruby-2.7
+      run: docker compose run ruby-2.7
 
     - name: Run ruby 3.0
-      run: docker-compose run ruby-3.0
+      run: docker compose run ruby-3.0
 
     - name: Run ruby 3.1
-      run: docker-compose run ruby-3.1
+      run: docker compose run ruby-3.1
 
   test_openssl3:
     name: Run test suite with docker and openssl 3.0
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Build docker images
       run: docker build -t netssh_openssl3 -f Dockerfile.openssl3 .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   ruby-3.1:
     build:


### PR DESCRIPTION
This PR tries to get to a green build by using a Docker compose that's available in the GitHub Actions runner.

I ran the CI green 🟢  on my GitHub user's CI. Example: https://github.com/olleolleolle/net-ssh/actions/runs/11793676372

## Details

Builds in #960 exited with:

/home/runner/work/_temp/bd3752ef-77e4-46f1-8a33-b2c8277ccc85.sh: line 1: docker-compose: command not found