### PR TITLE
Verify SSH certificate principals and validity when using @cert-authority

### DIFF
--- a/lib/net/ssh/known_hosts.rb
+++ b/lib/net/ssh/known_hosts.rb
@@ -61,6 +61,20 @@ module Net
             false
           end
         end
+
+        # Returns true if the certificate lists no principals (unrestricted) or
+        # if the given hostname is among the listed principals.
+        def matches_principal?(server_key, hostname)
+          server_key.valid_principals.empty? || server_key.valid_principals.include?(hostname)
+        end
+
+        # Returns true if the certificate's validity window covers the current time.
+        def matches_validity?(server_key)
+          return false if server_key.valid_after && server_key.valid_after > Time.now
+          return false if server_key.valid_before && server_key.valid_before < Time.now
+
+          true
+        end
       end
     end
 
@@ -88,6 +102,17 @@ module Net
 
       def empty?
         @host_keys.empty?
+      end
+
+      # Returns the bare hostname, stripping port and IP portions from the
+      # comma-separated host string used internally.
+      #
+      # Examples:
+      #   "server.example.com"            => "server.example.com"
+      #   "server.example.com,1.2.3.4"    => "server.example.com"
+      #   "[server.example.com]:2222"      => "server.example.com"
+      def hostname
+        @host.split(",").first.gsub(/\[|\]:\d+/, "")
       end
     end
 

--- a/lib/net/ssh/verifiers/always.rb
+++ b/lib/net/ssh/verifiers/always.rb
@@ -19,10 +19,8 @@ module Net
           # We've never seen this host before, so raise an exception.
           process_cache_miss(host_keys, arguments, HostKeyUnknown, "is unknown") if host_keys.empty?
 
-          # If we found any matches, check to see that the key type and
-          # blob also match.
-
-          found = host_keys.any? do |key|
+          # Find the known-hosts entry whose key matches the presented certificate.
+          found_key = host_keys.find do |key|
             if key.respond_to?(:matches_key?)
               key.matches_key?(arguments[:key])
             else
@@ -30,11 +28,31 @@ module Net
             end
           end
 
-          # If a match was found, return true. Otherwise, raise an exception
-          # indicating that the key was not recognized.
-          process_cache_miss(host_keys, arguments, HostKeyMismatch, "does not match") unless found
+          # No matching entry found — key is not recognized.
+          process_cache_miss(host_keys, arguments, HostKeyMismatch, "does not match") unless found_key
 
-          found
+          # For @cert-authority entries: verify the certificate's validity window.
+          if found_key.respond_to?(:matches_validity?)
+            unless found_key.matches_validity?(arguments[:key])
+              cert = arguments[:key]
+              reason = if cert.valid_before && cert.valid_before < Time.now
+                         "Certificate has expired"
+                       else
+                         "Certificate is not yet valid"
+                       end
+              process_cache_miss(host_keys, arguments, HostKeyUnknown, reason)
+            end
+          end
+
+          # For @cert-authority entries: verify the hostname is a listed principal.
+          if found_key.respond_to?(:matches_principal?)
+            unless found_key.matches_principal?(arguments[:key], host_keys.hostname)
+              process_cache_miss(host_keys, arguments, HostKeyUnknown,
+                                 "Certificate invalid: name is not a listed principal")
+            end
+          end
+
+          true
         end
 
         def verify_signature(&block)

--- a/test/test_known_hosts.rb
+++ b/test/test_known_hosts.rb
@@ -177,3 +177,89 @@ class TestKnownHosts < NetSSHTest
     OpenSSL::PKey::RSA.new(asn1.to_der)
   end
 end
+
+class TestCertAuthority < NetSSHTest
+  def make_cert(valid_principals: [], valid_after: nil, valid_before: nil)
+    OpenStruct.new(
+      valid_principals: valid_principals,
+      valid_after: valid_after,
+      valid_before: valid_before
+    )
+  end
+
+  def ca
+    Net::SSH::HostKeyEntries::CertAuthority.new(OpenStruct.new(to_blob: "ca-blob"))
+  end
+
+  # matches_principal?
+
+  def test_matches_principal_when_hostname_is_listed
+    cert = make_cert(valid_principals: ["server.example.com", "other.example.com"])
+    assert ca.matches_principal?(cert, "server.example.com")
+  end
+
+  def test_matches_principal_rejects_unlisted_hostname
+    cert = make_cert(valid_principals: ["server.example.com"])
+    refute ca.matches_principal?(cert, "other.example.com")
+  end
+
+  def test_matches_principal_allows_all_when_principals_empty
+    cert = make_cert(valid_principals: [])
+    assert ca.matches_principal?(cert, "any.host.example.com")
+  end
+
+  # matches_validity?
+
+  def test_matches_validity_for_cert_within_window
+    cert = make_cert(valid_after: Time.now - 3600, valid_before: Time.now + 3600)
+    assert ca.matches_validity?(cert)
+  end
+
+  def test_matches_validity_rejects_expired_cert
+    cert = make_cert(valid_after: Time.now - 7200, valid_before: Time.now - 3600)
+    refute ca.matches_validity?(cert)
+  end
+
+  def test_matches_validity_rejects_not_yet_valid_cert
+    cert = make_cert(valid_after: Time.now + 3600, valid_before: Time.now + 7200)
+    refute ca.matches_validity?(cert)
+  end
+
+  def test_matches_validity_when_valid_after_is_nil
+    cert = make_cert(valid_after: nil, valid_before: Time.now + 3600)
+    assert ca.matches_validity?(cert)
+  end
+
+  def test_matches_validity_when_valid_before_is_nil
+    cert = make_cert(valid_after: Time.now - 3600, valid_before: nil)
+    assert ca.matches_validity?(cert)
+  end
+
+  def test_matches_validity_when_both_bounds_are_nil
+    cert = make_cert(valid_after: nil, valid_before: nil)
+    assert ca.matches_validity?(cert)
+  end
+end
+
+class TestHostKeysHostname < NetSSHTest
+  def make_host_keys(host)
+    Net::SSH::HostKeys.new([], host, nil)
+  end
+
+  def test_hostname_plain
+    assert_equal "server.example.com", make_host_keys("server.example.com").hostname
+  end
+
+  def test_hostname_strips_ip
+    assert_equal "server.example.com", make_host_keys("server.example.com,1.2.3.4").hostname
+  end
+
+  def test_hostname_strips_port
+    assert_equal "server.example.com", make_host_keys("[server.example.com]:2222").hostname
+  end
+
+  def test_hostname_strips_port_and_ip
+    assert_equal "server.example.com",
+                 make_host_keys("[server.example.com]:2222,[1.2.3.4]:2222").hostname
+  end
+end

--- a/test/verifiers/test_always.rb
+++ b/test/verifiers/test_always.rb
@@ -44,3 +44,104 @@ class TestAlways < NetSSHTest
     assert(true, secure_verifier.verify_signature { true })
   end
 end
+
+class TestAlwaysCertAuthority < NetSSHTest
+  # A host_keys collection with a @cert-authority-style entry.
+  # `ca_opts` are forwarded to MockCertAuthorityEntry.
+  def make_session(hostname: "server.example.com", **ca_opts)
+    ca_entry = MockCertAuthorityEntry.new(**ca_opts)
+    host_keys = [ca_entry]
+    host_keys.define_singleton_method(:host) { "server.example.com" }
+    host_keys.define_singleton_method(:hostname) { hostname }
+    OpenStruct.new(host_keys: host_keys)
+  end
+
+  def cert(valid_principals: ["server.example.com"], valid_before: nil, valid_after: nil)
+    OpenStruct.new(
+      valid_principals: valid_principals,
+      valid_before: valid_before,
+      valid_after: valid_after
+    )
+  end
+
+  def test_passes_when_cert_is_valid_and_principal_matches
+    verifier = Net::SSH::Verifiers::Always.new
+    verifier.verify(session: make_session, key: cert)
+  end
+
+  def test_raises_host_key_unknown_when_principal_does_not_match
+    verifier = Net::SSH::Verifiers::Always.new
+    assert_raises(Net::SSH::HostKeyUnknown) do
+      verifier.verify(
+        session: make_session(matches_principal: false),
+        key: cert
+      )
+    end
+  end
+
+  def test_raises_host_key_unknown_when_cert_has_expired
+    verifier = Net::SSH::Verifiers::Always.new
+    expired_cert = cert(valid_before: Time.now - 3600)
+    assert_raises(Net::SSH::HostKeyUnknown) do
+      verifier.verify(
+        session: make_session(matches_validity: false),
+        key: expired_cert
+      )
+    end
+  end
+
+  def test_expired_cert_error_message_says_expired
+    verifier = Net::SSH::Verifiers::Always.new
+    expired_cert = cert(valid_before: Time.now - 3600)
+    error = assert_raises(Net::SSH::HostKeyUnknown) do
+      verifier.verify(
+        session: make_session(matches_validity: false),
+        key: expired_cert
+      )
+    end
+    assert_match(/expired/i, error.message)
+  end
+
+  def test_not_yet_valid_cert_error_message_says_not_yet_valid
+    verifier = Net::SSH::Verifiers::Always.new
+    future_cert = cert(valid_before: Time.now + 7200, valid_after: Time.now + 3600)
+    error = assert_raises(Net::SSH::HostKeyUnknown) do
+      verifier.verify(
+        session: make_session(matches_validity: false),
+        key: future_cert
+      )
+    end
+    assert_match(/not yet valid/i, error.message)
+  end
+
+  def test_raises_host_key_mismatch_when_ca_does_not_match
+    verifier = Net::SSH::Verifiers::Always.new
+    assert_raises(Net::SSH::HostKeyMismatch) do
+      verifier.verify(
+        session: make_session(matches_key: false),
+        key: cert
+      )
+    end
+  end
+
+  # A mock @cert-authority-style host key entry that duck-types CertAuthority.
+  class MockCertAuthorityEntry
+    def initialize(matches_key: true, matches_validity: true, matches_principal: true)
+      @matches_key = matches_key
+      @matches_validity = matches_validity
+      @matches_principal = matches_principal
+    end
+
+    def matches_key?(_server_key)
+      @matches_key
+    end
+
+    def matches_validity?(_server_key)
+      @matches_validity
+    end
+
+    def matches_principal?(_server_key, _hostname)
+      @matches_principal
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When a `known_hosts` file contains a `@cert-authority` entry, Net::SSH verifies that the server's certificate was signed by the trusted CA. But it does **not** verify:

1. That the certificate's `valid_principals` list includes the connecting hostname
2. That the current time falls within the certificate's `valid_after`/`valid_before` window

This means a certificate legitimately issued for `server-a.example.com` can silently authenticate as `server-b.example.com`, and an expired certificate will be accepted.

OpenSSH itself enforces both checks ([`PROTOCOL.certkeys`](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.certkeys)).

## Changes

**`HostKeyEntries::CertAuthority`** — two new methods:
- `matches_principal?(server_key, hostname)` — returns `true` when `valid_principals` is empty (unrestricted) or includes the hostname
- `matches_validity?(server_key)` — returns `true` when `Time.now` is within the certificate's validity window

**`HostKeys`** — new `hostname` method that extracts the bare hostname from the comma-separated/bracketed host string used internally (needed by the principal check).

**`Verifiers::Always`** — after a CA key match, now calls both checks. Changes `any?` to `find` so the matched entry is available for the subsequent checks. Raises `HostKeyUnknown` with a descriptive message on failure:
- `"Certificate has expired"`
- `"Certificate is not yet valid"`
- `"Certificate invalid: name is not a listed principal"`

## Tests

- `TestCertAuthority` — unit tests for `matches_principal?` and `matches_validity?` covering all branches (matching principal, unlisted principal, empty principals, valid window, expired, not yet valid, nil bounds)
- `TestHostKeysHostname` — unit tests for `HostKeys#hostname` with plain hostname, hostname+IP, hostname+port, and hostname+port+IP formats
- `TestAlwaysCertAuthority` — integration tests for the verifier covering all new failure modes and the happy path