### PR TITLE
Add logger gem dependency to gemspec

### DIFF
--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "logger"
+
   unless ENV['NET_SSH_NO_ED25519']
     spec.add_development_dependency("bcrypt_pbkdf", "~> 1.0") unless RUBY_PLATFORM == "java"
     spec.add_development_dependency("ed25519", "~> 1.2")


### PR DESCRIPTION
This PR remove warning about incoming changes in ruby 3.5.0:

```
/Users/.../.asdf/installs/ruby/3.4.2/lib/ruby/gems/3.4.0/gems/net-ssh-7.3.0/lib/net/ssh.rb:5:
warning: logger was loaded from the standard library, but will no longer be part of the default
gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
```