### PR TITLE
ProxyJump: "none" means no proxy, not the "none" hostname

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -306,8 +306,10 @@ module Net
               Net::SSH::Proxy::Command.new(value)
             end
           when 'proxyjump'
-            require 'net/ssh/proxy/jump'
-            Net::SSH::Proxy::Jump.new(value)
+            if value !~ /^none$/i
+              require 'net/ssh/proxy/jump'
+              Net::SSH::Proxy::Jump.new(value)
+            end
           end
         end
 


### PR DESCRIPTION
References 851ead5abeaeaa424e05a4e785624a95061dffaf (2010) where this was fixed for ProxyCommand config

Adds test coverage to ensure that later ProxyJump/ProxyCommand config won't override earlier ProxyJump/ProxyCommand none.

Fixes #893.