### PR TITLE
Port forwarding buffers entire stream in memory (no backpressure) on slow consumer

### DIFF
--- a/lib/net/ssh/buffered_io.rb
+++ b/lib/net/ssh/buffered_io.rb
@@ -129,6 +129,12 @@ module Net
         input.to_s
       end
 
+      # Returns the number of bytes currently queued in the output buffer
+      # but not yet written to the underlying IO. Used for backpressure.
+      def pending_write_bytes
+        output.length
+      end
+
       private
 
       #--

--- a/lib/net/ssh/connection/channel.rb
+++ b/lib/net/ssh/connection/channel.rb
@@ -642,6 +642,47 @@ module Net
           connection.loop { !remote_id }
         end
 
+        public # internal use only; public so the Forward service can drive backpressure
+
+        # High/low-water marks (bytes) for a forwarded channel's downstream
+        # socket buffer. Configurable via the connection option
+        # :forward_max_buffered_bytes (defaults to 4 MiB).
+        def forward_high_water
+          (connection.options[:forward_max_buffered_bytes] || (4 * 1024 * 1024)).to_i
+        end
+
+        def forward_low_water
+          forward_high_water / 4
+        end
+
+        # True when this channel forwards to a local socket whose pending output
+        # exceeds the high-water mark.
+        def downstream_congested?
+          sock = self[:socket]
+          sock.respond_to?(:pending_write_bytes) &&
+            sock.pending_write_bytes > forward_high_water
+        end
+
+        # Re-advertise window once a previously congested downstream socket has
+        # drained below the low-water mark. Called from the forwarder's
+        # on_process hook every event-loop tick. Necessary because once the peer
+        # has consumed the granted window no further data arrives to re-trigger
+        # #update_local_window_size.
+        def resume_local_window_size
+          return unless remote_id
+          sock = self[:socket]
+          return unless sock.respond_to?(:pending_write_bytes)
+          return if sock.pending_write_bytes > forward_low_water
+          return unless local_window_size < local_maximum_window_size / 2
+
+          connection.send_message(
+            Buffer.from(:byte, CHANNEL_WINDOW_ADJUST, :long, remote_id, :long, LOCAL_WINDOW_SIZE_INCREMENT)
+          )
+          @local_window_size += LOCAL_WINDOW_SIZE_INCREMENT
+        end
+
+        private
+
         LOCAL_WINDOW_SIZE_INCREMENT = 0x20000
         GOOD_LOCAL_MAXIUMUM_WINDOW_SIZE = 10 * LOCAL_WINDOW_SIZE_INCREMENT
 
@@ -651,6 +692,15 @@ module Net
         # server telling it that the window size has grown.
         def update_local_window_size(size)
           @local_window_size -= size
+
+          # Backpressure (channel -> local socket direction): if this channel is
+          # forwarding to a local socket whose outbound buffer is already backed
+          # up, do NOT advertise more window. The peer keeps sending only until
+          # the window we already granted is exhausted, then stalls, instead of
+          # flooding us into unbounded memory. #resume_local_window_size re-opens
+          # the window once the socket drains.
+          return if downstream_congested?
+
           if local_window_size < local_maximum_window_size / 2
             connection.send_message(
               Buffer.from(:byte, CHANNEL_WINDOW_ADJUST, :long, remote_id, :long, LOCAL_WINDOW_SIZE_INCREMENT)

--- a/lib/net/ssh/service/forward.rb
+++ b/lib/net/ssh/service/forward.rb
@@ -350,13 +350,31 @@ module Net
           end
 
           channel.on_process do |ch|
-            if ch[:socket].closed?
+            socket = ch[:socket]
+            if socket.closed?
               ch.info { "#{type} forwarded connection closed" }
               ch.close
-            elsif ch[:socket].available > 0
-              data = ch[:socket].read_available(8192)
-              ch.debug { "read #{data.length} bytes from client, sending over #{type} forwarded connection" }
-              ch.send_data(data)
+            else
+              # Backpressure, channel -> socket: re-open the receive window once
+              # the local socket has drained below the low-water mark.
+              ch.resume_local_window_size
+
+              # Backpressure, socket -> channel: stop pulling from the local
+              # socket while the channel's outgoing buffer is over the high-water
+              # mark. Pausing the listener lets the kernel TCP buffer fill so the
+              # local writer blocks, instead of buffering the whole stream in the
+              # Ruby heap. on_process keeps firing (it is driven per-channel, not
+              # per-socket), so we resume as soon as the buffer drains.
+              if ch.output.length >= ch.forward_high_water
+                session.stop_listening_to(socket) if session.listeners.key?(socket)
+              else
+                session.listen_to(socket) unless session.listeners.key?(socket)
+                if socket.available > 0 && ch.output.length < ch.forward_high_water
+                  data = socket.read_available(8192)
+                  ch.debug { "read #{data.length} bytes from client, sending over #{type} forwarded connection" }
+                  ch.send_data(data)
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
When forwarding a port, transferring a large amount of data through the tunnel (e.g. piping a multi-GB DB dump) causes Ruby memory to grow roughly to the size of the transfer.

Cause: the forwarder relays bytes between the local socket and the SSH channel with no coupling between read rate and write rate, so whichever leg is "fast in / slow out" buffers unboundedly in the Ruby heap:

channel → socket (reading from remote): update_local_window_size keeps sending CHANNEL_WINDOW_ADJUST regardless of whether the local socket is draining, so the peer keeps flooding while socket output grows.

socket → channel (writing to remote): on_process keeps reading the local socket into the channel's output buffer even when the remote window is exhausted.

Expected: memory stays bounded; the slow side applies backpressure to the fast side.

Environment: net-ssh 7.3.2, Ruby 3.x.