### PR TITLE
Add ability to configure default settings for new connections

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -76,6 +76,25 @@ module Net
       fingerprint_hash check_host_ip pubkey_algorithms
     ]
 
+    class << self
+      # Allows to set the default configuration that will be used
+      # when starting a new SSH connection.
+      #
+      # Example:
+      #
+      #   Net::SSH.default_configuration = {
+      #     timeout: 5,
+      #     keepalive: true
+      #   }
+      #   Net::SSH.start("host", "user") do |ssh|
+      #     # will have a default 5 seconds connection timeout
+      #     # will use keepalive
+      #   end
+      #
+      attr_accessor :default_configuration
+    end
+    self.default_configuration = {}
+
     # The standard means of starting a new SSH connection. When used with a
     # block, the connection will be closed when the block terminates, otherwise
     # the connection will just be returned. The yielded (or returned) value
@@ -223,6 +242,7 @@ module Net
     # If +user+ parameter is nil it defaults to USER from ssh_config, or
     # local username
     def self.start(host, user = nil, options = {}, &block)
+      options.merge!(default_configuration) { |_key, value, _default_value| value }
       invalid_options = options.keys - VALID_OPTIONS
       if invalid_options.any?
         raise ArgumentError, "invalid option(s): #{invalid_options.join(', ')}"

--- a/test/start/test_options.rb
+++ b/test/start/test_options.rb
@@ -115,5 +115,16 @@ module NetSSH
       assert !options[:logger].nil?
       assert !options[:password_prompt].nil?
     end
+
+    def test_constructor_should_consider_default_configuration
+      previous = Net::SSH.default_configuration
+      Net::SSH.default_configuration = { timeout: 5, keepalive: true }
+      options = { keepalive: false }
+      Net::SSH.start('localhost', 'testuser', options)
+      assert_equal 5, options[:timeout]
+      assert_equal false, options[:keepalive]
+    ensure
+      Net::SSH.default_configuration = previous
+    end
   end
 end


### PR DESCRIPTION
We use `net-ssh` via `net-sftp` gem indirectly. We want to be able to set a connection timeout by default for all the connections, but this is currently not possible. You need to either not to forget to always pass it to `Net::SSH.start` options or to monkey patch (the approach we currently use) the gem.

A similar feature was recently was added into the `net-http` gem (https://github.com/ruby/net-http/pull/177).

Example usage:
```ruby
Net::SSH.default_configuration = {
  timeout: 5,
  keepalive: true
}

Net::SSH.start("host", "user") do |ssh|
  # will have a default 5 seconds connection timeout
  # will use keepalive
end
```