### PR TITLE
fix: use explicitly unfrozen strings in ED25519 loader

### DIFF
--- a/lib/net/ssh/authentication/ed25519_loader.rb
+++ b/lib/net/ssh/authentication/ed25519_loader.rb
@@ -14,13 +14,13 @@ module Net
         end
 
         def self.raiseUnlessLoaded(message)
-          description = ERROR.is_a?(LoadError) ? dependenciesRequiredForED25519 : ''
+          description = ERROR.is_a?(LoadError) ? dependenciesRequiredForED25519 : +''
           description << "#{ERROR.class} : \"#{ERROR.message}\"\n" if ERROR
           raise NotImplementedError, "#{message}\n#{description}" unless LOADED
         end
 
         def self.dependenciesRequiredForED25519
-          result = "net-ssh requires the following gems for ed25519 support:\n"
+          result = +"net-ssh requires the following gems for ed25519 support:\n"
           result << " * ed25519 (>= 1.2, < 2.0)\n"
           result << " * bcrypt_pbkdf (>= 1.0, < 2.0)\n" unless RUBY_PLATFORM == "java"
           result << "See https://github.com/net-ssh/net-ssh/issues/565 for more information\n"


### PR DESCRIPTION
This addresses a frozen string warning:

```
net-ssh-7.3.2/lib/net/ssh/authentication/ed25519_loader.rb:24: warning: literal string will be frozen in the future
```

I'm just getting this for `self.dependenciesRequiredForED255191`, but I'm pretty sure `self.raiseUnlessLoaded` would technically generate this too if its falsey path is ever triggered so I've changed that too since the downsides are really small