### PR TITLE
Stop mutating ENV['HOME'] at require time

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -1,7 +1,3 @@
-# Make sure HOME is set, regardless of OS, so that File.expand_path works
-# as expected with tilde characters.
-ENV['HOME'] ||= ENV['HOMEPATH'] ? "#{ENV['HOMEDRIVE']}#{ENV['HOMEPATH']}" : Dir.pwd
-
 require 'logger'
 require 'etc'
 require 'shellwords'

--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -72,11 +72,15 @@ module Net
         def add(key_file)
           key_files.push(File.expand_path(key_file)).uniq!
           self
+        rescue ArgumentError
+          self
         end
 
         # Add the given keycert_file to the list of keycert files that will be used.
         def add_keycert(keycert_file)
           keycert_files.push(File.expand_path(keycert_file)).uniq!
+          self
+        rescue ArgumentError
           self
         end
 

--- a/lib/net/ssh/known_hosts.rb
+++ b/lib/net/ssh/known_hosts.rb
@@ -160,6 +160,8 @@ module Net
       # file. The path is expanded file File.expand_path.
       def initialize(source)
         @source = File.expand_path(source)
+      rescue ArgumentError
+        @source = source
       end
 
       # Returns an array of all keys that are known to be associatd with the


### PR DESCRIPTION
Fixes #996

Remove the eager `ENV['HOME']` mutation from `lib/net/ssh.rb` line 3. Ruby 2.6+ (net-ssh's minimum) resolves `~` paths via the OS passwd database when HOME is unset, making this unnecessary. The few `File.expand_path` call sites that handle `~` default paths now rescue `ArgumentError` to degrade gracefully.