### PR TITLE
Ignore received ext info packet

### DIFF
--- a/lib/net/ssh/authentication/session.rb
+++ b/lib/net/ssh/authentication/session.rb
@@ -119,6 +119,9 @@ module Net
               transport.hint :authenticated
               return packet
 
+            when EXT_INFO
+              info { 'Ignoring SSH_MSG_EXT_INFO packet' }
+
             else
               raise Net::SSH::Exception, "unexpected message #{packet.type} (#{packet})"
             end

--- a/lib/net/ssh/transport/constants.rb
+++ b/lib/net/ssh/transport/constants.rb
@@ -12,6 +12,7 @@ module Net
         DEBUG                     = 4
         SERVICE_REQUEST           = 5
         SERVICE_ACCEPT            = 6
+        EXT_INFO                  = 7
 
         #--
         # Algorithm negotiation messages

--- a/test/authentication/test_session.rb
+++ b/test/authentication/test_session.rb
@@ -92,6 +92,11 @@ module Authentication
       assert_equal SERVICE_ACCEPT, session.expect_message(SERVICE_ACCEPT).type
     end
 
+    def test_next_message_should_silently_handle_EXT_INFO
+      transport.return(EXT_INFO)
+      assert_equal EXT_INFO, session.next_message.type
+    end
+
     def test_uses_some_default_keys_if_none_are_provided
       File.stubs(:file?).returns(false)
 


### PR DESCRIPTION
Following this issue #955, I am creating this merge request because this is going to become increasingly problematic.

The client does not offer "ext-info-c" and is therefore not handled. So, we can simply ignore SSH_MSG_EXT_INFO.
cf. https://www.rfc-editor.org/rfc/rfc8308.html