### PR TITLE
Add logger & fiddle as runtime dependencies

### DIFF
--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency 'logger', '< 2'
+
   unless ENV['NET_SSH_NO_ED25519']
     spec.add_development_dependency("bcrypt_pbkdf", "~> 1.0") unless RUBY_PLATFORM == "java"
     spec.add_development_dependency("ed25519", "~> 1.2")

--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency 'fiddle', '< 2'
   spec.add_runtime_dependency 'logger', '< 2'
 
   unless ENV['NET_SSH_NO_ED25519']

--- a/net-ssh.gemspec
+++ b/net-ssh.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency("openssl", ">= 3.2.0")
+  spec.add_runtime_dependency 'logger', '< 2'
 
   spec.add_development_dependency("bcrypt_pbkdf", "~> 1.0") unless RUBY_PLATFORM == "java"
 


### PR DESCRIPTION
starting with Ruby 4, logger isn't bundled into Ruby anymore and it needs to be explicitly declared as dependency.