### PR TITLE
Allow multiple UserKnownHostsFile entries

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -229,7 +229,6 @@ module Net
           fingerprinthash: :fingerprint_hash,
           port: :port,
           user: :user,
-          userknownhostsfile: :user_known_hosts_file,
           checkhostip: :check_host_ip
         }.freeze
         def translate_config_key(hash, key, value, settings)
@@ -293,6 +292,8 @@ module Net
             hash[:set_env] = Shellwords.split(value.to_s).map { |e| e.split '=', 2 }.to_h
           when :numberofpasswordprompts
             hash[:number_of_password_prompts] = value.to_i
+          when :userknownhostsfile
+            hash[:user_known_hosts_file] = value.split(/\s+/)
           when *TRANSLATE_CONFIG_KEY_RENAME_MAP.keys
             hash[TRANSLATE_CONFIG_KEY_RENAME_MAP[key]] = value
           end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -169,7 +169,7 @@ class TestConfig < NetSSHTest
     assert_equal 2,         net_ssh[:keepalive_interval]
     assert_equal 'MD5',     net_ssh[:fingerprint_hash]
     assert_equal true,      net_ssh[:keepalive]
-    assert_equal '/dev/null', net_ssh[:user_known_hosts_file]
+    assert_equal ['/dev/null'], net_ssh[:user_known_hosts_file]
     assert_equal :never, net_ssh[:verify_host_key]
   end
 
@@ -544,6 +544,28 @@ class TestConfig < NetSSHTest
       proxy.build_proxy_command_equivalent if proxy.is_a? Net::SSH::Proxy::Jump
 
       assert_equal 'ssh -W %h:%p jump2', config[:proxy].command_line_template
+    end
+  end
+
+  def test_single_user_known_hosts_is_array
+    data = '
+      Host *
+        UserKnownHostsFile ~/.special_known_hosts
+    '
+    with_config_from_data data do |f|
+      config = Net::SSH::Config.for("foo", [f])
+      assert_equal ["~/.special_known_hosts"], config[:user_known_hosts_file]
+    end
+  end
+
+  def test_multiple_user_known_hosts
+    data = '
+      Host *
+        UserKnownHostsFile ~/.ssh/known_hosts ~/.special_known_hosts
+    '
+    with_config_from_data data do |f|
+      config = Net::SSH::Config.for("foo", [f])
+      assert_equal ["~/.ssh/known_hosts", "~/.special_known_hosts"], config[:user_known_hosts_file]
     end
   end
 


### PR DESCRIPTION
ssh_config(5) says that the value is “one or more files to use for the user host key database, separated by whitespace.”

Yet right now if it is set as `~/.ssh/known_hosts ~/.ssh/special_known_hosts`, Net:SSH tries to open that file and doesn’t find any host keys.

Some [existing code in `known_hosts.rb`][1] assumes `config[:user_known_hosts_file]` can be an array already.

[1]: https://github.com/net-ssh/net-ssh/blob/07acd8ddaff31bc745335e2006780233c0781c98/lib/net/ssh/known_hosts.rb#L133-L137