### PR TITLE
Support agent-backed FIDO/U2F security keys (sk-*)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 === 7.3.3
 
+  * Support agent-backed FIDO/U2F security keys (sk-ecdsa-sha2-nistp256@openssh.com, sk-ssh-ed25519@openssh.com) for publickey auth
   * Support .pub file as IdentityFile to filter/prioritize agent keys (1Password SSH agent use case) [#942]
   * Fix cert signing regression when using a .pub companion file without an agent [#1006]
   * Fix unreadable .pub IdentityFile silently skipped instead of raising [#1006]

--- a/README.md
+++ b/README.md
@@ -197,6 +197,20 @@ gem install bcrypt_pbkdf
 
 For curve25519-sha256 kex exchange support your bundle file should contain `x25519` dependency.
 
+### FIDO/U2F security keys (agent only)
+
+FIDO/U2F hardware security keys (`sk-ecdsa-sha2-nistp256@openssh.com` and
+`sk-ssh-ed25519@openssh.com`, created with `ssh-keygen -t ecdsa-sk` / `-t ed25519-sk`)
+are supported for public key authentication **only when provided by a running
+`ssh-agent`**. The agent (and the hardware token behind it) performs the actual
+signing, including the required user-presence touch, so no extra gems or native
+FIDO libraries are needed.
+
+Loading `sk-*` keys directly from private key files on disk is **not** supported,
+because that requires talking to the authenticator over the FIDO/CTAP protocol
+(e.g. via libfido2), which Net::SSH does not implement. Make sure your key is
+loaded in the agent (`ssh-add -K` / `ssh-add`) and that `SSH_AUTH_SOCK` is set.
+
 ## RUBY SUPPORT
 
 * See [net-ssh.gemspec](https://github.com/net-ssh/net-ssh/blob/master/net-ssh.gemspec) for current versions ruby requirements

--- a/lib/net/ssh/authentication/security_key.rb
+++ b/lib/net/ssh/authentication/security_key.rb
@@ -1,0 +1,106 @@
+require 'net/ssh/authentication/pub_key_fingerprint'
+
+module Net
+  module SSH
+    module Authentication
+      # Support for FIDO/U2F hardware "security key" public keys, i.e. the
+      # +sk-ecdsa-sha2-nistp256@openssh.com+ and +sk-ssh-ed25519@openssh.com+
+      # key types created by <tt>ssh-keygen -t ecdsa-sk</tt> / <tt>-t ed25519-sk</tt>.
+      #
+      # == Agent only
+      #
+      # This implements *agent-backed* security keys only. Net::SSH does not talk
+      # to the hardware authenticator directly (that requires a FIDO/CTAP stack
+      # such as libfido2), so:
+      #
+      # * security keys *must* be provided by a running ssh-agent
+      #   (the agent performs the actual signing, including the required user
+      #   presence / touch), and
+      # * loading +sk-*+ keys from private key files on disk is *not* supported.
+      #
+      # Because the agent does the signing, Net::SSH only needs to understand the
+      # public key well enough to (a) parse the blob the agent advertises and
+      # (b) re-serialize that exact blob when building authentication and signing
+      # requests. The agent returns a ready-made SSH signature blob that Net::SSH
+      # forwards to the server verbatim.
+      #
+      # See OpenSSH's PROTOCOL.u2f for the wire formats.
+      module SecurityKey
+        # OpenSSH public key algorithm name for ECDSA (NIST P-256) security keys.
+        SK_ECDSA_SHA2_NISTP256 = "sk-ecdsa-sha2-nistp256@openssh.com"
+
+        # OpenSSH public key algorithm name for Ed25519 security keys.
+        SK_SSH_ED25519 = "sk-ssh-ed25519@openssh.com"
+
+        # The +sk-*+ public key algorithm names supported here.
+        TYPES = [SK_ECDSA_SHA2_NISTP256, SK_SSH_ED25519].freeze
+
+        # Returns true if +type+ is a (non-certificate) security key public key
+        # algorithm name handled by this module.
+        def self.understands?(type)
+          TYPES.include?(type)
+        end
+
+        # A public key for a FIDO/U2F security key. It can report its type and
+        # fingerprint and round-trip its wire blob; all signing is delegated to
+        # the ssh-agent that holds the corresponding credential.
+        class PubKey
+          include Net::SSH::Authentication::PubKeyFingerprint
+
+          attr_reader :ssh_type, :curve, :public_key_data, :application
+
+          # Reads the public key fields for +type+ from +buffer+ (the leading
+          # type string has already been consumed by Buffer#read_key). Wire
+          # formats per PROTOCOL.u2f:
+          #
+          #   sk-ecdsa-sha2-nistp256@openssh.com: string curve, string Q, string application
+          #   sk-ssh-ed25519@openssh.com:         string public_key, string application
+          def self.read_keyblob(type, buffer)
+            case type
+            when SK_ECDSA_SHA2_NISTP256
+              curve = buffer.read_string
+              public_key_data = buffer.read_string
+              application = buffer.read_string
+              new(type, public_key_data, application, curve: curve)
+            when SK_SSH_ED25519
+              public_key_data = buffer.read_string
+              application = buffer.read_string
+              new(type, public_key_data, application)
+            else
+              raise NotImplementedError, "unsupported security key type `#{type}'"
+            end
+          end
+
+          def initialize(ssh_type, public_key_data, application, curve: nil)
+            @ssh_type = ssh_type
+            @public_key_data = public_key_data
+            @application = application
+            @curve = curve
+          end
+
+          def to_blob
+            buffer = Net::SSH::Buffer.new
+            buffer.write_string(ssh_type)
+            buffer.write_string(curve) if curve
+            buffer.write_string(public_key_data)
+            buffer.write_string(application)
+            buffer.to_s
+          end
+
+          # The signature algorithm used with this key. Security keys do not have
+          # alternate signature types, so this is just the key type.
+          def ssh_signature_type
+            ssh_type
+          end
+
+          # Security keys have no OpenSSL PEM representation. The key manager only
+          # uses #to_pem to de-duplicate identities, so a stable, key-specific
+          # string is sufficient (and will simply never match a real PEM).
+          def to_pem
+            "#{ssh_type} #{[to_blob].pack('m0')}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/net/ssh/buffer.rb
+++ b/lib/net/ssh/buffer.rb
@@ -2,6 +2,7 @@ require 'net/ssh/transport/openssl'
 
 require 'net/ssh/authentication/certificate'
 require 'net/ssh/authentication/ed25519_loader'
+require 'net/ssh/authentication/security_key'
 
 module Net
   module SSH
@@ -338,6 +339,10 @@ module Net
           key = Net::SSH::Authentication::ED25519::PubKey.read_keyblob(self)
         when /^ecdsa\-sha2\-(\w*)$/
           key = OpenSSL::PKey::EC.read_keyblob($1, self)
+        when Net::SSH::Authentication::SecurityKey::SK_ECDSA_SHA2_NISTP256,
+          Net::SSH::Authentication::SecurityKey::SK_SSH_ED25519
+          # FIDO/U2F security keys (agent-backed only); see SecurityKey.
+          key = Net::SSH::Authentication::SecurityKey::PubKey.read_keyblob(type, self)
         else
           raise NotImplementedError, "unsupported key type `#{type}'"
         end

--- a/test/authentication/test_agent.rb
+++ b/test/authentication/test_agent.rb
@@ -139,6 +139,26 @@ module Authentication
       assert_equal "Okay, but not the best", result.last.comment
     end
 
+    def test_identities_should_return_agent_backed_security_key
+      sk_blob = Net::SSH::Buffer.from(
+        :string, "sk-ecdsa-sha2-nistp256@openssh.com",
+        :string, "nistp256",
+        :string, "\x04#{"\x11" * 64}".b,
+        :string, "ssh:"
+      ).to_s
+
+      socket.expect do |s, type, _buffer|
+        assert_equal SSH2_AGENT_REQUEST_IDENTITIES, type
+        s.return(SSH2_AGENT_IDENTITIES_ANSWER, :long, 1, :string, sk_blob, :string, "yubikey")
+      end
+
+      result = agent.identities
+      assert_equal 1, result.size
+      assert_equal "sk-ecdsa-sha2-nistp256@openssh.com", result.first.ssh_type
+      assert_equal sk_blob, result.first.to_blob
+      assert_equal "yubikey", result.first.comment
+    end
+
     def test_identities_should_ignore_unimplemented_ones
       key1 = key
       key2 = OpenSSL::PKey::DSA.new(1024)

--- a/test/authentication/test_security_key.rb
+++ b/test/authentication/test_security_key.rb
@@ -1,0 +1,79 @@
+# encoding: ASCII-8BIT
+# frozen_string_literal: false
+
+require_relative '../common'
+require 'net/ssh/buffer'
+require 'net/ssh/authentication/security_key'
+
+module Authentication
+  class TestSecurityKey < NetSSHTest
+    SK_ECDSA = Net::SSH::Authentication::SecurityKey::SK_ECDSA_SHA2_NISTP256
+    SK_ED25519 = Net::SSH::Authentication::SecurityKey::SK_SSH_ED25519
+
+    # 65-byte uncompressed NIST P-256 point (0x04 || X || Y).
+    ECDSA_POINT = "\x04#{"\x11" * 64}".b
+    ED25519_POINT = ("\x22" * 32).b
+
+    def sk_ecdsa_blob(application = "ssh:")
+      Net::SSH::Buffer.from(:string, SK_ECDSA, :string, "nistp256",
+                            :string, ECDSA_POINT, :string, application).to_s
+    end
+
+    def sk_ed25519_blob(application = "ssh:")
+      Net::SSH::Buffer.from(:string, SK_ED25519, :string, ED25519_POINT,
+                            :string, application).to_s
+    end
+
+    def test_buffer_read_key_returns_security_key_pubkey_for_sk_ecdsa
+      key = Net::SSH::Buffer.new(sk_ecdsa_blob).read_key
+      assert_instance_of Net::SSH::Authentication::SecurityKey::PubKey, key
+      assert_equal SK_ECDSA, key.ssh_type
+      assert_equal "nistp256", key.curve
+      assert_equal ECDSA_POINT, key.public_key_data
+      assert_equal "ssh:", key.application
+    end
+
+    def test_buffer_read_key_returns_security_key_pubkey_for_sk_ed25519
+      key = Net::SSH::Buffer.new(sk_ed25519_blob).read_key
+      assert_instance_of Net::SSH::Authentication::SecurityKey::PubKey, key
+      assert_equal SK_ED25519, key.ssh_type
+      assert_nil key.curve
+      assert_equal ED25519_POINT, key.public_key_data
+      assert_equal "ssh:", key.application
+    end
+
+    def test_to_blob_round_trips_sk_ecdsa
+      blob = sk_ecdsa_blob
+      assert_equal blob, Net::SSH::Buffer.new(blob).read_key.to_blob
+    end
+
+    def test_to_blob_round_trips_sk_ed25519
+      blob = sk_ed25519_blob
+      assert_equal blob, Net::SSH::Buffer.new(blob).read_key.to_blob
+    end
+
+    def test_fingerprint_uses_openssh_sha256_format
+      blob = sk_ecdsa_blob
+      key = Net::SSH::Buffer.new(blob).read_key
+      expected = "SHA256:#{[OpenSSL::Digest.digest('SHA256', blob)].pack('m').chomp.delete('=')}"
+      assert_equal expected, key.fingerprint('SHA256')
+    end
+
+    def test_ssh_signature_type_is_key_type
+      key = Net::SSH::Buffer.new(sk_ed25519_blob).read_key
+      assert_equal SK_ED25519, key.ssh_signature_type
+    end
+
+    def test_understands_only_known_sk_types
+      assert Net::SSH::Authentication::SecurityKey.understands?(SK_ECDSA)
+      assert Net::SSH::Authentication::SecurityKey.understands?(SK_ED25519)
+      refute Net::SSH::Authentication::SecurityKey.understands?("ssh-ed25519")
+      refute Net::SSH::Authentication::SecurityKey.understands?("ecdsa-sha2-nistp256")
+    end
+
+    def test_unknown_type_still_raises
+      blob = Net::SSH::Buffer.from(:string, "totally-unknown", :string, "x").to_s
+      assert_raises(NotImplementedError) { Net::SSH::Buffer.new(blob).read_key }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds support for FIDO/U2F hardware **security keys** for publickey authentication, specifically the OpenSSH key types:

- `sk-ecdsa-sha2-nistp256@openssh.com`
- `sk-ssh-ed25519@openssh.com`

(created with `ssh-keygen -t ecdsa-sk` / `-t ed25519-sk`).

### Agent only — by design

This intentionally implements **agent-backed security keys only**:

- The keys **must** be provided by a running `ssh-agent`. The agent (and the hardware token behind it) performs the actual signing, including the required user-presence touch.
- Loading `sk-*` keys from **private key files on disk is not supported**, because that requires driving the authenticator over the FIDO/CTAP protocol (e.g. libfido2), which net-ssh does not implement. No new gems or native dependencies are added.

Because the agent does the signing and returns a ready-made SSH signature blob (which net-ssh forwards to the server verbatim), net-ssh only needs to understand the **public key**: parse the blob the agent advertises and re-serialize that exact blob when building auth/sign requests.

## Problem

Today `Net::SSH::Buffer#read_keyblob` raises `NotImplementedError` for `sk-*` key types. `Net::SSH::Authentication::Agent#identities` rescues that and **silently drops** the identity, so a security key loaded in the agent is never offered for authentication — even though the agent is fully capable of signing with it. This makes net-ssh unusable for users/orgs that require hardware-backed SSH keys.

## Changes

- New `Net::SSH::Authentication::SecurityKey` module with a `PubKey` class (parses/serializes the `sk-*` public key blobs per OpenSSH `PROTOCOL.u2f`, reports `ssh_type`/`fingerprint`/`ssh_signature_type`). Modeled on the existing `ED25519::PubKey`.
- `Net::SSH::Buffer#read_keyblob` recognizes the two `sk-*` types and delegates to `SecurityKey::PubKey`.
- Tests:
  - `test/authentication/test_security_key.rb` — blob parsing, exact `to_blob` round-trip, OpenSSH-format SHA256 fingerprint, type guard, and unknown types still raising.
  - `test/authentication/test_agent.rb` — agent `identities` now returns an `sk-ecdsa` key instead of dropping it.
- `CHANGES.txt` and `README.md` updated (README documents the agent-only limitation explicitly).

## Notes / scope

- Certificate variants (`sk-*-cert-v01@openssh.com`) are out of scope here.
- The `webauthn-sk-ecdsa-sha2-nistp256@openssh.com` signature variant is out of scope.
- No change to host-key handling; this is purely client publickey auth.

## Test plan

- [x] `ruby -Itest -Ilib test/authentication/test_security_key.rb`
- [x] `ruby -Itest -Ilib test/authentication/test_agent.rb`
- [x] `ruby -Itest -Ilib test/test_buffer.rb`
- [x] `ruby -Itest -Ilib test/authentication/test_key_manager.rb` / `test_ed25519.rb` / `test_certificate.rb`
- [x] `rubocop` clean on changed files
- [x] Verified end-to-end against a real `ssh-agent` holding an `ecdsa-sk` key: the key is now listed by `Agent#identities` with the correct SHA256 fingerprint (previously dropped).

Made with [Cursor](https://cursor.com)