### PR TITLE
forward: pass session.options[:identity_agent] to Authentication::Agent.connect (follow-up to #645)

### DIFF
--- a/lib/net/ssh/service/forward.rb
+++ b/lib/net/ssh/service/forward.rb
@@ -409,7 +409,7 @@ module Net
           channel[:invisible] = true
 
           begin
-            agent = Authentication::Agent.connect(logger, session.options[:agent_socket_factory])
+            agent = Authentication::Agent.connect(logger, session.options[:agent_socket_factory], session.options[:identity_agent])
             if (agent.socket.is_a? ::IO)
               prepare_client(agent.socket, channel, :agent)
             else


### PR DESCRIPTION
## Summary

Fixed SSH Agent forwarding to properly pass the identity_agent option to Authentication::Agent.connect

## Changes

- Modified lib/net/ssh/service/forward.rb line 409
- Added session.options[:identity_agent] as the third argument to Authentication::Agent.connect call

## Background

This is a follow-up fix to PR #645. When forwarding SSH Agent connections, the custom identity_agent path (e.g., specified via SSH_AUTH_SOCK environment variable or configuration) was not being
passed through, preventing the use of alternative agent sockets.

## Impact

- SSH Agent forwarding will now correctly use custom identity_agent paths when specified
- No breaking changes - defaults to standard behavior when identity_agent is not specified
- Ensures consistency with the authentication flow established in #645