### PR TITLE
Add OpenSSL-backed ML-KEM key exchange

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -336,6 +336,7 @@ Naming/MethodName:
   Exclude:
     - 'lib/net/ssh/authentication/ed25519_loader.rb'
     - 'lib/net/ssh/transport/kex/curve25519_sha256_loader.rb'
+    - 'lib/net/ssh/transport/kex/mlkem768_x25519_sha256_loader.rb'
     - 'test/authentication/test_agent.rb'
     - 'test/authentication/test_session.rb'
     - 'test/common.rb'

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -6,6 +6,7 @@ require 'net/ssh/transport/constants'
 require 'net/ssh/transport/hmac'
 require 'net/ssh/transport/kex'
 require 'net/ssh/transport/kex/curve25519_sha256_loader'
+require 'net/ssh/transport/kex/mlkem768_x25519_sha256_loader'
 require 'net/ssh/transport/server_version'
 require 'net/ssh/authentication/ed25519_loader'
 
@@ -71,6 +72,11 @@ module Net
           DEFAULT_ALGORITHMS[:kex].unshift(
             'curve25519-sha256',
             'curve25519-sha256@libssh.org'
+          )
+        end
+        if Net::SSH::Transport::Kex::MLKEM768X25519Sha256Loader::LOADED
+          DEFAULT_ALGORITHMS[:kex].unshift(
+            'mlkem768x25519-sha256'
           )
         end
 

--- a/lib/net/ssh/transport/kex.rb
+++ b/lib/net/ssh/transport/kex.rb
@@ -7,6 +7,7 @@ require 'net/ssh/transport/kex/ecdh_sha2_nistp256'
 require 'net/ssh/transport/kex/ecdh_sha2_nistp384'
 require 'net/ssh/transport/kex/ecdh_sha2_nistp521'
 require 'net/ssh/transport/kex/curve25519_sha256_loader'
+require 'net/ssh/transport/kex/mlkem768_x25519_sha256_loader'
 
 module Net::SSH::Transport
   module Kex
@@ -27,5 +28,6 @@ module Net::SSH::Transport
       MAP['curve25519-sha256'] = Curve25519Sha256
       MAP['curve25519-sha256@libssh.org'] = Curve25519Sha256
     end
+    MAP['mlkem768x25519-sha256'] = MLKEM768X25519Sha256 if Net::SSH::Transport::Kex::MLKEM768X25519Sha256Loader::LOADED
   end
 end

--- a/lib/net/ssh/transport/kex/mlkem768_x25519_sha256.rb
+++ b/lib/net/ssh/transport/kex/mlkem768_x25519_sha256.rb
@@ -1,0 +1,167 @@
+require 'openssl'
+require 'net/ssh/buffer'
+require 'net/ssh/transport/constants'
+require 'net/ssh/transport/kex/abstract'
+
+module Net
+  module SSH
+    module Transport
+      module Kex
+        # Hybrid ML-KEM-768 and X25519 key exchange used by OpenSSH.
+        class MLKEM768X25519Sha256 < Abstract
+          MLKEM_ALGORITHM = "ML-KEM-768"
+          MLKEM_PUBLIC_KEY_BYTES = 1184
+          MLKEM_PRIVATE_KEY_BYTES = 2400
+          MLKEM_CIPHERTEXT_BYTES = 1088
+          MLKEM_SHARED_SECRET_BYTES = 32
+          X25519_ALGORITHM = "X25519"
+          X25519_KEY_BYTES = 32
+
+          class UnsupportedError < StandardError; end
+
+          # Wrapper for OpenSSH's string-encoded hybrid shared secret.
+          class StringEncodedSharedSecret
+            def initialize(bytes)
+              @bytes = bytes
+            end
+
+            def to_ssh
+              @bytes
+            end
+
+            def ==(other)
+              other.respond_to?(:to_ssh) && to_ssh == other.to_ssh
+            end
+          end
+
+          def self.ensure_supported!
+            raise UnsupportedError, "openssl gem >= 4.0.0 is required" unless Gem::Version.new(OpenSSL::VERSION) >= Gem::Version.new("4.0.0")
+
+            unless OpenSSL::PKey::PKey.method_defined?(:encapsulate) &&
+                   OpenSSL::PKey::PKey.method_defined?(:decapsulate)
+              raise UnsupportedError, "OpenSSL::PKey KEM APIs are unavailable"
+            end
+
+            mlkem_key = generate_mlkem_key
+            validate_mlkem_key_bytes!(mlkem_key.raw_public_key, "public key", MLKEM_PUBLIC_KEY_BYTES)
+            validate_mlkem_key_bytes!(mlkem_key.raw_private_key, "private key", MLKEM_PRIVATE_KEY_BYTES)
+
+            mlkem_public_key = new_mlkem_public_key(mlkem_key.raw_public_key)
+            ciphertext, client_secret = mlkem_public_key.encapsulate
+            server_secret = mlkem_key.decapsulate(ciphertext)
+
+            validate_mlkem_key_bytes!(ciphertext, "ciphertext", MLKEM_CIPHERTEXT_BYTES)
+            validate_mlkem_key_bytes!(client_secret, "shared secret", MLKEM_SHARED_SECRET_BYTES)
+            raise UnsupportedError, "OpenSSL ML-KEM-768 shared secret decapsulation failed" if client_secret != server_secret
+          rescue OpenSSL::PKey::PKeyError, ArgumentError => e
+            raise UnsupportedError, e.message
+          end
+
+          def self.generate_mlkem_key
+            OpenSSL::PKey.generate_key(MLKEM_ALGORITHM)
+          end
+
+          def self.generate_x25519_key
+            OpenSSL::PKey.generate_key(X25519_ALGORITHM)
+          end
+
+          def self.new_mlkem_public_key(key)
+            validate_mlkem_key_bytes!(key, "public key", MLKEM_PUBLIC_KEY_BYTES)
+            OpenSSL::PKey.new_raw_public_key(MLKEM_ALGORITHM, binary_string(key))
+          end
+
+          def self.new_x25519_public_key(key)
+            validate_x25519_key_bytes!(key, "public key")
+            OpenSSL::PKey.new_raw_public_key(X25519_ALGORITHM, binary_string(key))
+          end
+
+          def self.validate_mlkem_key_bytes!(key, label, expected_bytes)
+            raise ArgumentError, "invalid ML-KEM-768 #{label}" unless key.respond_to?(:bytesize) && key.bytesize == expected_bytes
+          end
+
+          def self.validate_x25519_key_bytes!(key, label)
+            raise ArgumentError, "invalid X25519 #{label}" unless key.respond_to?(:bytesize) && key.bytesize == X25519_KEY_BYTES
+          end
+
+          def self.binary_string(string)
+            string.dup.force_encoding('BINARY')
+          end
+          private_class_method :binary_string
+
+          def digester
+            OpenSSL::Digest::SHA256
+          end
+
+          private
+
+          def generate_key
+            {
+              mlkem: self.class.generate_mlkem_key,
+              x25519: self.class.generate_x25519_key
+            }
+          end
+
+          def client_public_key_bytes
+            @client_public_key_bytes ||= dh.fetch(:mlkem).raw_public_key + dh.fetch(:x25519).raw_public_key
+          end
+
+          def build_signature_buffer(result)
+            response = Net::SSH::Buffer.new
+            response.write_string data[:client_version_string],
+                                  data[:server_version_string],
+                                  data[:client_algorithm_packet],
+                                  data[:server_algorithm_packet],
+                                  result[:key_blob],
+                                  client_public_key_bytes,
+                                  result[:server_blob]
+            response.write result[:shared_secret].to_ssh
+            response
+          end
+
+          def send_kexinit
+            buffer = Net::SSH::Buffer.from(:byte, KEXECDH_INIT, :mstring, client_public_key_bytes)
+            connection.send_message(buffer)
+
+            buffer = connection.next_message
+            raise Net::SSH::Exception, 'expected REPLY' unless buffer.type == KEXECDH_REPLY
+
+            result = {}
+            result[:key_blob] = buffer.read_string
+            result[:server_key] = Net::SSH::Buffer.new(result[:key_blob]).read_key
+            result[:server_blob] = buffer.read_string
+            result[:shared_secret] = compute_shared_secret(result[:server_blob])
+
+            sig_buffer = Net::SSH::Buffer.new(buffer.read_string)
+            sig_type = sig_buffer.read_string
+            if sig_type != algorithms.host_key_format
+              raise Net::SSH::Exception, "host key algorithm mismatch for signature '#{sig_type}' != '#{algorithms.host_key_format}'"
+            end
+
+            result[:server_sig] = sig_buffer.read_string
+
+            result
+          end
+
+          def compute_shared_secret(server_blob)
+            unless server_blob.respond_to?(:bytesize) && server_blob.bytesize == MLKEM_CIPHERTEXT_BYTES + X25519_KEY_BYTES
+              raise Net::SSH::Exception, "invalid mlkem768x25519-sha256 server key"
+            end
+
+            ciphertext = server_blob.byteslice(0, MLKEM_CIPHERTEXT_BYTES)
+            server_x25519 = server_blob.byteslice(MLKEM_CIPHERTEXT_BYTES, X25519_KEY_BYTES)
+
+            mlkem_secret = dh.fetch(:mlkem).decapsulate(ciphertext)
+            self.class.validate_mlkem_key_bytes!(mlkem_secret, "shared secret", MLKEM_SHARED_SECRET_BYTES)
+
+            server_x25519_key = self.class.new_x25519_public_key(server_x25519)
+            x25519_secret = dh.fetch(:x25519).derive(server_x25519_key)
+            self.class.validate_x25519_key_bytes!(x25519_secret, "shared secret")
+
+            hash = digester.digest(mlkem_secret + x25519_secret)
+            StringEncodedSharedSecret.new(Net::SSH::Buffer.from(:string, hash).to_s)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/net/ssh/transport/kex/mlkem768_x25519_sha256_loader.rb
+++ b/lib/net/ssh/transport/kex/mlkem768_x25519_sha256_loader.rb
@@ -1,0 +1,39 @@
+module Net
+  module SSH
+    module Transport
+      module Kex
+        # Loads MLKEM768X25519Sha256 support backed by Ruby OpenSSL KEM APIs.
+        module MLKEM768X25519Sha256Loader
+          begin
+            require 'net/ssh/transport/kex/mlkem768_x25519_sha256'
+            Net::SSH::Transport::Kex::MLKEM768X25519Sha256.ensure_supported!
+            LOADED = true
+            ERROR = nil
+          rescue LoadError => e
+            ERROR = e
+            LOADED = false
+          rescue StandardError => e
+            if defined?(Net::SSH::Transport::Kex::MLKEM768X25519Sha256::UnsupportedError) &&
+               e.is_a?(Net::SSH::Transport::Kex::MLKEM768X25519Sha256::UnsupportedError)
+              ERROR = e
+              LOADED = false
+            else
+              raise
+            end
+          end
+
+          def self.raiseUnlessLoaded(message)
+            description = LOADED ? '' : mlkem768x25519SupportRequired
+            description += "#{ERROR.class} : \"#{ERROR.message}\"\n" if ERROR
+            raise NotImplementedError, "#{message}\n#{description}" unless LOADED
+          end
+
+          def self.mlkem768x25519SupportRequired
+            "net-ssh requires openssl >= 4.0.0 and OpenSSL >= 3.5.0 " \
+              "with ML-KEM-768 and X25519 enabled for mlkem768x25519-sha256 support.\n"
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/test_mlkem768x25519_sha256.rb
+++ b/test/integration/test_mlkem768x25519_sha256.rb
@@ -1,0 +1,52 @@
+require_relative 'common'
+require 'fileutils'
+require 'tmpdir'
+
+require 'net/ssh'
+
+require 'timeout'
+
+class TestMLKEM768X25519Sha256 < NetSSHTest
+  include IntegrationTestHelpers
+
+  KEX = "mlkem768x25519-sha256"
+
+  def setup
+    skip "ML-KEM-768/X25519 is not available" unless Net::SSH::Transport::Kex::MLKEM768X25519Sha256Loader::LOADED
+    skip "#{KEX} is not supported by this OpenSSH" unless openssh_kex_supported?(KEX)
+  end
+
+  def test_with_only_mlkem768x25519_kex
+    config_lines = File.read('/etc/ssh/sshd_config').split("\n")
+    config_lines = config_lines.map do |line|
+      if line =~ /^KexAlgorithms/
+        "##{line}"
+      else
+        line
+      end
+    end
+    config_lines.push("KexAlgorithms #{KEX}")
+
+    Tempfile.open('empty_kh') do |f|
+      f.close
+      start_sshd_7_or_later(config: config_lines) do |_pid, port|
+        Timeout.timeout(4) do
+          ret = Net::SSH.start("localhost", "net_ssh_1", password: 'foopwd', port: port, user_known_hosts_file: [f.path]) do |ssh|
+            assert_equal KEX, ssh.transport.algorithms.kex
+            ssh.exec! "echo 'foo'"
+          end
+          assert_equal "foo\n", ret
+        rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+          sleep 0.25
+          retry
+        end
+      end
+    end
+  end
+
+  private
+
+  def openssh_kex_supported?(name)
+    `ssh -Q kex 2>/dev/null`.split.include?(name)
+  end
+end

--- a/test/transport/kex/test_mlkem768_x25519_sha256.rb
+++ b/test/transport/kex/test_mlkem768_x25519_sha256.rb
@@ -1,0 +1,171 @@
+require_relative '../../common'
+require 'net/ssh/transport/kex/mlkem768_x25519_sha256_loader'
+require 'base64'
+
+module Transport
+  module Kex
+    class TestMLKEM768X25519Sha256 < NetSSHTest
+      include Net::SSH::Transport::Constants
+
+      Algorithms = Struct.new(:host_key, :host_key_format, keyword_init: true)
+
+      def setup
+        skip 'ML-KEM-768/X25519 is not available' unless Net::SSH::Transport::Kex::MLKEM768X25519Sha256Loader::LOADED
+
+        @algorithms = @connection = @kex = @packet_data = nil
+        @server_blob = @server_host_key = @shared_secret = @signature = nil
+      end
+
+      def test_exchange_keys_should_return_expected_results_when_successful
+        result = exchange!
+        assert_equal session_id, result[:session_id]
+        assert_equal server_host_key.to_blob, result[:server_key].to_blob
+        assert_equal shared_secret.to_ssh, result[:shared_secret].to_ssh
+        assert_equal digester, result[:hashing_algorithm]
+      end
+
+      def test_exchange_keys_with_unverifiable_host_should_raise_exception
+        connection.verifier { false }
+        assert_raises(Net::SSH::Exception) { exchange! }
+      end
+
+      def test_exchange_keys_with_signature_key_type_mismatch_should_raise_exception
+        assert_raises(Net::SSH::Exception) { exchange! key_type: 'ssh-dss' }
+      end
+
+      def test_exchange_keys_when_server_signature_could_not_be_verified_should_raise_exception
+        @signature = '1234567890'
+        assert_raises(Net::SSH::Exception) { exchange! }
+      end
+
+      def test_exchange_keys_with_invalid_server_blob_should_raise_exception
+        @server_blob = 'too short'
+        assert_raises(Net::SSH::Exception) { exchange! signature: 'ignored' }
+      end
+
+      def test_exchange_keys_should_pass_expected_parameters_to_host_key_verifier
+        verified = false
+        connection.verifier do |data|
+          verified = true
+          assert_equal server_host_key.to_blob, data[:key].to_blob
+
+          blob = b(:key, data[:key]).to_s
+          fingerprint = "SHA256:#{Base64.encode64(OpenSSL::Digest.digest('SHA256', blob)).chomp.gsub(/=+\z/, '')}"
+
+          assert_equal blob, data[:key_blob]
+          assert_equal fingerprint, data[:fingerprint]
+          assert_equal connection, data[:session]
+
+          true
+        end
+
+        assert_nothing_raised { exchange! }
+        assert verified
+      end
+
+      private
+
+      def digester
+        OpenSSL::Digest::SHA256
+      end
+
+      def subject
+        Net::SSH::Transport::Kex::MLKEM768X25519Sha256
+      end
+
+      def key_type
+        'ecdsa-sha2-nistp256'
+      end
+
+      def exchange!(options = {})
+        connection.expect do |t, buffer|
+          assert_equal KEXECDH_INIT, buffer.type
+          @client_blob = buffer.read_string
+          assert_equal subject::MLKEM_PUBLIC_KEY_BYTES + subject::X25519_KEY_BYTES, @client_blob.bytesize
+
+          build_server_exchange unless @server_blob
+          t.return(KEXECDH_REPLY,
+                   :string, b(:key, server_host_key),
+                   :string, @server_blob,
+                   :string, b(:string, options[:key_type] || key_type,
+                              :string, options[:signature] || signature))
+          connection.expect do |t2, buffer2|
+            assert_equal NEWKEYS, buffer2.type
+            t2.return(NEWKEYS)
+          end
+        end
+        kex.exchange_keys
+      end
+
+      def build_server_exchange
+        mlkem_public_key = OpenSSL::PKey.new_raw_public_key(subject::MLKEM_ALGORITHM, client_mlkem_public_key)
+        ciphertext, mlkem_secret = mlkem_public_key.encapsulate
+
+        @server_x25519_key = OpenSSL::PKey.generate_key('X25519')
+        client_x25519_key = OpenSSL::PKey.new_raw_public_key('X25519', client_x25519_public_key)
+        x25519_secret = @server_x25519_key.derive(client_x25519_key)
+
+        @server_blob = ciphertext + @server_x25519_key.raw_public_key
+        hash = digester.digest(mlkem_secret + x25519_secret)
+        @shared_secret = subject::StringEncodedSharedSecret.new(Net::SSH::Buffer.from(:string, hash).to_s)
+      end
+
+      def client_mlkem_public_key
+        @client_blob.byteslice(0, subject::MLKEM_PUBLIC_KEY_BYTES)
+      end
+
+      def client_x25519_public_key
+        @client_blob.byteslice(subject::MLKEM_PUBLIC_KEY_BYTES, subject::X25519_KEY_BYTES)
+      end
+
+      def kex
+        @kex ||= subject.new(algorithms, connection, packet_data)
+      end
+
+      def algorithms(options = {})
+        @algorithms ||= Algorithms.new(host_key: options[:server_host_key] || 'ecdsa-sha2-nistp256', host_key_format: options[:server_host_key] || 'ecdsa-sha2-nistp256')
+      end
+
+      def connection
+        @connection ||= MockTransport.new
+      end
+
+      def server_host_key
+        @server_host_key ||= OpenSSL::PKey::EC.generate('prime256v1')
+      end
+
+      def packet_data
+        @packet_data ||= { client_version_string: 'client version string',
+                           server_version_string: 'server version string',
+                           server_algorithm_packet: 'server algorithm packet',
+                           client_algorithm_packet: 'client algorithm packet' }
+      end
+
+      def shared_secret
+        @shared_secret ||= build_server_exchange || @shared_secret
+      end
+
+      def session_id
+        @session_id ||= begin
+          buffer = Net::SSH::Buffer.from(:string, packet_data[:client_version_string],
+                                         :string, packet_data[:server_version_string],
+                                         :string, packet_data[:client_algorithm_packet],
+                                         :string, packet_data[:server_algorithm_packet],
+                                         :string, Net::SSH::Buffer.from(:key, server_host_key),
+                                         :string, @client_blob,
+                                         :string, @server_blob,
+                                         :raw, shared_secret.to_ssh)
+          digester.digest(buffer.to_s)
+        end
+      end
+
+      def signature
+        @signature ||= server_host_key.ssh_do_sign(session_id)
+      end
+
+      def b(*args)
+        Net::SSH::Buffer.from(*args)
+      end
+    end
+  end
+end

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -18,7 +18,7 @@ module Transport
 
     def test_constructor_should_build_default_list_of_preferred_algorithms
       assert_equal ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa rsa-sha2-256 rsa-sha2-512], algorithms[:host_key]
-      assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1], algorithms[:kex]
+      assert_equal modern_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1], algorithms[:kex]
       assert_equal chacha_poly_cipher + %w[aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com], algorithms[:encryption]
       assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1], algorithms[:hmac]
       assert_equal %w[none zlib@openssh.com zlib], algorithms[:compression]
@@ -27,7 +27,7 @@ module Transport
 
     def test_constructor_should_build_complete_list_of_algorithms_with_append_all_supported_algorithms
       assert_equal ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa rsa-sha2-256 rsa-sha2-512 ssh-dss], algorithms(append_all_supported_algorithms: true)[:host_key]
-      assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1], algorithms(append_all_supported_algorithms: true)[:kex]
+      assert_equal modern_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1], algorithms(append_all_supported_algorithms: true)[:kex]
       assert_equal chacha_poly_cipher + %w[aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(append_all_supported_algorithms: true)[:encryption]
       assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 hmac-md5-96 none], algorithms(append_all_supported_algorithms: true)[:hmac]
       assert_equal %w[none zlib@openssh.com zlib], algorithms(append_all_supported_algorithms: true)[:compression]
@@ -91,6 +91,18 @@ module Transport
       end
     end
 
+    def pq_kex
+      if Net::SSH::Transport::Kex::MLKEM768X25519Sha256Loader::LOADED
+        %w[mlkem768x25519-sha256]
+      else
+        []
+      end
+    end
+
+    def modern_kex
+      pq_kex + x25519_kex
+    end
+
     def chacha_poly_cipher
       if Net::SSH::Transport::ChaCha20Poly1305CipherLoader::LOADED
         %w[chacha20-poly1305@openssh.com]
@@ -108,22 +120,22 @@ module Transport
     end
 
     def test_constructor_with_preferred_kex_should_put_preferred_kex_first
-      assert_equal %w[diffie-hellman-group1-sha1] + x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1],
+      assert_equal %w[diffie-hellman-group1-sha1] + modern_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1],
                    algorithms(kex: "diffie-hellman-group1-sha1", append_all_supported_algorithms: true)[:kex]
     end
 
     def test_constructor_with_unrecognized_kex_should_not_raise_exception
-      assert_equal %w[diffie-hellman-group1-sha1] + x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1],
+      assert_equal %w[diffie-hellman-group1-sha1] + modern_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1],
                    algorithms(kex: %w[bogus diffie-hellman-group1-sha1], append_all_supported_algorithms: true)[:kex]
     end
 
     def test_constructor_with_preferred_kex_supports_additions
-      assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1],
+      assert_equal modern_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1],
                    algorithms(kex: %w[+diffie-hellman-group1-sha1])[:kex]
     end
 
     def test_constructor_with_preferred_kex_supports_removals_with_wildcard
-      assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256],
+      assert_equal modern_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256],
                    algorithms(kex: %w[-diffie-hellman-group*-sha1 -diffie-hellman-group-exchange-sha1])[:kex]
     end
 
@@ -242,7 +254,7 @@ module Transport
       kexinit kex: "diffie-hellman-group14-sha1"
       transport.expect do |_t, buffer|
         assert_kexinit(buffer)
-        install_mock_key_exchange(buffer, kex: Net::SSH::Transport::Kex::DiffieHellmanGroup1SHA1)
+        install_mock_key_exchange(buffer, kex: Net::SSH::Transport::Kex::DiffieHellmanGroup14SHA1)
       end
       algorithms.accept_kexinit(kexinit)
     end
@@ -430,7 +442,7 @@ module Transport
     def assert_kexinit(buffer, options = {})
       assert_equal KEXINIT, buffer.type
       assert_equal 16, buffer.read(16).length
-      assert_equal options[:kex] || (x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1]).join(','), buffer.read_string
+      assert_equal options[:kex] || (modern_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1]).join(','), buffer.read_string
       assert_equal options[:host_key] || (ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa rsa-sha2-256 rsa-sha2-512]).join(','), buffer.read_string
       assert_equal options[:encryption_client] || "#{chacha_poly_cipher_str}aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com", buffer.read_string
       assert_equal options[:encryption_server] || "#{chacha_poly_cipher_str}aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com", buffer.read_string


### PR DESCRIPTION
This PR adds support for `mlkem768x25519-sha256` key exchange. It is dependant on https://github.com/ruby/openssl/pull/1062 getting merged, but locally unit and integration tests pass when running that branch with a crypto backend that supports ML-KEM-768 (eg OpenSSL version 3.5+). When available, net-ssh advertises it ahead of existing key exchange algorithms; when unavailable, behavior is unchanged.

[OpenSSH 10.0](https://www.openssh.org/txt/release-10.0) made `mlkem768x25519-sha256` the default key agreement algorithm for post-quantum safety. OpenSSH describes it as NIST-standardized, quantum-safe, no weaker than curve25519-sha256, and faster than the previous default:  This is also where public-sector cryptography guidance is heading. NIST finalized ML-KEM in FIPS 203 in August 2024, and government roadmaps are starting to put late-2020s/2030s dates on PQC migration planning.