### PR TITLE
Fix host and ip assignment in HostKeyError

### DIFF
--- a/lib/net/ssh/errors.rb
+++ b/lib/net/ssh/errors.rb
@@ -64,17 +64,17 @@ module Net
 
       # Returns the host name for the remote host, as reported by the socket.
       def host
-        @data && @data[:peer] && @data[:peer][:host]
+        @data && @data[:session]&.host_as_string&.split(",").first
       end
 
       # Returns the port number for the remote host, as reported by the socket.
       def port
-        @data && @data[:peer] && @data[:peer][:port]
+        @data && @data[:session]&.port
       end
 
       # Returns the IP address of the remote host, as reported by the socket.
       def ip
-        @data && @data[:peer] && @data[:peer][:ip]
+        @data && @data[:session]&.host_as_string&.split(",").last
       end
 
       # Returns the key itself, as reported by the remote host.


### PR DESCRIPTION
If the host is a URL then host_as_string will be "fileshare.com,123.123.123.1" which can split into the host as the first and IP as the second part.

If the host is an IP address then host_as_string will be "123.123.123.1" so the host and IP both are assigned the same value