### PR TITLE
Fix cert signing regression and .pub file error handling (follow-up to #942)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,8 @@
 .git/
 .gitignore
 
+# Vagrant
+test/integration/.vagrant
+
 docker-compose.yml
 README.md

--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -248,10 +248,14 @@ module Net
         def prepare_identities_from_files
           key_files.map do |file|
             if readable_file?(file)
-              identity = {}
+              identity = {privkey_file: file}
               cert_file = file + "-cert.pub"
               public_key_file = file + ".pub"
-              if readable_file?(cert_file)
+              if file.end_with?(".pub")
+                identity[:load_from] = :pubkey_file
+                identity[:pubkey_file] = file
+                identity.delete(:privkey_file)
+              elsif readable_file?(cert_file)
                 identity[:load_from] = :pubkey_file
                 identity[:pubkey_file] = cert_file
               elsif readable_file?(public_key_file)
@@ -260,7 +264,7 @@ module Net
               else
                 identity[:load_from] = :privkey_file
               end
-              identity.merge(privkey_file: file)
+              identity
             end
           end.compact
         end

--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -252,7 +252,7 @@ module Net
         def prepare_identities_from_files
           key_files.map do |file|
             if readable_file?(file)
-              identity = {privkey_file: file}
+              identity = { privkey_file: file }
               cert_file = file + "-cert.pub"
               public_key_file = file + ".pub"
               if file.end_with?(".pub")

--- a/lib/net/ssh/authentication/key_manager.rb
+++ b/lib/net/ssh/authentication/key_manager.rb
@@ -176,7 +176,7 @@ module Net
             raise KeyManagerError, "the given identity is a public key only and cannot be used for signing without an agent"
           end
 
-          if info[:key].nil? && info[:from] == :file
+          if info[:key].nil? && (info[:from] == :file || info[:from] == :pubkey_file)
             begin
               info[:key] = KeyFactory.load_private_key(info[:file], options[:passphrase], !options[:non_interactive], options[:password_prompt])
             rescue OpenSSL::OpenSSLError, Exception => e
@@ -324,7 +324,7 @@ module Net
 
         def process_identity_loading_error(identity, e)
           case identity[:load_from]
-          when :pubkey_file
+          when :pubkey_file, :pubkey_file_only
             error { "could not load public key file `#{identity[:pubkey_file]}': #{e.class} (#{e.message})" }
           when :privkey_file
             error { "could not load private key file `#{identity[:privkey_file]}': #{e.class} (#{e.message})" }

--- a/test/authentication/test_key_manager.rb
+++ b/test/authentication/test_key_manager.rb
@@ -96,6 +96,24 @@ module Authentication
       assert_equal({ from: :file, file: first }, manager.known_identities[rsa_cert])
     end
 
+    def test_each_identity_should_load_from_public_key_files
+      manager.stubs(:agent).returns(nil)
+      first = File.expand_path("/first")
+      second = File.expand_path("/second")
+      stub_file_public_key first, rsa
+      stub_file_public_key second, dsa
+
+      identities = []
+      manager.each_identity { |identity| identities << identity }
+
+      assert_equal 2, identities.length
+      assert_equal rsa.to_blob, identities.first.to_blob
+      assert_equal dsa.to_blob, identities.last.to_blob
+
+      assert_equal({ from: :file, file: nil }, manager.known_identities[rsa])
+      assert_equal({ from: :file, file: nil }, manager.known_identities[dsa])
+    end
+
     def test_each_identity_should_use_cert_data
       manager.stubs(:agent).returns(nil)
 
@@ -301,9 +319,7 @@ module Authentication
     end
 
     def stub_file_public_key(name, key)
-      manager.add(name)
-      File.stubs(:file?).with(name).returns(true)
-      File.stubs(:readable?).with(name).returns(true)
+      manager.add(name + ".pub")
       File.stubs(:file?).with(name + ".pub").returns(true)
       File.stubs(:readable?).with(name + ".pub").returns(true)
       File.stubs(:file?).with(name + "-cert.pub").returns(false)

--- a/test/authentication/test_key_manager.rb
+++ b/test/authentication/test_key_manager.rb
@@ -119,7 +119,7 @@ module Authentication
       first = File.expand_path("/first")
       stub_file_public_key first, rsa
 
-      manager.each_identity { |identity| }
+      manager.each_identity { |identity| } # preload known_identities
 
       Net::SSH::KeyFactory.expects(:load_private_key).never
       assert_raises Net::SSH::Authentication::KeyManagerError do
@@ -175,7 +175,7 @@ module Authentication
       first = File.expand_path("/first")
       stub_file_public_key first, rsa_pk
 
-      manager.each_identity { |identity| }
+      manager.each_identity { |identity| } # preload known_identities
 
       agent.expects(:sign).with(rsa_pk, "hello, world").returns("abcxyz123")
       assert_equal "abcxyz123", manager.sign(rsa_pk, "hello, world")
@@ -338,7 +338,7 @@ module Authentication
       manager.stubs(:agent).returns(nil)
       first = File.expand_path("/first")
       stub_implicit_file_cert first, rsa, rsa_cert
-      manager.each_identity { |identity| }
+      manager.each_identity { |identity| } # preload known_identities
 
       Net::SSH::KeyFactory.expects(:load_private_key).with(first, nil, true, prompt).returns(rsa)
       rsa.expects(:ssh_do_sign).with("hello, world").returns("abcxyz123")

--- a/test/authentication/test_key_manager.rb
+++ b/test/authentication/test_key_manager.rb
@@ -127,6 +127,60 @@ module Authentication
       end
     end
 
+    def test_each_identity_with_pubkey_file_uses_matching_agent_key
+      # Primary use case: IdentityFile ~/.ssh/kamal.pub + IdentityAgent ~/.1password/agent.sock
+      # The .pub file pins which agent key to use; signing is via the agent.
+      manager.stubs(:agent).returns(agent)
+      first = File.expand_path("/first")
+      stub_file_public_key first, rsa_pk
+
+      identities = []
+      manager.each_identity { |identity| identities << identity }
+
+      # rsa_pk from agent matches the pubkey file; dsa_pk from agent is also yielded (no keys_only)
+      assert identities.map(&:to_blob).include?(rsa_pk.to_blob)
+      assert_equal({ from: :agent, identity: rsa_pk }, manager.known_identities[rsa_pk])
+    end
+
+    def test_each_identity_with_pubkey_file_filters_agent_keys_when_keys_only
+      # With keys_only (IdentitiesOnly yes), only the agent key matching the .pub file is offered.
+      manager(keys_only: true).stubs(:agent).returns(agent)
+      first = File.expand_path("/first")
+      stub_file_public_key first, rsa_pk
+
+      identities = []
+      manager.each_identity { |identity| identities << identity }
+
+      assert_equal 1, identities.length
+      assert_equal rsa_pk.to_blob, identities.first.to_blob
+      assert_equal({ from: :agent, identity: rsa_pk }, manager.known_identities[rsa_pk])
+    end
+
+    def test_each_identity_skips_unreadable_pubkey_file_only_without_raising
+      manager.stubs(:agent).returns(nil)
+      first = File.expand_path("/first")
+      manager.add(first + ".pub")
+      File.stubs(:file?).with(first + ".pub").returns(true)
+      File.stubs(:readable?).with(first + ".pub").returns(true)
+      File.stubs(:file?).with(first + "-cert.pub").returns(false)
+      Net::SSH::KeyFactory.expects(:load_public_key).with(first + ".pub").raises(OpenSSL::PKey::PKeyError, "bad key").at_least_once
+
+      identities = []
+      assert_nothing_raised { manager.each_identity { |identity| identities << identity } }
+      assert_equal 0, identities.length
+    end
+
+    def test_sign_with_pubkey_file_identity_delegates_to_agent
+      manager.stubs(:agent).returns(agent)
+      first = File.expand_path("/first")
+      stub_file_public_key first, rsa_pk
+
+      manager.each_identity { |identity| }
+
+      agent.expects(:sign).with(rsa_pk, "hello, world").returns("abcxyz123")
+      assert_equal "abcxyz123", manager.sign(rsa_pk, "hello, world")
+    end
+
     def test_each_identity_should_use_cert_data
       manager.stubs(:agent).returns(nil)
 
@@ -278,6 +332,17 @@ module Authentication
       manager.each_identity { |identity| } # preload the known_identities
       agent.expects(:sign).with(rsa_pk, "hello, world").returns("abcxyz123")
       assert_equal "abcxyz123", manager.sign(rsa_cert, "hello, world")
+    end
+
+    def test_sign_with_implicit_cert_file_and_no_agent_uses_private_key
+      manager.stubs(:agent).returns(nil)
+      first = File.expand_path("/first")
+      stub_implicit_file_cert first, rsa, rsa_cert
+      manager.each_identity { |identity| }
+
+      Net::SSH::KeyFactory.expects(:load_private_key).with(first, nil, true, prompt).returns(rsa)
+      rsa.expects(:ssh_do_sign).with("hello, world").returns("abcxyz123")
+      assert_equal "\0\0\0\assh-rsa\0\0\0\011abcxyz123", manager.sign(rsa_cert, "hello, world")
     end
 
     def test_sign_with_file_originated_key_should_load_private_key_and_sign_with_it


### PR DESCRIPTION
Follow-up to #942 which adds support for bare `.pub` files as `IdentityFile`.

Two bugs found during review:

**1. Cert signing broken without an agent**

The PR renamed `from: :file` to `from: :pubkey_file` for implicit cert identities (e.g. `key-cert.pub`), but `sign()` only lazy-loads the private key when `from: :file`. Anyone using cert auth without an agent would hit `[BUG] can't determine identity origin` instead of signing.

Fix: extend the condition in `sign()` to also handle `from: :pubkey_file`.

**2. Unreadable `.pub` file raises instead of logging**

`process_identity_loading_error` had no `when :pubkey_file_only` branch, so a bad or unreadable bare `.pub` file would hit `else raise e` instead of logging and continuing.

Fix: add `when :pubkey_file_only` alongside `when :pubkey_file`.

**Tests added**
- Agent happy-path: `.pub` IdentityFile pins which agent key is offered
- `keys_only` filtering: only the agent key matching the `.pub` file is offered (`IdentitiesOnly yes`)
- Signing via agent when identity came from a `.pub` file
- Cert signing without agent loads private key from disk (regression test — confirmed failing before fix)
- Unreadable `.pub` file is skipped without raising