### PR TITLE
CI: Upgrade actions/cache version from 1 to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: 3.8
 
       - name: Cache bundler
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: bundler-cache
         with:
           path: vendor/bundle


### PR DESCRIPTION
We faced this issue at https://github.com/net-ssh/net-ssh/pull/976#issuecomment-3285208244.

Upgrade actions/cache version from 1 to 4 to fix the test failures.

https://github.com/net-ssh/net-ssh/actions/runs/17651350058/job/50226666721?pr=976
> Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v1`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down