### PR TITLE
Handle inline comments in ssh config

### DIFF
--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -399,7 +399,7 @@ module Net
         end
 
         def uncomment(string)
-          string[...string =~ /\s+#.*?$/]
+          string[0...string =~ /\s+#.*?$/]
         end
 
         def unquote(string)

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -98,8 +98,8 @@ module Net
             next if value.nil?
 
             key.downcase!
-            value = unquote(value)
             value = uncomment(value)
+            value = unquote(value)
 
             value = case value.strip
                     when /^\d+$/ then value.to_i

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -99,6 +99,7 @@ module Net
 
             key.downcase!
             value = unquote(value)
+            value = uncomment(value)
 
             value = case value.strip
                     when /^\d+$/ then value.to_i
@@ -395,6 +396,10 @@ module Net
           end
 
           !condition_matches.empty? && condition_matches.all?
+        end
+
+        def uncomment(string)
+          string[...string =~ /\s*#.*?$/]
         end
 
         def unquote(string)

--- a/lib/net/ssh/config.rb
+++ b/lib/net/ssh/config.rb
@@ -399,7 +399,7 @@ module Net
         end
 
         def uncomment(string)
-          string[...string =~ /\s*#.*?$/]
+          string[...string =~ /\s+#.*?$/]
         end
 
         def unquote(string)

--- a/test/configs/comments
+++ b/test/configs/comments
@@ -2,10 +2,10 @@ Host example1 #host comment
   User person #commentcomment
 
 Host example2   #host comment
-  User "person" #commentcomment
+  User "person person" #commentcomment
 
 Host example3 #host comment
-  User person#commentcomment
+  User person#notacomment
 
 Host example4   #host comment
   User=person #commentcomment

--- a/test/configs/comments
+++ b/test/configs/comments
@@ -1,0 +1,2 @@
+Host example #host comment
+  User person#commentcomment

--- a/test/configs/comments
+++ b/test/configs/comments
@@ -1,2 +1,11 @@
-Host example #host comment
+Host example1 #host comment
+  User person #commentcomment
+
+Host example2   #host comment
+  User "person" #commentcomment
+
+Host example3 #host comment
   User person#commentcomment
+
+Host example4   #host comment
+  User=person #commentcomment

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -552,7 +552,7 @@ class TestConfig < NetSSHTest
     assert_equal 'person', config[:user]
 
     config = Net::SSH::Config.for('example2', [config(:comments)])
-    assert_equal 'person', config[:user]
+    assert_equal 'person person', config[:user]
 
     config = Net::SSH::Config.for('example3', [config(:comments)])
     assert_equal 'person#notacomment', config[:user]

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -548,7 +548,16 @@ class TestConfig < NetSSHTest
   end
 
   def test_comments_are_ignored
-    config = Net::SSH::Config.for('example', [config(:comments)])
+    config = Net::SSH::Config.for('example1', [config(:comments)])
+    assert_equal 'person', config[:user]
+
+    config = Net::SSH::Config.for('example2', [config(:comments)])
+    assert_equal 'person', config[:user]
+
+    config = Net::SSH::Config.for('example3', [config(:comments)])
+    assert_equal 'person#notacomment', config[:user]
+
+    config = Net::SSH::Config.for('example4', [config(:comments)])
     assert_equal 'person', config[:user]
   end
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -547,6 +547,11 @@ class TestConfig < NetSSHTest
     end
   end
 
+  def test_comments_are_ignored
+    config = Net::SSH::Config.for('example', [config(:comments)])
+    assert_equal 'person', config[:user]
+  end
+
   private
 
   def with_home_env(value, &block)


### PR DESCRIPTION
I'm kinda confused how it was working before: I could swear I had inline comments in my config and it worked fine. But I don't have a record of that (could have been a lot of versions ago), and it isn't working now.

The issue is simply that a config like
```
Host foo
  SettingA 1    # this is set because of X
  SettingB xyz  # this is set because of Y
```
results in `config[:setting_b]` being `xyz  # this is set because of Y` instead of `xyz`.

I think that I've set everything up correctly, but first time contribution, so lmk if I need to do anything else.