### PR TITLE
Fix parsing of the algorithms from ssh_config

### DIFF
--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -302,22 +302,28 @@ module Net
           list = []
           option = Array(option).compact.uniq
 
-          if option.first && option.first.start_with?('+', '-')
+          if option.first && option.first.start_with?('+', '-', '^')
             list = supported.dup
 
-            appends = option.select { |opt| opt.start_with?('+') }.map { |opt| opt[1..-1] }
-            deletions = option.select { |opt| opt.start_with?('-') }.map { |opt| opt[1..-1] }
+            modifier = option.first[0]
+            options_without_modifier = [option.first[1..-1]] + option[1..-1]
 
-            list.concat(appends)
-
-            deletions.each do |opt|
-              if opt.include?('*')
-                opt_escaped = Regexp.escape(opt)
-                algo_re = /\A#{opt_escaped.gsub('\*', '[A-Za-z\d\-@\.]*')}\z/
-                list.delete_if { |existing_opt| algo_re.match(existing_opt) }
-              else
-                list.delete(opt)
+            case modifier
+            when '+'
+              list.concat(options_without_modifier)
+            when '^'
+              list.unshift(*options_without_modifier)
+            when '-'
+              options_without_modifier.each do |opt|
+                if opt.include?('*')
+                  opt_escaped = Regexp.escape(opt)
+                  algo_re = /\A#{opt_escaped.gsub('\*', '[A-Za-z\d\-@\.]*')}\z/
+                  list.delete_if { |existing_opt| algo_re.match(existing_opt) }
+                else
+                  list.delete(opt)
+                end
               end
+
             end
 
             list.uniq!

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -122,6 +122,11 @@ module Transport
                    algorithms(kex: %w[+diffie-hellman-group1-sha1])[:kex]
     end
 
+    def test_constructor_with_preferred_kex_supports_prepend
+      assert_equal %w[diffie-hellman-group1-sha1] + x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1],
+                   algorithms(kex: %w[^diffie-hellman-group1-sha1])[:kex]
+    end
+
     def test_constructor_with_preferred_kex_supports_removals_with_wildcard
       assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256],
                    algorithms(kex: %w[-diffie-hellman-group*-sha1 -diffie-hellman-group-exchange-sha1])[:kex]
@@ -147,9 +152,14 @@ module Transport
                    algorithms(encryption: %w[+3des-cbc])[:encryption]
     end
 
+    def test_constructor_with_preferred_encryption_supports_prepend
+      assert_equal %w[3des-cbc] + chacha_poly_cipher + %w[aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr idea-cbc none],
+                   algorithms(encryption: %w[^3des-cbc])[:encryption]
+    end
+
     def test_constructor_with_preferred_encryption_supports_removals_with_wildcard
       assert_equal chacha_poly_cipher + %w[aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com cast128-ctr],
-                   algorithms(encryption: %w[-rijndael-cbc@lysator.liu.se -blowfish-* -3des-* -*-cbc -none])[:encryption]
+                   algorithms(encryption: %w[-rijndael-cbc@lysator.liu.se blowfish-* 3des-* *-cbc none])[:encryption]
     end
 
     def test_constructor_with_preferred_hmac_should_put_preferred_hmac_first
@@ -166,13 +176,18 @@ module Transport
     end
 
     def test_constructor_with_preferred_hmac_supports_additions
-      assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 hmac-md5-96],
-                   algorithms(hmac: %w[+hmac-md5-96 -none])[:hmac]
+      assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 hmac-md5-96 none],
+                   algorithms(hmac: %w[+none])[:hmac]
+    end
+
+    def test_constructor_with_preferred_hmac_supports_prepend
+      assert_equal %w[none hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 hmac-md5-96],
+                   algorithms(hmac: %w[^none])[:hmac]
     end
 
     def test_constructor_with_preferred_hmac_supports_removals_with_wildcard
       assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha2-512-96 hmac-sha2-256-96 hmac-ripemd160 hmac-ripemd160@openssh.com],
-                   algorithms(hmac: %w[-hmac-sha1* -hmac-md5* -none])[:hmac]
+                   algorithms(hmac: %w[-hmac-sha1* hmac-md5* none])[:hmac]
     end
 
     def test_constructor_with_preferred_compression_should_put_preferred_compression_first
@@ -200,7 +215,7 @@ module Transport
     end
 
     def test_constructor_with_host_key_removals_with_wildcard
-      assert_equal ed_host_keys + %w[ecdsa-sha2-nistp521-cert-v01@openssh.com ecdsa-sha2-nistp384-cert-v01@openssh.com ecdsa-sha2-nistp256-cert-v01@openssh.com ecdsa-sha2-nistp521 ecdsa-sha2-nistp384 ecdsa-sha2-nistp256], algorithms(host_key: %w[-ssh-rsa* -ssh-dss -rsa-sha*])[:host_key]
+      assert_equal ed_host_keys + %w[ecdsa-sha2-nistp521-cert-v01@openssh.com ecdsa-sha2-nistp384-cert-v01@openssh.com ecdsa-sha2-nistp256-cert-v01@openssh.com ecdsa-sha2-nistp521 ecdsa-sha2-nistp384 ecdsa-sha2-nistp256], algorithms(host_key: %w[-ssh-rsa* ssh-dss rsa-sha*])[:host_key]
     end
 
     def test_initial_state_should_be_neither_pending_nor_initialized


### PR DESCRIPTION
Based on `ssh_config`'s documentation, section `Ciphers` parsing of the algorithm configs work in the following way :

https://www.man7.org/linux/man-pages/man5/ssh_config.5.html

> Specifies the ciphers allowed and their order of preference.  Multiple ciphers must be comma-separated.  If the specified list begins with a ‘+’ character, then the specified
> ciphers will be appended to the default set instead of replacing them.  If the specified list begins with a ‘-’ character, then the specified ciphers (including wildcards) will
> be removed from the default set instead of replacing them.  If the specified list begins with a ‘^’ character, then the specified ciphers will be placed at the head of the
> default set.

This means only the very first character in the list is used to determine operation (append, prepend, remove), afterwards the rest of the config items will remain as-is, without any prefix needed

This change would modify how the config is parsed from the previous version, which expected each item to have it's own prefix. This was likely due to the wrong wording in older versions of the config's documentation that was fixed a while ago: https://github.com/openssh/openssh-portable/commit/4f9d75fbafde83d428e291516f8ce98e6b3a7c4b It also adds support for the `^` prepend operator added here: https://github.com/openssh/openssh-portable/commit/91a2135f32acdd6378476c5bae475a6e7811a6a2

More specifically this fixes an issue with recent version of MacOS (Sequoia 15 and above) where the default ssh config is the following:

```
Ciphers ^aes-128-gcm@openssh.com,aes256-gcm@openssh.conf
```

Current version of the code would drop the first item (as it doesn't understand the prepend operator), then add the second. If the first character would be a `+` then however the first item would have been added, with the second silently ignored, although correct operation would have been to add both to the end of the list.