### PR TITLE
Skip comments at the end of the line in SSH config

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -88,6 +88,8 @@ module Net
           IO.foreach(file) do |line|
             next if line =~ /^\s*(?:#.*)?$/
 
+            line = line.split('#', 2)[0].strip()
+
             if line =~ /^\s*(\S+)\s*=(.*)$/
               key, value = $1, $2
             else


### PR DESCRIPTION
We faced an issue while using [Kamal](https://kamal-deploy.org), which uses `net-ssh`. Our SSH config file had a comment at the end of the argument definition line like this:

```
  X=Y # this is a comment
```

`net-ssh` wasn't able to read the config correctly and ignore the comment. I know the `man` page of the `ssh_config` states the following:


> The file contains keyword-argument pairs, one per line.  Lines starting with ‘#’ and empty lines are interpreted as comments.

But, this is the first time to face this issue, while using this SSH config file with the same comment for years now.

This PR is splitting the argument definition line on the `#` comment character and takes the first part only. It should fix the issue mentioned above.